### PR TITLE
Force stereo audio

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -36,3 +36,4 @@ quick_station_skip   = false       # tune the radio away and back within 1s to s
 volume_normalization = false       # apply ReplayGain (local files) / EBU R128 loudnorm (YT) when on
 equalizer_enabled    = false
 equalizer_bands      = [0.0, 0.0, 0.0, 0.0, 0.0]   # 60/250/1000/4000/12000 Hz, [-6, +6] dB
+force_stereo_audio   = true        # off => mono + 2D path (clean 3D spatialisation)

--- a/include/fh6/config.hpp
+++ b/include/fh6/config.hpp
@@ -13,6 +13,7 @@ struct PlaybackConfig {
     bool volume_normalization       = false;
     bool equalizer_enabled          = false;
     std::array<float, 5> equalizer_bands{}; // 60 / 250 / 1000 / 4000 / 12000 Hz, [-6, +6] dB
+    bool force_stereo_audio         = false;
 };
 
 struct GeneralConfig {

--- a/include/fh6/config.hpp
+++ b/include/fh6/config.hpp
@@ -13,7 +13,7 @@ struct PlaybackConfig {
     bool volume_normalization       = false;
     bool equalizer_enabled          = false;
     std::array<float, 5> equalizer_bands{}; // 60 / 250 / 1000 / 4000 / 12000 Hz, [-6, +6] dB
-    bool force_stereo_audio         = false;
+    bool force_stereo_audio         = true;
 };
 
 struct GeneralConfig {

--- a/include/fh6/fmod/dsp_bridge.hpp
+++ b/include/fh6/fmod/dsp_bridge.hpp
@@ -88,6 +88,9 @@ public:
     float gain() const noexcept { return gain_.load(std::memory_order_acquire); }
     void set_gain(float g) noexcept { gain_.store(g, std::memory_order_release); }
 
+    bool force_stereo_audio() const noexcept { return force_stereo_audio_.load(std::memory_order_acquire); }
+    void set_force_stereo_audio(bool v) noexcept;
+
     uint64_t underruns() const noexcept { return underruns_.load(std::memory_order_relaxed); }
     uint64_t call_count() const noexcept { return calls_.load(std::memory_order_relaxed); }
     uint32_t last_buffer_len() const noexcept { return last_len_.load(std::memory_order_relaxed); }
@@ -122,6 +125,7 @@ private:
 
     std::atomic<DSPMode> mode_{DSPMode::pcm};
     std::atomic<float> gain_{1.0f};
+    std::atomic<bool> force_stereo_audio_{false};
 
     std::atomic<uint64_t> underruns_{0};
     std::atomic<uint64_t> calls_{0};

--- a/include/fh6/fmod/dsp_bridge.hpp
+++ b/include/fh6/fmod/dsp_bridge.hpp
@@ -119,7 +119,9 @@ private:
 
     void* fmod_system_       = nullptr;
     void* current_dsp_       = nullptr;
-    uint32_t current_handle_ = 0;
+    // Read from the config-change thread via set_force_stereo_audio;
+    // mutated from the control-loop thread via install/release/retarget.
+    std::atomic<uint32_t> current_handle_{0};
     mutable uint32_t last_bad_handle_ = 0;  // suppress repeated rc=3 / SEH warnings for the same handle
     std::byte* radio_stream_ = nullptr;
 

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -127,6 +127,7 @@ void run_bridge(HMODULE self) noexcept {
 
     fmod_bridge::DSPBridge bridge{mgr, fns};
     bridge.set_gain(cfg.audio.output_gain);
+    bridge.set_force_stereo_audio(cfg.playback.force_stereo_audio);
 
     std::unique_ptr<fmod_bridge::ControlLoop> ctrl;
     if (fns.ready())
@@ -144,6 +145,7 @@ void run_bridge(HMODULE self) noexcept {
         // Push the gain to both: the control loop's ramper otherwise snaps
         // the bridge value back to its own cached target on the next tick.
         bridge.set_gain(c.audio.output_gain);
+        bridge.set_force_stereo_audio(c.playback.force_stereo_audio);
         if (ctrl_ptr) ctrl_ptr->set_configured_gain(c.audio.output_gain);
         if (auto* local = dynamic_cast<sources::LocalFileSource*>(mgr.find("local_files"))) {
             local->set_shuffle(c.local_files.shuffle);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -94,6 +94,8 @@ Config load_config(const std::filesystem::path& path) {
         pick<bool>(pb, "volume_normalization", cfg.playback.volume_normalization);
     cfg.playback.equalizer_enabled =
         pick<bool>(pb, "equalizer_enabled", cfg.playback.equalizer_enabled);
+    cfg.playback.force_stereo_audio =
+        pick<bool>(pb, "force_stereo_audio", cfg.playback.force_stereo_audio);
     try {
         if (pb.contains("equalizer_bands")) {
             auto v = toml::find<std::vector<double>>(pb, "equalizer_bands");
@@ -228,6 +230,7 @@ void save_config(const std::filesystem::path& path, const Config& cfg) {
     e.kv("volume_normalization", cfg.playback.volume_normalization);
     e.kv("equalizer_enabled", cfg.playback.equalizer_enabled);
     e.kv_floats("equalizer_bands", std::span<const float>{cfg.playback.equalizer_bands});
+    e.kv("force_stereo_audio", cfg.playback.force_stereo_audio);
 
     auto tmp  = path;
     tmp      += ".tmp";

--- a/src/fmod/dsp_bridge.cpp
+++ b/src/fmod/dsp_bridge.cpp
@@ -336,14 +336,12 @@ uint32_t __stdcall DSPBridge::read_callback(void* /*dsp_state*/, float* in_buf, 
 
     // Declare our DSP output: stereo (default, force_stereo path) or mono
     // (when force_stereo is off and we're feeding the 3D panner -- stereo
-    // into a 3D panner phase-cancels into a metallic mess). Clamp to
-    // whatever FMOD pre-sized out_buf for: writing more channels than
-    // allocated is a heap overflow that crashes the mixer a few seconds
-    // later.
-    const int32_t desired = b->force_stereo_audio() ? 2 : 1;
-    const int32_t out_ch  = (out_channels && *out_channels > 0)
-                                ? std::min(*out_channels, desired)
-                                : desired;
+    // into a 3D panner phase-cancels into a metallic mess). FMOD does not
+    // re-query *out_channels after a mid-stream setMode, so we have to
+    // overwrite it unconditionally; clamping to its incoming value would
+    // pin us to whatever the channel was first allocated for (mono on the
+    // 3D radio channel) and silently ignore force_stereo.
+    const int32_t out_ch = b->force_stereo_audio() ? 2 : 1;
     if (out_channels) *out_channels = out_ch;
     const std::size_t total = static_cast<std::size_t>(length) * out_ch;
 

--- a/src/fmod/dsp_bridge.cpp
+++ b/src/fmod/dsp_bridge.cpp
@@ -40,7 +40,7 @@ constexpr FMODSig kAnchored[] = {
 // FMOD_LOOP_NORMAL: makes the channel loop forever on its source sample.
 // Set once at install time so the placeholder sample doesn't end and
 // drop the channel out from under our DSP.
-constexpr uint32_t kFmodLoopNormal = 0x2 | 0x8;  // FMOD_LOOP_NORMAL | FMOD_2D
+constexpr uint32_t kFmodLoopNormal = 0x2;
 
 // FMOD's `Handle::open` / `Handle::unlock` have no .rdata anchor; we match
 // their (unique) prologues directly.
@@ -246,10 +246,19 @@ void DSPBridge::install_dsp_locked(uint32_t handle) noexcept {
     // handle when the user toggles the in-game radio.
     if (fns_.channel_control_set_mode) {
         uint32_t mrc = ~0u;
-        if (!seh_call([&] { mrc = fns_.channel_control_set_mode(channel, kFmodLoopNormal); }) ||
+        uint32_t mode = force_stereo_audio() ? kFmodLoopNormal : (kFmodLoopNormal | 0x8);
+        if (!seh_call([&] { mrc = fns_.channel_control_set_mode(channel, mode); }) ||
             mrc != 0) {
             log::warn("[dsp] setMode(FMOD_LOOP_NORMAL) failed r={}; channel may die early", mrc);
         }
+    }
+}
+
+void DSPBridge::set_force_stereo_audio(bool v) noexcept {
+    bool old = force_stereo_audio_.exchange(v, std::memory_order_release);
+    if (old != v && current_handle_ && fns_.channel_control_set_mode) {
+        uint32_t mode = v ? 0x2 : (0x2 | 0x8);
+        seh_call([&] { fns_.channel_control_set_mode(current_handle_, mode); });
     }
 }
 
@@ -300,12 +309,14 @@ uint32_t __stdcall DSPBridge::read_callback(void* /*dsp_state*/, float* in_buf, 
     if (!b || !out_buf) return 0;
     const DSPMode m = b->mode();
 
-    // Force FMOD to treat our DSP output as purely Stereo (2 channels).
-    // This allows the game's 3D panner to correctly spatialize the audio into
-    // the Surround Sound space (5.1/7.1). If we don't do this, the 3D panner
-    // receives a 5.1/7.1 signal and distorts it terribly.
-    if (out_channels) *out_channels = 2;
-    int32_t out_ch = 2;
+    // Force FMOD to treat our DSP output as Mono (1 channel) by default.
+    // The radio is a 3D point-source in the game world; feeding stereo into
+    // a 3D panner causes phase cancellation (metallic/robotic sound).
+    // A true mono signal lets the panner spatialize cleanly.
+    // If force_stereo_audio is enabled, we revert to Stereo.
+    bool force_stereo = b->force_stereo_audio();
+    if (out_channels) *out_channels = force_stereo ? 2 : 1;
+    int32_t out_ch = force_stereo ? 2 : 1;
     const std::size_t total = static_cast<std::size_t>(length) * out_ch;
 
     auto stats = [&] {

--- a/src/fmod/dsp_bridge.cpp
+++ b/src/fmod/dsp_bridge.cpp
@@ -5,6 +5,7 @@
 #include "fh6/safe_mem.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <cstring>
 
 namespace fh6::fmod_bridge {
@@ -175,11 +176,12 @@ bool DSPBridge::validate_handle(uint32_t handle) const noexcept {
 
 void DSPBridge::release_current_dsp_locked() noexcept {
     if (!current_dsp_) return;
-    if (current_handle_)
-        seh_call([&] { fns_.channel_control_rem_dsp(current_handle_, current_dsp_); });
+    const uint32_t handle = current_handle_.load(std::memory_order_relaxed);
+    if (handle)
+        seh_call([&] { fns_.channel_control_rem_dsp(handle, current_dsp_); });
     seh_call([&] { fns_.dsp_release(current_dsp_); });
-    current_dsp_    = nullptr;
-    current_handle_ = 0;
+    current_dsp_ = nullptr;
+    current_handle_.store(0, std::memory_order_release);
 }
 
 void DSPBridge::install_dsp_locked(uint32_t handle) noexcept {
@@ -236,8 +238,8 @@ void DSPBridge::install_dsp_locked(uint32_t handle) noexcept {
         return;
     }
 
-    current_dsp_    = dsp;
-    current_handle_ = handle;
+    current_dsp_ = dsp;
+    current_handle_.store(handle, std::memory_order_release);
     log::info("[dsp] installed dsp={} on handle=0x{:X}", dsp, handle);
 
     // Pin the channel in loop mode so FMOD doesn't tear it down when the
@@ -256,10 +258,11 @@ void DSPBridge::install_dsp_locked(uint32_t handle) noexcept {
 
 void DSPBridge::set_force_stereo_audio(bool v) noexcept {
     bool old = force_stereo_audio_.exchange(v, std::memory_order_release);
-    if (old != v && current_handle_ && fns_.channel_control_set_mode) {
-        uint32_t mode = v ? 0x2 : (0x2 | 0x8);
-        seh_call([&] { fns_.channel_control_set_mode(current_handle_, mode); });
-    }
+    if (old == v || !fns_.channel_control_set_mode) return;
+    const uint32_t handle = current_handle_.load(std::memory_order_acquire);
+    if (!handle) return;
+    const uint32_t mode = v ? kFmodLoopNormal : (kFmodLoopNormal | 0x8);
+    seh_call([&] { fns_.channel_control_set_mode(handle, mode); });
 }
 
 void DSPBridge::set_target(const RadioInstance& inst, void* fmod_system) noexcept {
@@ -276,7 +279,8 @@ uint32_t DSPBridge::read_live_handle(std::byte* radio_stream) const noexcept {
 }
 
 bool DSPBridge::current_handle_alive() const noexcept {
-    return current_handle_ != 0 && fns_.ready() && validate_handle(current_handle_);
+    const uint32_t handle = current_handle_.load(std::memory_order_acquire);
+    return handle != 0 && fns_.ready() && validate_handle(handle);
 }
 
 bool DSPBridge::channel_handle_alive(std::byte* radio_stream) const noexcept {
@@ -286,11 +290,12 @@ bool DSPBridge::channel_handle_alive(std::byte* radio_stream) const noexcept {
 void DSPBridge::retarget_if_needed() noexcept {
     if (mode() != DSPMode::pcm || !fmod_system_) return;
     const uint32_t handle = read_live_handle(radio_stream_);
-    if (handle == current_handle_) return;
+    if (handle == current_handle_.load(std::memory_order_relaxed)) return;
     // No live handle on the RadioStreamFmod. If we still think we're installed
     // on a dead one, release it so we stop querying the stale handle.
     if (!handle) {
-        if (current_handle_) release_current_dsp_locked();
+        if (current_handle_.load(std::memory_order_relaxed))
+            release_current_dsp_locked();
         return;
     }
 

--- a/src/fmod/dsp_bridge.cpp
+++ b/src/fmod/dsp_bridge.cpp
@@ -39,9 +39,30 @@ constexpr FMODSig kAnchored[] = {
 };
 
 // FMOD_LOOP_NORMAL: makes the channel loop forever on its source sample.
-// Set once at install time so the placeholder sample doesn't end and
-// drop the channel out from under our DSP.
+// Set at install time (and re-set on config change) so the placeholder
+// sample doesn't end and drop the channel out from under our DSP.
 constexpr uint32_t kFmodLoopNormal = 0x2;
+
+// FMOD_2D: switches the channel out of 3D spatialisation. Default path
+// (force_stereo) clears this bit and feeds stereo, so the channel plays
+// back as a regular non-positional stereo source. When force_stereo is
+// off we set the bit and feed mono, because stereo into a 3D panner
+// phase-cancels into a metallic mess.
+constexpr uint32_t kFmod2D = 0x8;
+
+inline uint32_t channel_mode(bool force_stereo) noexcept {
+    return kFmodLoopNormal | (force_stereo ? 0u : kFmod2D);
+}
+
+// Smooth saturation near full-scale. Transparent for |x| <= knee and
+// asymptotically approaches ±1 above, so clean signals pass through
+// untouched and only over-driven peaks get rounded off.
+inline float soft_clip(float x) noexcept {
+    constexpr float k = 0.85f;
+    const float a    = std::fabs(x);
+    const float over = std::max(0.0f, a - k) / (1.0f - k);
+    return std::copysign(std::min(a, k) + (1.0f - k) * over / (1.0f + over), x);
+}
 
 // FMOD's `Handle::open` / `Handle::unlock` have no .rdata anchor; we match
 // their (unique) prologues directly.
@@ -247,22 +268,21 @@ void DSPBridge::install_dsp_locked(uint32_t handle) noexcept {
     // the channel after ~2 min and Forza only allocates a replacement
     // handle when the user toggles the in-game radio.
     if (fns_.channel_control_set_mode) {
-        uint32_t mrc = ~0u;
-        uint32_t mode = force_stereo_audio() ? kFmodLoopNormal : (kFmodLoopNormal | 0x8);
+        uint32_t mrc        = ~0u;
+        const uint32_t mode = channel_mode(force_stereo_audio());
         if (!seh_call([&] { mrc = fns_.channel_control_set_mode(channel, mode); }) ||
             mrc != 0) {
-            log::warn("[dsp] setMode(FMOD_LOOP_NORMAL) failed r={}; channel may die early", mrc);
+            log::warn("[dsp] setMode(0x{:X}) failed r={}; channel may die early", mode, mrc);
         }
     }
 }
 
 void DSPBridge::set_force_stereo_audio(bool v) noexcept {
-    bool old = force_stereo_audio_.exchange(v, std::memory_order_release);
+    const bool old = force_stereo_audio_.exchange(v, std::memory_order_release);
     if (old == v || !fns_.channel_control_set_mode) return;
     const uint32_t handle = current_handle_.load(std::memory_order_acquire);
     if (!handle) return;
-    const uint32_t mode = v ? kFmodLoopNormal : (kFmodLoopNormal | 0x8);
-    seh_call([&] { fns_.channel_control_set_mode(handle, mode); });
+    seh_call([&] { fns_.channel_control_set_mode(handle, channel_mode(v)); });
 }
 
 void DSPBridge::set_target(const RadioInstance& inst, void* fmod_system) noexcept {
@@ -308,20 +328,23 @@ void DSPBridge::retarget_if_needed() noexcept {
 // (miniaudio / ffmpeg resample upstream), which is FMOD's master rate, so
 // the callback is a straight int16 -> float conversion with gain.
 uint32_t __stdcall DSPBridge::read_callback(void* /*dsp_state*/, float* in_buf, float* out_buf,
-                                            uint32_t length, int32_t in_channels,
+                                            uint32_t length, int32_t /*in_channels*/,
                                             int32_t* out_channels) {
     auto* b = g_bridge;
     if (!b || !out_buf) return 0;
     const DSPMode m = b->mode();
 
-    // Force FMOD to treat our DSP output as Mono (1 channel) by default.
-    // The radio is a 3D point-source in the game world; feeding stereo into
-    // a 3D panner causes phase cancellation (metallic/robotic sound).
-    // A true mono signal lets the panner spatialize cleanly.
-    // If force_stereo_audio is enabled, we revert to Stereo.
-    bool force_stereo = b->force_stereo_audio();
-    if (out_channels) *out_channels = force_stereo ? 2 : 1;
-    int32_t out_ch = force_stereo ? 2 : 1;
+    // Declare our DSP output: stereo (default, force_stereo path) or mono
+    // (when force_stereo is off and we're feeding the 3D panner -- stereo
+    // into a 3D panner phase-cancels into a metallic mess). Clamp to
+    // whatever FMOD pre-sized out_buf for: writing more channels than
+    // allocated is a heap overflow that crashes the mixer a few seconds
+    // later.
+    const int32_t desired = b->force_stereo_audio() ? 2 : 1;
+    const int32_t out_ch  = (out_channels && *out_channels > 0)
+                                ? std::min(*out_channels, desired)
+                                : desired;
+    if (out_channels) *out_channels = out_ch;
     const std::size_t total = static_cast<std::size_t>(length) * out_ch;
 
     auto stats = [&] {
@@ -372,10 +395,8 @@ uint32_t __stdcall DSPBridge::read_callback(void* /*dsp_state*/, float* in_buf, 
         for (uint32_t f = 0; f < got_frames; ++f) {
             const float fl = scratch[f * 2 + 0] * scale;
             const float fr = scratch[f * 2 + 1] * scale;
-            
-            // Soft clipping (analog-style) instead of harsh digital hard-clipping
-            const float L  = std::tanh(fl);
-            const float R  = std::tanh(fr);
+            const float L  = soft_clip(fl);
+            const float R  = soft_clip(fr);
 
             float* o = out_buf + static_cast<std::size_t>(produced + f) * out_ch;
             if (out_ch == 1) {

--- a/src/fmod/dsp_bridge.cpp
+++ b/src/fmod/dsp_bridge.cpp
@@ -40,7 +40,7 @@ constexpr FMODSig kAnchored[] = {
 // FMOD_LOOP_NORMAL: makes the channel loop forever on its source sample.
 // Set once at install time so the placeholder sample doesn't end and
 // drop the channel out from under our DSP.
-constexpr uint32_t kFmodLoopNormal = 0x2;
+constexpr uint32_t kFmodLoopNormal = 0x2 | 0x8;  // FMOD_LOOP_NORMAL | FMOD_2D
 
 // FMOD's `Handle::open` / `Handle::unlock` have no .rdata anchor; we match
 // their (unique) prologues directly.

--- a/src/fmod/dsp_bridge.cpp
+++ b/src/fmod/dsp_bridge.cpp
@@ -300,12 +300,12 @@ uint32_t __stdcall DSPBridge::read_callback(void* /*dsp_state*/, float* in_buf, 
     if (!b || !out_buf) return 0;
     const DSPMode m = b->mode();
 
-    // Use only what FMOD allocated: out_buf is pre-sized by FMOD, writing
-    // more channels than requested is a heap overflow that crashes the mixer
-    // a few seconds later. If FMOD wants mono, downmix our stereo.
-    int32_t out_ch = in_channels > 0 ? in_channels : 2;
-    if (out_channels && *out_channels > 0) out_ch = *out_channels;
-    if (out_channels) *out_channels = out_ch;
+    // Force FMOD to treat our DSP output as purely Stereo (2 channels).
+    // This allows the game's 3D panner to correctly spatialize the audio into
+    // the Surround Sound space (5.1/7.1). If we don't do this, the 3D panner
+    // receives a 5.1/7.1 signal and distorts it terribly.
+    if (out_channels) *out_channels = 2;
+    int32_t out_ch = 2;
     const std::size_t total = static_cast<std::size_t>(length) * out_ch;
 
     auto stats = [&] {
@@ -356,8 +356,10 @@ uint32_t __stdcall DSPBridge::read_callback(void* /*dsp_state*/, float* in_buf, 
         for (uint32_t f = 0; f < got_frames; ++f) {
             const float fl = scratch[f * 2 + 0] * scale;
             const float fr = scratch[f * 2 + 1] * scale;
-            const float L  = fl > 1.0f ? 1.0f : (fl < -1.0f ? -1.0f : fl);
-            const float R  = fr > 1.0f ? 1.0f : (fr < -1.0f ? -1.0f : fr);
+            
+            // Soft clipping (analog-style) instead of harsh digital hard-clipping
+            const float L  = std::tanh(fl);
+            const float R  = std::tanh(fr);
 
             float* o = out_buf + static_cast<std::size_t>(produced + f) * out_ch;
             if (out_ch == 1) {

--- a/src/fmod/dsp_bridge.cpp
+++ b/src/fmod/dsp_bridge.cpp
@@ -44,14 +44,14 @@ constexpr FMODSig kAnchored[] = {
 constexpr uint32_t kFmodLoopNormal = 0x2;
 
 // FMOD_2D: switches the channel out of 3D spatialisation. Default path
-// (force_stereo) clears this bit and feeds stereo, so the channel plays
+// (force_stereo) sets this bit and feeds stereo, so the channel plays
 // back as a regular non-positional stereo source. When force_stereo is
-// off we set the bit and feed mono, because stereo into a 3D panner
+// off we clear the bit and feed mono, because stereo into a 3D panner
 // phase-cancels into a metallic mess.
 constexpr uint32_t kFmod2D = 0x8;
 
 inline uint32_t channel_mode(bool force_stereo) noexcept {
-    return kFmodLoopNormal | (force_stereo ? 0u : kFmod2D);
+    return kFmodLoopNormal | (force_stereo ? kFmod2D : 0u);
 }
 
 // Smooth saturation near full-scale. Transparent for |x| <= knee and

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -136,6 +136,7 @@ json config_to_json(const Config& c) {
              {"volume_normalization", c.playback.volume_normalization},
              {"equalizer_enabled", c.playback.equalizer_enabled},
              {"equalizer_bands", c.playback.equalizer_bands},
+             {"force_stereo_audio", c.playback.force_stereo_audio},
          }},
     };
 }
@@ -188,6 +189,8 @@ void apply_patch(Config& c, const json& j) {
             pull(*it, "quick_station_skip", c.playback.quick_station_skip);
         c.playback.volume_normalization =
             pull(*it, "volume_normalization", c.playback.volume_normalization);
+        c.playback.force_stereo_audio =
+            pull(*it, "force_stereo_audio", c.playback.force_stereo_audio);
         c.playback.equalizer_enabled =
             pull(*it, "equalizer_enabled", c.playback.equalizer_enabled);
         if (auto bands = it->find("equalizer_bands");

--- a/ui/dist/app.js
+++ b/ui/dist/app.js
@@ -147,6 +147,7 @@ const SCHEMA = [
     ["volume_normalization", "Normalize loudness",        "checkbox"],
     ["equalizer_enabled",    "Equalizer",                 "checkbox"],
     ["equalizer_bands",      "Equalizer bands",           "bands"],
+    ["force_stereo_audio",   "Force stereo audio",        "checkbox"],
   ]],
 ];
 


### PR DESCRIPTION
I figured out how to force the audio to be Stereo and also disable 3D spatialization ~~with a bit of help from AI~~ 
This doesn't affect outdoor speakers like at the festival site or other audio post processing from the game like when you're in a garage.

This also in my opinion makes music quality significantly better and less "tinny" when using YT music playback (did not test with local audio, but i assume the same applies). I still decided to add it as an option instead of just forcing it and its disabled by default. 

The only "drawback" is that it makes playback significantly louder for some reason, but it can be easily adjusted by just reducing the volume a bit. 

Force Stereo off: https://streamable.com/p5ryqc
Force Stereo on: https://streamable.com/chj85d

I'm soon going to record a video with an actual music playing to show the difference better

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable force_stereo_audio setting to control stereo vs mono playback; applied at startup and when configs change live.
  * Configuration is now viewable and updatable through the HTTP API.

* **Improvements**
  * Audio processing uses soft-clipping for smoother output and more consistent downmixing/replication.

* **Documentation**
  * Added playback.force_stereo_audio to example config (default: true).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/g0ldyy/fh6-universal-radio/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->