### PR TITLE
feat: add Jellyfin user favorites support

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -33,6 +33,7 @@ server_url         = ''                # e.g. 'http://127.0.0.1:8096'
 api_key            = ''                # generate this in the Jellyfin dashboard
 user_id            = ''                # the ID of the user to track playback against
 default_playlist   = ''                # jellyfin playlist ID goes here
+use_favorites      = false             # set to true to play your favorites instead of a playlist
 shuffle            = true              # true or false
 
 [audio]

--- a/include/fh6/config.hpp
+++ b/include/fh6/config.hpp
@@ -47,6 +47,7 @@ struct JellyfinConfig {
     std::string api_key;
     std::string user_id;
     std::string default_playlist;
+    bool use_favorites = false;
     bool shuffle = true;
 };
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -84,6 +84,7 @@ Config load_config(const std::filesystem::path& path) {
     cfg.jellyfin.api_key = pick<std::string>(jf, "api_key", cfg.jellyfin.api_key);
     cfg.jellyfin.user_id = pick<std::string>(jf, "user_id", cfg.jellyfin.user_id);
     cfg.jellyfin.default_playlist = pick<std::string>(jf, "default_playlist", cfg.jellyfin.default_playlist);
+    cfg.jellyfin.use_favorites = pick<bool>(jf, "use_favorites", cfg.jellyfin.use_favorites);
     cfg.jellyfin.shuffle = pick<bool>(jf, "shuffle", cfg.jellyfin.shuffle);
 
     const auto& au = section(root, "audio");
@@ -235,6 +236,7 @@ void save_config(const std::filesystem::path& path, const Config& cfg) {
     e.kv("api_key", cfg.jellyfin.api_key);
     e.kv("user_id", cfg.jellyfin.user_id);
     e.kv("default_playlist", cfg.jellyfin.default_playlist);
+    e.kv("use_favorites", cfg.jellyfin.use_favorites);
     e.kv("shuffle", cfg.jellyfin.shuffle);
 
     e.header("audio");

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -132,6 +132,7 @@ json config_to_json(const Config& c) {
              {"api_key", c.jellyfin.api_key},
              {"user_id", c.jellyfin.user_id},
              {"default_playlist", c.jellyfin.default_playlist},
+             {"use_favorites", c.jellyfin.use_favorites},
              {"shuffle", c.jellyfin.shuffle},
          }},
         {"audio",
@@ -193,6 +194,7 @@ void apply_patch(Config& c, const json& j) {
         c.jellyfin.api_key          = pull(*it, "api_key", c.jellyfin.api_key);
         c.jellyfin.user_id          = pull(*it, "user_id", c.jellyfin.user_id);
         c.jellyfin.default_playlist = pull(*it, "default_playlist", c.jellyfin.default_playlist);
+        c.jellyfin.use_favorites    = pull(*it, "use_favorites", c.jellyfin.use_favorites);
         c.jellyfin.shuffle          = pull(*it, "shuffle", c.jellyfin.shuffle);
     }
     if (auto it = j.find("audio"); it != j.end()) {

--- a/src/sources/jellyfin_source.cpp
+++ b/src/sources/jellyfin_source.cpp
@@ -44,14 +44,15 @@ using WinHttpHandle = std::unique_ptr<void, WinHttpDeleter>;
 
 bool config_complete(const JellyfinConfig& c) noexcept {
     return !c.server_url.empty() && !c.api_key.empty() &&
-           !c.user_id.empty() && !c.default_playlist.empty();
+           !c.user_id.empty() && (!c.default_playlist.empty() || c.use_favorites);
 }
 
 // Fields that determine which playlist gets fetched. `shuffle` deliberately
 // omitted -- it doesn't require a re-query.
 bool same_query_target(const JellyfinConfig& a, const JellyfinConfig& b) noexcept {
     return a.server_url == b.server_url && a.api_key == b.api_key &&
-           a.user_id    == b.user_id    && a.default_playlist == b.default_playlist;
+           a.user_id    == b.user_id    && a.default_playlist == b.default_playlist &&
+           a.use_favorites == b.use_favorites;
 }
 
 std::optional<std::string> http_get(const JellyfinConfig& cfg, const std::string& path) {
@@ -124,8 +125,14 @@ std::optional<std::string> http_get(const JellyfinConfig& cfg, const std::string
 }
 
 std::optional<std::vector<JellyfinTrack>> fetch_tracks(const JellyfinConfig& cfg) {
-    const std::string path = std::format(
-        "/Users/{}/Items?ParentId={}&Filters=IsNotFolder", cfg.user_id, cfg.default_playlist);
+    std::string path;
+    if (cfg.use_favorites) {
+        // query user's favorite audio items recursively
+        path = std::format("/Users/{}/Items?Filters=IsFavorite&IncludeItemTypes=Audio&Recursive=true", cfg.user_id);
+    } else {
+        // standard playlist query
+        path = std::format("/Users/{}/Items?ParentId={}&Filters=IsNotFolder", cfg.user_id, cfg.default_playlist);
+    }
     auto body = http_get(cfg, path);
     if (!body) return std::nullopt;
 

--- a/src/sources/jellyfin_source.cpp
+++ b/src/sources/jellyfin_source.cpp
@@ -50,9 +50,11 @@ bool config_complete(const JellyfinConfig& c) noexcept {
 // Fields that determine which playlist gets fetched. `shuffle` deliberately
 // omitted -- it doesn't require a re-query.
 bool same_query_target(const JellyfinConfig& a, const JellyfinConfig& b) noexcept {
-    return a.server_url == b.server_url && a.api_key == b.api_key &&
-           a.user_id    == b.user_id    && a.default_playlist == b.default_playlist &&
-           a.use_favorites == b.use_favorites;
+    if (a.server_url != b.server_url || a.api_key != b.api_key ||
+        a.user_id != b.user_id || a.use_favorites != b.use_favorites) return false;
+    // default_playlist is irrelevant when both sides fetch favorites.
+    if (a.use_favorites && b.use_favorites) return true;
+    return a.default_playlist == b.default_playlist;
 }
 
 std::optional<std::string> http_get(const JellyfinConfig& cfg, const std::string& path) {
@@ -324,6 +326,7 @@ bool JellyfinSource::cast(std::string playlist_id) {
         snap = cfg_;
     }
     snap.default_playlist = playlist_id;
+    snap.use_favorites    = false;   // cast targets a specific playlist
     if (!config_complete(snap)) return false;
 
     std::optional<std::vector<JellyfinTrack>> tracks;

--- a/src/sources/jellyfin_source.cpp
+++ b/src/sources/jellyfin_source.cpp
@@ -129,10 +129,8 @@ std::optional<std::string> http_get(const JellyfinConfig& cfg, const std::string
 std::optional<std::vector<JellyfinTrack>> fetch_tracks(const JellyfinConfig& cfg) {
     std::string path;
     if (cfg.use_favorites) {
-        // query user's favorite audio items recursively
         path = std::format("/Users/{}/Items?Filters=IsFavorite&IncludeItemTypes=Audio&Recursive=true", cfg.user_id);
     } else {
-        // standard playlist query
         path = std::format("/Users/{}/Items?ParentId={}&Filters=IsNotFolder", cfg.user_id, cfg.default_playlist);
     }
     auto body = http_get(cfg, path);

--- a/ui/dist/app.js
+++ b/ui/dist/app.js
@@ -147,6 +147,7 @@ const SCHEMA = [
     ["user_id",          "User ID",          "text"],
     ["api_key",          "API Key",          "text"],
     ["default_playlist", "Default Playlist", "text"],
+    ["use_favorites",   "Use Favorites",    "checkbox"],
     ["shuffle",          "Shuffle",          "checkbox"],
   ]],
   ["audio", "Audio", [

--- a/ui/dist/app.js
+++ b/ui/dist/app.js
@@ -147,7 +147,7 @@ const SCHEMA = [
     ["user_id",          "User ID",          "text"],
     ["api_key",          "API Key",          "text"],
     ["default_playlist", "Default Playlist", "text"],
-    ["use_favorites",   "Use Favorites",    "checkbox"],
+    ["use_favorites",    "Use Favorites",    "checkbox"],
     ["shuffle",          "Shuffle",          "checkbox"],
   ]],
   ["audio", "Audio", [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Jellyfin source gains a new use_favorites setting to play a user's favorite tracks instead of the configured playlist (defaults to off).
  * Settings can be updated live via the app's HTTP config interface.

* **Bug Fixes / Behavior**
  * Casting/remote playback will continue to use playlists (favorites mode is not applied to cast targets).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/g0ldyy/fh6-universal-radio/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->