### PR TITLE
feat: implement pre-buffering for next track across sources

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -46,3 +46,4 @@ volume_normalization = false       # apply ReplayGain (local files) / EBU R128 l
 equalizer_enabled    = false
 equalizer_bands      = [0.0, 0.0, 0.0, 0.0, 0.0]   # 60/250/1000/4000/12000 Hz, [-6, +6] dB
 force_stereo_audio   = true        # off => mono (avoids metallic phase-cancellation on the 3D radio channel)
+prebuffer_next_track = true        # pre-spawn the next track's pipeline so transitions skip the "(loading)" gap

--- a/include/fh6/config.hpp
+++ b/include/fh6/config.hpp
@@ -14,6 +14,9 @@ struct PlaybackConfig {
     bool equalizer_enabled          = false;
     std::array<float, 5> equalizer_bands{}; // 60 / 250 / 1000 / 4000 / 12000 Hz, [-6, +6] dB
     bool force_stereo_audio         = true;
+    // Pre-spawn the next track's pipeline so transitions (skip / end-of-track)
+    // are instant.
+    bool prebuffer_next_track       = true;
 };
 
 struct GeneralConfig {

--- a/include/fh6/sources/jellyfin_source.hpp
+++ b/include/fh6/sources/jellyfin_source.hpp
@@ -68,8 +68,13 @@ private:
 
     // mu_ held.
     bool refresh_queue_locked();   // releases mu_ across the HTTP fetch, re-acquires to swap
+    std::unique_ptr<Pipe> spawn_pipe_locked(std::size_t for_idx);
     void start_pipe_locked();
     void stop_pipe_locked();
+    void discard_prefetch_locked() noexcept;
+    bool promote_prefetch_locked(std::size_t expected_idx);
+    void maybe_spawn_prefetch_locked();
+    std::size_t next_queue_idx_locked() const noexcept;
     void advance_locked(std::ptrdiff_t step);
 
     JellyfinConfig cfg_;
@@ -79,10 +84,12 @@ private:
     std::vector<JellyfinTrack> queue_;
     std::size_t current_idx_ = 0;
     std::unique_ptr<Pipe> pipe_;
+    std::unique_ptr<Pipe> prefetch_;
     std::atomic<PlaybackState> state_{PlaybackState::stopped};
 
     EqualizerStage eq_;
     std::atomic<bool> volume_norm_{false};
+    std::atomic<bool> prebuffer_next_{true};
 };
 
 } // namespace fh6::sources

--- a/include/fh6/sources/local_file_source.hpp
+++ b/include/fh6/sources/local_file_source.hpp
@@ -51,18 +51,27 @@ public:
     SourceCapabilities capabilities() const noexcept override { return {true, true, false}; }
 
 private:
+    struct Decoder; // pimpl, keeps miniaudio out of the header
+
     void rebuild_playlist();
-    bool open_track(std::size_t index);
-    bool open_track_ffmpeg(const std::filesystem::path& path);
+    // Open one decoder for playlist_[index] (miniaudio first, ffmpeg fallback).
+    // Returns nullptr if the file is unplayable / out of range.
+    std::unique_ptr<Decoder> open_decoder_locked(std::size_t index);
+    bool open_track_ffmpeg(Decoder& d, const std::filesystem::path& path);
+    bool open_track(std::size_t index);   // open + install as current
     void close_current();
+    void discard_prefetch_locked() noexcept;
+    bool promote_prefetch_locked(std::size_t expected_cursor);
+    void maybe_spawn_prefetch_locked();
+    std::size_t next_cursor_locked() const noexcept;
 
     LocalFilesConfig cfg_;
     std::filesystem::path ffmpeg_path_;
     std::vector<std::filesystem::path> playlist_;
     std::size_t cursor_ = 0;
 
-    struct Decoder; // pimpl, keeps miniaudio out of the header
     std::unique_ptr<Decoder> dec_;
+    std::unique_ptr<Decoder> prefetch_dec_;
 
     mutable std::mutex mu_;
     std::atomic<PlaybackState> state_{PlaybackState::stopped};
@@ -70,7 +79,7 @@ private:
 
     EqualizerStage eq_;
     std::atomic<bool> volume_norm_{true};
-    std::atomic<float> loudness_coef_{1.0f}; // per-track multiplier, computed in open_track()
+    std::atomic<bool> prebuffer_next_{true};
 };
 
 } // namespace fh6::sources

--- a/include/fh6/sources/youtube_music_source.hpp
+++ b/include/fh6/sources/youtube_music_source.hpp
@@ -58,20 +58,27 @@ public:
 private:
     struct Pipe;
 
-    void start_pipe_locked();   // mu_ held
-    void stop_pipe_locked();    // mu_ held
-    void resolve_queue_locked();// mu_ held; populates queue_ from target_url_
+    // mu_ held for all *_locked helpers.
+    std::unique_ptr<Pipe> spawn_pipe_locked(std::string_view url, std::size_t for_idx);
+    void start_pipe_locked();         // (re)spawn pipe_ for queue_[queue_idx_]
+    void stop_pipe_locked();          // drop pipe_ only
+    void discard_prefetch_locked() noexcept;
+    void resolve_queue_locked();      // populates queue_ from target_url_
+    std::size_t next_queue_idx_locked() const noexcept;
+    bool promote_prefetch_locked(std::size_t expected_idx);
+    void maybe_spawn_prefetch_locked();   // called from pump() once current is healthy
+    void drain_title_pipe_locked(Pipe* p);
 
     YouTubeMusicConfig cfg_;
     std::filesystem::path ffmpeg_path_;
     std::unique_ptr<Pipe> pipe_;
+    std::unique_ptr<Pipe> prefetch_;     // pre-spawned next-track pipeline (or null)
 
     mutable std::mutex mu_;
     std::string target_url_;
     std::vector<std::string> queue_;     // canonical watch URLs in playback order
     std::size_t queue_idx_ = 0;
     std::string queue_built_for_;        // value of target_url_ when queue_ was resolved
-    TrackInfo info_{};
     std::atomic<uint64_t> position_ms_{0};
     int consecutive_failed_ = 0;        // tracks-in-a-row that produced 0 PCM bytes
     AuthState auth_ = AuthState::none_required;
@@ -79,6 +86,7 @@ private:
 
     EqualizerStage eq_;
     std::atomic<bool> volume_norm_{true};
+    std::atomic<bool> prebuffer_next_{true};
 };
 
 } // namespace fh6::sources

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -105,6 +105,8 @@ Config load_config(const std::filesystem::path& path) {
         pick<bool>(pb, "equalizer_enabled", cfg.playback.equalizer_enabled);
     cfg.playback.force_stereo_audio =
         pick<bool>(pb, "force_stereo_audio", cfg.playback.force_stereo_audio);
+    cfg.playback.prebuffer_next_track =
+        pick<bool>(pb, "prebuffer_next_track", cfg.playback.prebuffer_next_track);
     try {
         if (pb.contains("equalizer_bands")) {
             auto v = toml::find<std::vector<double>>(pb, "equalizer_bands");
@@ -249,6 +251,7 @@ void save_config(const std::filesystem::path& path, const Config& cfg) {
     e.kv("equalizer_enabled", cfg.playback.equalizer_enabled);
     e.kv_floats("equalizer_bands", std::span<const float>{cfg.playback.equalizer_bands});
     e.kv("force_stereo_audio", cfg.playback.force_stereo_audio);
+    e.kv("prebuffer_next_track", cfg.playback.prebuffer_next_track);
 
     auto tmp  = path;
     tmp      += ".tmp";

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -147,6 +147,7 @@ json config_to_json(const Config& c) {
              {"equalizer_enabled", c.playback.equalizer_enabled},
              {"equalizer_bands", c.playback.equalizer_bands},
              {"force_stereo_audio", c.playback.force_stereo_audio},
+             {"prebuffer_next_track", c.playback.prebuffer_next_track},
          }},
     };
 }
@@ -210,6 +211,8 @@ void apply_patch(Config& c, const json& j) {
             pull(*it, "volume_normalization", c.playback.volume_normalization);
         c.playback.force_stereo_audio =
             pull(*it, "force_stereo_audio", c.playback.force_stereo_audio);
+        c.playback.prebuffer_next_track =
+            pull(*it, "prebuffer_next_track", c.playback.prebuffer_next_track);
         c.playback.equalizer_enabled =
             pull(*it, "equalizer_enabled", c.playback.equalizer_enabled);
         if (auto bands = it->find("equalizer_bands");

--- a/src/sources/jellyfin_source.cpp
+++ b/src/sources/jellyfin_source.cpp
@@ -190,6 +190,7 @@ struct JellyfinSource::Pipe {
     std::uint64_t bytes_written = 0;
     std::atomic<std::uint64_t> position_ms{0};
     bool ended = false;
+    std::size_t for_queue_idx = 0;
 
     ~Pipe() {
         // Close the read side first so ffmpeg's next write returns
@@ -206,6 +207,7 @@ JellyfinSource::JellyfinSource(JellyfinConfig cfg, std::filesystem::path ffmpeg_
 
 JellyfinSource::~JellyfinSource() {
     std::scoped_lock lk{mu_};
+    discard_prefetch_locked();
     stop_pipe_locked();
 }
 
@@ -224,23 +226,25 @@ bool JellyfinSource::initialize() {
 
 void JellyfinSource::shutdown() noexcept {
     std::scoped_lock lk{mu_};
+    discard_prefetch_locked();
     stop_pipe_locked();
 }
 
-void JellyfinSource::start_pipe_locked() {
-    stop_pipe_locked();
-    if (queue_.empty() || current_idx_ >= queue_.size()) return;
+std::unique_ptr<JellyfinSource::Pipe>
+JellyfinSource::spawn_pipe_locked(std::size_t for_idx) {
+    if (queue_.empty() || for_idx >= queue_.size()) return nullptr;
 
     auto pipe = std::make_unique<Pipe>();
+    pipe->for_queue_idx = for_idx;
     pipe->job = create_kill_on_close_job();
     if (!pipe->job) {
         log::warn("[jellyfin] CreateJobObject failed ({})", GetLastError());
-        return;
+        return nullptr;
     }
 
     SECURITY_ATTRIBUTES sa{sizeof(sa), nullptr, TRUE};
     HANDLE out_r = nullptr, out_w = nullptr;
-    if (!CreatePipe(&out_r, &out_w, &sa, 1 << 20)) return;
+    if (!CreatePipe(&out_r, &out_w, &sa, 1 << 20)) return nullptr;
     SetHandleInformation(out_r, HANDLE_FLAG_INHERIT, 0);
 
     HANDLE nul_in  = open_nul(GENERIC_READ);
@@ -249,7 +253,7 @@ void JellyfinSource::start_pipe_locked() {
     const std::wstring ff = ffmpeg_path_.empty() ? std::wstring{L"ffmpeg"}
                                                  : ffmpeg_path_.wstring();
     const std::string stream_url = std::format("{}/Audio/{}/stream?static=true",
-                                                cfg_.server_url, queue_[current_idx_].id);
+                                                cfg_.server_url, queue_[for_idx].id);
     // Pass the API key via -headers so it isn't visible on the ffmpeg command
     // line to other local processes. \r\n is the canonical separator ffmpeg
     // expects between (and trailing) custom headers.
@@ -272,16 +276,50 @@ void JellyfinSource::start_pipe_locked() {
         CloseHandle(out_r);
         log::warn("[jellyfin] failed to launch ffmpeg -- {}",
                   describe_launch_failure(ff, ec, !ffmpeg_path_.empty()));
-        return;  // ~Pipe reaps the job
+        return nullptr;  // ~Pipe reaps the job
     }
 
     pipe->read_pipe = out_r;
-    pipe_           = std::move(pipe);
+    return pipe;
+}
+
+void JellyfinSource::start_pipe_locked() {
+    stop_pipe_locked();
+    pipe_ = spawn_pipe_locked(current_idx_);
 }
 
 void JellyfinSource::stop_pipe_locked() {
+    // Symmetric with YT: prefetch is preserved across stop_pipe_locked() so a
+    // pending promotion isn't dropped on re-spawn. stop()/shutdown() drop it
+    // explicitly.
     pipe_.reset();
     state_.store(PlaybackState::stopped, std::memory_order_release);
+}
+
+void JellyfinSource::discard_prefetch_locked() noexcept { prefetch_.reset(); }
+
+std::size_t JellyfinSource::next_queue_idx_locked() const noexcept {
+    if (queue_.empty()) return 0;
+    return (current_idx_ + 1) % queue_.size();
+}
+
+bool JellyfinSource::promote_prefetch_locked(std::size_t expected_idx) {
+    if (!prefetch_ || prefetch_->for_queue_idx != expected_idx) {
+        discard_prefetch_locked();
+        return false;
+    }
+    pipe_ = std::move(prefetch_);
+    return true;
+}
+
+void JellyfinSource::maybe_spawn_prefetch_locked() {
+    if (!prebuffer_next_.load(std::memory_order_acquire)) return;
+    if (prefetch_ || !pipe_ || queue_.size() < 2) return;
+    // Match YT's threshold: ~0.5 s of PCM proves the current pipe is viable
+    // before we commit a second ffmpeg.
+    constexpr std::uint64_t kViableBytes = 96 * 1024;
+    if (pipe_->bytes_written < kViableBytes) return;
+    prefetch_ = spawn_pipe_locked(next_queue_idx_locked());
 }
 
 void JellyfinSource::advance_locked(std::ptrdiff_t step) {
@@ -289,7 +327,12 @@ void JellyfinSource::advance_locked(std::ptrdiff_t step) {
     const auto n = (std::ptrdiff_t)queue_.size();
     auto i = (std::ptrdiff_t)current_idx_ + step;
     current_idx_ = (std::size_t)(((i % n) + n) % n);
-    start_pipe_locked();
+    if (step == 1 && promote_prefetch_locked(current_idx_)) {
+        // Promoted: pipe_ is the pre-warmed pipeline, no fresh spawn needed.
+    } else {
+        discard_prefetch_locked();   // backwards step invalidates the prefetch
+        start_pipe_locked();
+    }
     if (pipe_) state_.store(PlaybackState::playing, std::memory_order_release);
 }
 
@@ -306,6 +349,7 @@ void JellyfinSource::pause() {
 
 void JellyfinSource::stop() {
     std::scoped_lock lk{mu_};
+    discard_prefetch_locked();
     stop_pipe_locked();
     current_idx_ = 0;
 }
@@ -339,6 +383,7 @@ bool JellyfinSource::cast(std::string playlist_id) {
     queue_                = std::move(*tracks);
     current_idx_          = 0;
     if (cfg_.shuffle) shuffle_range(queue_, 0);
+    discard_prefetch_locked();   // stale: targets the old playlist
     start_pipe_locked();
     if (pipe_) state_.store(PlaybackState::playing, std::memory_order_release);
     return true;
@@ -365,6 +410,7 @@ void JellyfinSource::set_config(JellyfinConfig cfg) {
     cfg_ = std::move(cfg);
 
     if (tracks) {
+        discard_prefetch_locked();
         stop_pipe_locked();
         queue_       = std::move(*tracks);
         current_idx_ = 0;
@@ -375,6 +421,7 @@ void JellyfinSource::set_config(JellyfinConfig cfg) {
         }
     } else if (shuffle_flip && cfg_.shuffle) {
         shuffle_range(queue_, current_idx_ + 1);   // preserve the currently-playing track
+        discard_prefetch_locked();                  // next-idx URL just changed
     }
 }
 
@@ -390,6 +437,12 @@ void JellyfinSource::set_playback_options(const PlaybackConfig& opts) {
     }
     // loudnorm is in the ffmpeg argv; new state takes effect on the next track.
     volume_norm_.store(opts.volume_normalization, std::memory_order_release);
+    const bool prev = prebuffer_next_.exchange(opts.prebuffer_next_track,
+                                                std::memory_order_acq_rel);
+    if (prev && !opts.prebuffer_next_track) {
+        std::scoped_lock lk{mu_};
+        discard_prefetch_locked();
+    }
 }
 
 TrackInfo JellyfinSource::current_track() const {
@@ -463,6 +516,7 @@ void JellyfinSource::pump(RingBuffer& ring) {
         avail = avail > got ? avail - got : 0;
     }
     update_position();
+    maybe_spawn_prefetch_locked();
 }
 
 } // namespace fh6::sources

--- a/src/sources/local_file_source.cpp
+++ b/src/sources/local_file_source.cpp
@@ -146,31 +146,25 @@ struct LocalFileSource::Decoder {
     bool ff_eof                = false;
 
     TrackInfo info{};
+    // Per-decoder so a prefetched track promotes with its own ReplayGain
+    // multiplier instead of inheriting the current track's.
+    float loudness_coef     = 1.0f;
+    std::size_t for_cursor  = 0;
 
     bool any_open() const noexcept { return ma_open || ff_pipe != nullptr; }
 
-    void close_ff() {
-        if (ff_pipe) { CloseHandle(ff_pipe); ff_pipe = nullptr; }
-        if (ff_proc) { CloseHandle(ff_proc); ff_proc = nullptr; }
-        if (ff_job)  { CloseHandle(ff_job);  ff_job  = nullptr; }
-        ff_bytes_out = 0;
-        ff_eof       = false;
-    }
-
-    void close_all() {
-        if (ma_open) {
-            ma_decoder_uninit(&ma);
-            ma_open = false;
-        }
-        close_ff();
-        info = {};
+    ~Decoder() {
+        if (ma_open)  ma_decoder_uninit(&ma);
+        if (ff_pipe)  CloseHandle(ff_pipe);
+        if (ff_proc)  CloseHandle(ff_proc);
+        // KILL_ON_JOB_CLOSE on the job reaps ffmpeg if it's still resident.
+        if (ff_job)   CloseHandle(ff_job);
     }
 };
 
 LocalFileSource::LocalFileSource(LocalFilesConfig cfg, std::filesystem::path ffmpeg_path)
     : cfg_{std::move(cfg)},
-      ffmpeg_path_{std::move(ffmpeg_path)},
-      dec_{std::make_unique<Decoder>()} {}
+      ffmpeg_path_{std::move(ffmpeg_path)} {}
 
 LocalFileSource::~LocalFileSource() { close_current(); }
 
@@ -191,6 +185,7 @@ bool LocalFileSource::initialize() {
 
 void LocalFileSource::rebuild_playlist() {
     std::scoped_lock lk{mu_};
+    discard_prefetch_locked();   // playlist contents/order are about to change
     playlist_.clear();
     std::error_code ec;
     auto add = [&](const std::filesystem::path& p) {
@@ -215,65 +210,73 @@ void LocalFileSource::rebuild_playlist() {
 
 void LocalFileSource::close_current() {
     std::scoped_lock lk{mu_};
-    dec_->close_all();
+    discard_prefetch_locked();
+    dec_.reset();
 }
 
-bool LocalFileSource::open_track(std::size_t index) {
-    if (playlist_.empty()) return false;
-    cursor_          = index % playlist_.size();
-    const auto& path = playlist_[cursor_];
+std::unique_ptr<LocalFileSource::Decoder>
+LocalFileSource::open_decoder_locked(std::size_t index) {
+    if (playlist_.empty()) return nullptr;
+    const std::size_t resolved = index % playlist_.size();
+    const auto& path           = playlist_[resolved];
 
-    dec_->close_all();
+    auto d         = std::make_unique<Decoder>();
+    d->for_cursor  = resolved;
 
-    auto meta = probe_metadata(ffmpeg_path_.empty() ? L"ffmpeg" : ffmpeg_path_.wstring(), path);
-    dec_->info.duration_ms = meta.duration_ms;
-    dec_->info.title       = std::move(meta.title);
-    dec_->info.artist      = std::move(meta.artist);
-    dec_->info.album       = std::move(meta.album);
+    auto meta      = probe_metadata(ffmpeg_path_.empty() ? L"ffmpeg" : ffmpeg_path_.wstring(),
+                                     path);
+    d->info.duration_ms = meta.duration_ms;
+    d->info.title       = std::move(meta.title);
+    d->info.artist      = std::move(meta.artist);
+    d->info.album       = std::move(meta.album);
 
     ma_decoder_config mc = ma_decoder_config_init(ma_format_s16, 2, kSampleRate);
-    if (ma_decoder_init_file(path.string().c_str(), &mc, &dec_->ma) == MA_SUCCESS) {
-        dec_->ma_open = true;
+    if (ma_decoder_init_file(path.string().c_str(), &mc, &d->ma) == MA_SUCCESS) {
+        d->ma_open = true;
         // Decoded frame count beats ffmpeg's header duration on VBR MP3s.
         ma_uint64 frames = 0;
-        if (ma_decoder_get_length_in_pcm_frames(&dec_->ma, &frames) == MA_SUCCESS)
-            dec_->info.duration_ms = (frames * 1000ull) / kSampleRate;
-    } else if (!open_track_ffmpeg(path)) {
+        if (ma_decoder_get_length_in_pcm_frames(&d->ma, &frames) == MA_SUCCESS)
+            d->info.duration_ms = (frames * 1000ull) / kSampleRate;
+    } else if (!open_track_ffmpeg(*d, path)) {
         log::warn("[local] failed to open {} (miniaudio rejected the format and the ffmpeg "
                   "fallback also failed; install ffmpeg or convert the file)",
                   path.string());
-        return false;
+        return nullptr;
     }
 
-    if (dec_->info.title.empty()) dec_->info.title = path.stem().string();
-    if (dec_->info.album.empty()) dec_->info.album = path.parent_path().filename().string();
-    position_ms_.store(0, std::memory_order_release);
+    if (d->info.title.empty()) d->info.title = path.stem().string();
+    if (d->info.album.empty()) d->info.album = path.parent_path().filename().string();
 
     float gain_db = std::numeric_limits<float>::quiet_NaN();
     float peak    = std::numeric_limits<float>::quiet_NaN();
     parse_replaygain_file(path, gain_db, peak);
-    loudness_coef_.store(compute_loudness_correction(gain_db, peak), std::memory_order_release);
+    d->loudness_coef = compute_loudness_correction(gain_db, peak);
 
-    log::info("[local] now playing: {}", path.string());
+    return d;
+}
+
+bool LocalFileSource::open_track(std::size_t index) {
+    auto d = open_decoder_locked(index);
+    if (!d) return false;
+    cursor_ = d->for_cursor;
+    dec_    = std::move(d);
+    position_ms_.store(0, std::memory_order_release);
+    log::info("[local] now playing: {}", playlist_[cursor_].string());
     return true;
 }
 
-bool LocalFileSource::open_track_ffmpeg(const std::filesystem::path& path) {
+bool LocalFileSource::open_track_ffmpeg(Decoder& d, const std::filesystem::path& path) {
     const std::wstring ff = ffmpeg_path_.empty() ? L"ffmpeg" : ffmpeg_path_.wstring();
 
-    auto* d = dec_.get();
-    d->ff_job = create_kill_on_close_job();
-    if (!d->ff_job) {
+    d.ff_job = create_kill_on_close_job();
+    if (!d.ff_job) {
         log::warn("[local] ffmpeg fallback: CreateJobObject failed ({})", GetLastError());
         return false;
     }
 
     SECURITY_ATTRIBUTES sa{sizeof(sa), nullptr, TRUE};
     HANDLE rd = nullptr, wr = nullptr;
-    if (!CreatePipe(&rd, &wr, &sa, 1 << 20)) {
-        d->close_ff();
-        return false;
-    }
+    if (!CreatePipe(&rd, &wr, &sa, 1 << 20)) return false;
     SetHandleInformation(rd, 0, HANDLE_FLAG_INHERIT);
 
     HANDLE nul_in  = open_nul(GENERIC_READ);
@@ -282,26 +285,52 @@ bool LocalFileSource::open_track_ffmpeg(const std::filesystem::path& path) {
         quote(ff) + L" -hide_banner -loglevel error -nostdin -vn -i " + quote(path.wstring()) +
         L" -f s16le -acodec pcm_s16le -ar 48000 -ac 2 pipe:1";
 
-    d->ff_proc = spawn_in_job(d->ff_job, cmd, nul_in, wr, err_log);
-    const DWORD ec = d->ff_proc ? 0u : GetLastError();
+    d.ff_proc = spawn_in_job(d.ff_job, cmd, nul_in, wr, err_log);
+    const DWORD ec = d.ff_proc ? 0u : GetLastError();
     CloseHandle(wr);
     if (nul_in)  CloseHandle(nul_in);
     if (err_log) CloseHandle(err_log);
-    if (!d->ff_proc) {
+    if (!d.ff_proc) {
         CloseHandle(rd);
-        d->close_ff();
         log::warn("[local] ffmpeg fallback: failed to launch -- {}",
                   describe_launch_failure(ff, ec, !ffmpeg_path_.empty()));
-        return false;
+        return false;  // ~Decoder reaps the job
     }
 
-    d->ff_pipe = rd;
+    d.ff_pipe = rd;
     return true;
+}
+
+void LocalFileSource::discard_prefetch_locked() noexcept { prefetch_dec_.reset(); }
+
+std::size_t LocalFileSource::next_cursor_locked() const noexcept {
+    if (playlist_.empty()) return 0;
+    return (cursor_ + 1) % playlist_.size();
+}
+
+bool LocalFileSource::promote_prefetch_locked(std::size_t expected_cursor) {
+    if (!prefetch_dec_ || prefetch_dec_->for_cursor != expected_cursor) {
+        discard_prefetch_locked();
+        return false;
+    }
+    dec_    = std::move(prefetch_dec_);
+    cursor_ = dec_->for_cursor;
+    position_ms_.store(0, std::memory_order_release);
+    log::info("[local] now playing (prebuffered): {}", playlist_[cursor_].string());
+    return true;
+}
+
+void LocalFileSource::maybe_spawn_prefetch_locked() {
+    if (!prebuffer_next_.load(std::memory_order_acquire)) return;
+    if (prefetch_dec_ || !dec_ || playlist_.size() < 2) return;
+    // Local files (esp. miniaudio) open near-instantly, so no byte threshold is
+    // needed -- spawning on the first pump tick after a track change is cheap.
+    prefetch_dec_ = open_decoder_locked(next_cursor_locked());
 }
 
 void LocalFileSource::play() {
     std::scoped_lock lk{mu_};
-    if (!dec_->any_open() && !open_track(cursor_)) {
+    if ((!dec_ || !dec_->any_open()) && !open_track(cursor_)) {
         state_.store(PlaybackState::stopped, std::memory_order_release);
         return;
     }
@@ -312,14 +341,16 @@ void LocalFileSource::pause() { state_.store(PlaybackState::paused, std::memory_
 
 bool LocalFileSource::skip_next() {
     std::scoped_lock lk{mu_};
-    if (playlist_.empty() || !open_track(cursor_ + 1)) return false;
+    if (playlist_.empty()) return false;
+    const std::size_t next = next_cursor_locked();
+    if (!promote_prefetch_locked(next) && !open_track(next)) return false;
     state_.store(PlaybackState::playing, std::memory_order_release);
     return true;
 }
 
 bool LocalFileSource::restart_current() {
     std::scoped_lock lk{mu_};
-    if (!dec_->any_open()) return false;
+    if (!dec_ || !dec_->any_open()) return false;
     if (dec_->ma_open) {
         if (ma_decoder_seek_to_pcm_frame(&dec_->ma, 0) != MA_SUCCESS) return false;
     } else {
@@ -338,12 +369,15 @@ void LocalFileSource::stop() {
 
 void LocalFileSource::next() {
     std::scoped_lock lk{mu_};
-    open_track(cursor_ + 1);
+    if (playlist_.empty()) return;
+    const std::size_t next = next_cursor_locked();
+    if (!promote_prefetch_locked(next)) open_track(next);
     state_.store(PlaybackState::playing, std::memory_order_release);
 }
 
 void LocalFileSource::previous() {
     std::scoped_lock lk{mu_};
+    discard_prefetch_locked();   // prefetch targets cursor+1; previous() rewinds
     open_track(cursor_ == 0 ? playlist_.size() - 1 : cursor_ - 1);
     state_.store(PlaybackState::playing, std::memory_order_release);
 }
@@ -352,11 +386,15 @@ void LocalFileSource::pump(RingBuffer& ring) {
     if (state_.load(std::memory_order_acquire) != PlaybackState::playing) return;
 
     std::scoped_lock lk{mu_};
-    if (!dec_->any_open()) return;
+    if (!dec_ || !dec_->any_open()) return;
 
     const float rg = volume_norm_.load(std::memory_order_acquire)
-                         ? loudness_coef_.load(std::memory_order_acquire)
+                         ? dec_->loudness_coef
                          : 1.0f;
+    auto advance_at_eof = [&] {
+        const std::size_t next = next_cursor_locked();
+        if (!promote_prefetch_locked(next)) open_track(next);
+    };
 
     auto apply_dsp = [&](int16_t* samples, std::size_t frames) {
         if (rg != 1.0f) {
@@ -379,7 +417,7 @@ void LocalFileSource::pump(RingBuffer& ring) {
             if (ma_decoder_read_pcm_frames(&dec_->ma, scratch, kChunkFrames, &read) != MA_SUCCESS)
                 read = 0;
             if (read == 0) {
-                open_track(cursor_ + 1);
+                advance_at_eof();
                 return;
             }
             apply_dsp(scratch, static_cast<std::size_t>(read));
@@ -394,6 +432,7 @@ void LocalFileSource::pump(RingBuffer& ring) {
             const uint64_t played = cursor > queued ? cursor - queued : 0;
             position_ms_.store((played * 1000ull) / kSampleRate, std::memory_order_release);
         }
+        maybe_spawn_prefetch_locked();
         return;
     }
 
@@ -406,7 +445,7 @@ void LocalFileSource::pump(RingBuffer& ring) {
 
     if (dec_->ff_eof) {
         update_position();
-        if (ring.readable() == 0) open_track(cursor_ + 1);
+        if (ring.readable() == 0) advance_at_eof();
         return;
     }
 
@@ -439,11 +478,13 @@ void LocalFileSource::pump(RingBuffer& ring) {
         avail = avail > got ? avail - got : 0;
     }
     update_position();
+    maybe_spawn_prefetch_locked();
 }
 
 TrackInfo LocalFileSource::current_track() const {
     std::scoped_lock lk{mu_};
-    TrackInfo info   = dec_->info;
+    TrackInfo info;
+    if (dec_) info = dec_->info;
     info.position_ms = position_ms_.load(std::memory_order_acquire);
     return info;
 }
@@ -502,6 +543,12 @@ void LocalFileSource::set_ffmpeg_path(std::filesystem::path p) {
 void LocalFileSource::set_playback_options(const PlaybackConfig& opts) {
     volume_norm_.store(opts.volume_normalization, std::memory_order_release);
     eq_.set_options(opts.equalizer_enabled, opts.equalizer_bands, (float)kSampleRate);
+    const bool prev = prebuffer_next_.exchange(opts.prebuffer_next_track,
+                                                std::memory_order_acq_rel);
+    if (prev && !opts.prebuffer_next_track) {
+        std::scoped_lock lk{mu_};
+        discard_prefetch_locked();
+    }
 }
 
 std::vector<std::string> LocalFileSource::playlist_snapshot() const {

--- a/src/sources/local_file_source.cpp
+++ b/src/sources/local_file_source.cpp
@@ -377,7 +377,8 @@ void LocalFileSource::next() {
 
 void LocalFileSource::previous() {
     std::scoped_lock lk{mu_};
-    discard_prefetch_locked();   // prefetch targets cursor+1; previous() rewinds
+    if (playlist_.empty()) return;   // size()-1 would underflow size_t
+    discard_prefetch_locked();       // prefetch targets cursor+1; previous() rewinds
     open_track(cursor_ == 0 ? playlist_.size() - 1 : cursor_ - 1);
     state_.store(PlaybackState::playing, std::memory_order_release);
 }

--- a/src/sources/youtube_music_source.cpp
+++ b/src/sources/youtube_music_source.cpp
@@ -60,6 +60,11 @@ struct YouTubeMusicSource::Pipe {
     std::uint64_t bytes_written = 0;
     bool ended = false;
 
+    // Identity + metadata travel with the pipeline so prefetch promotion
+    // carries the (already-resolved) title without a "(loading)" flash.
+    std::size_t for_queue_idx = 0;
+    TrackInfo info{};
+
     ~Pipe() {
         // Close pipes first so any blocked ReadFile in the children unblocks
         // with broken-pipe, then drop the job handle -- KILL_ON_JOB_CLOSE
@@ -90,6 +95,7 @@ bool YouTubeMusicSource::initialize() {
 
 void YouTubeMusicSource::shutdown() noexcept {
     std::scoped_lock lk{mu_};
+    discard_prefetch_locked();
     stop_pipe_locked();
 }
 
@@ -100,6 +106,7 @@ void YouTubeMusicSource::set_target(std::string url) {
     queue_.clear();
     queue_idx_ = 0;
     queue_built_for_.clear();
+    discard_prefetch_locked();
 }
 
 void YouTubeMusicSource::set_ffmpeg_path(std::filesystem::path p) {
@@ -110,6 +117,9 @@ void YouTubeMusicSource::set_ffmpeg_path(std::filesystem::path p) {
 void YouTubeMusicSource::set_shuffle(bool shuffle) {
     std::scoped_lock lk{mu_};
     cfg_.shuffle = shuffle;
+    // The next-queue-index URL is about to change; any prefetched pipeline
+    // would now be playing the wrong track.
+    discard_prefetch_locked();
     if (!queue_.empty() && queue_built_for_ == target_url_) {
         // Re-shuffle or re-sort the remaining queue (preserve current track)
         if (shuffle) {
@@ -217,19 +227,19 @@ void YouTubeMusicSource::resolve_queue_locked() {
     }
 }
 
-void YouTubeMusicSource::start_pipe_locked() {
-    stop_pipe_locked();
-    resolve_queue_locked();
-    if (queue_.empty()) return;
-    if (queue_idx_ >= queue_.size()) queue_idx_ = 0;
-
-    const std::string play_url = queue_[queue_idx_];
+std::unique_ptr<YouTubeMusicSource::Pipe>
+YouTubeMusicSource::spawn_pipe_locked(std::string_view url, std::size_t for_idx) {
+    const std::string play_url{url};
 
     auto pipe = std::make_unique<Pipe>();
+    pipe->for_queue_idx = for_idx;
+    pipe->info.title    = "(loading)";
+    pipe->info.artist   = "YouTube Music";
+
     pipe->job = create_kill_on_close_job();
     if (!pipe->job) {
         log::warn("[yt] CreateJobObject failed ({})", GetLastError());
-        return;
+        return nullptr;
     }
 
     SECURITY_ATTRIBUTES sa{sizeof(sa), nullptr, TRUE};
@@ -246,11 +256,11 @@ void YouTubeMusicSource::start_pipe_locked() {
         if (tl_out_w) CloseHandle(tl_out_w);
     };
 
-    if (!CreatePipe(&yt_out_r, &yt_out_w, &sa, 1 << 20)) { bail(); return; }
+    if (!CreatePipe(&yt_out_r, &yt_out_w, &sa, 1 << 20)) { bail(); return nullptr; }
     SetHandleInformation(yt_out_r, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT);
-    if (!CreatePipe(&ff_out_r, &ff_out_w, &sa, 1 << 20)) { bail(); return; }
+    if (!CreatePipe(&ff_out_r, &ff_out_w, &sa, 1 << 20)) { bail(); return nullptr; }
     SetHandleInformation(ff_out_r, 0, HANDLE_FLAG_INHERIT);
-    if (!CreatePipe(&tl_out_r, &tl_out_w, &sa, 1 << 16)) { bail(); return; }
+    if (!CreatePipe(&tl_out_r, &tl_out_w, &sa, 1 << 16)) { bail(); return nullptr; }
     SetHandleInformation(tl_out_r, 0, HANDLE_FLAG_INHERIT);
 
     HANDLE nul_in  = open_nul(GENERIC_READ);
@@ -295,7 +305,7 @@ void YouTubeMusicSource::start_pipe_locked() {
         bail();
         if (nul_in)  CloseHandle(nul_in);
         if (err_log) CloseHandle(err_log);
-        return;
+        return nullptr;
     }
 
     pipe->proc_ff = spawn_in_job(pipe->job, ff_cmd, yt_out_r, ff_out_w, err_log);
@@ -310,7 +320,7 @@ void YouTubeMusicSource::start_pipe_locked() {
         if (tl_out_w) CloseHandle(tl_out_w);
         if (nul_in)   CloseHandle(nul_in);
         if (err_log)  CloseHandle(err_log);
-        return;  // ~Pipe closes the job, which kills the orphan yt-dlp
+        return nullptr;  // ~Pipe closes the job, which kills the orphan yt-dlp
     }
 
     pipe->proc_title = spawn_in_job(pipe->job, tl_cmd, nul_in, tl_out_w, err_log);
@@ -328,20 +338,66 @@ void YouTubeMusicSource::start_pipe_locked() {
     if (err_log) CloseHandle(err_log);
 
     pipe->read_pipe = ff_out_r;
-    pipe_           = std::move(pipe);
-
-    info_              = TrackInfo{};
-    info_.title        = "(loading)";
-    info_.artist       = "YouTube Music";
-    info_.duration_ms  = 0;
-    position_ms_.store(0, std::memory_order_release);
-    state_.store(PlaybackState::buffering, std::memory_order_release);
 
     log::info("[yt] pipe started for {} (track {}/{}; child stderr -> {})", play_url,
-              queue_idx_ + 1, queue_.size(), stderr_log_path().string());
+              for_idx + 1, queue_.size(), stderr_log_path().string());
+    return pipe;
+}
+
+void YouTubeMusicSource::start_pipe_locked() {
+    stop_pipe_locked();
+    resolve_queue_locked();
+    if (queue_.empty()) return;
+    if (queue_idx_ >= queue_.size()) queue_idx_ = 0;
+
+    pipe_ = spawn_pipe_locked(queue_[queue_idx_], queue_idx_);
+    if (!pipe_) return;
+    position_ms_.store(0, std::memory_order_release);
+    state_.store(PlaybackState::buffering, std::memory_order_release);
+}
+
+std::size_t YouTubeMusicSource::next_queue_idx_locked() const noexcept {
+    if (queue_.empty()) return 0;
+    return (queue_idx_ + 1) % queue_.size();
+}
+
+void YouTubeMusicSource::discard_prefetch_locked() noexcept {
+    // ~Pipe closes the job; KILL_ON_JOB_CLOSE reaps yt-dlp+ffmpeg+title.
+    prefetch_.reset();
+}
+
+bool YouTubeMusicSource::promote_prefetch_locked(std::size_t expected_idx) {
+    if (!prefetch_ || prefetch_->for_queue_idx != expected_idx) {
+        discard_prefetch_locked();
+        return false;
+    }
+    pipe_ = std::move(prefetch_);
+    // Ring still drains leftover PCM from the previous track; the new pipe's
+    // OS pipe buffer (~1 MB) already holds ~5 s of decoded audio, so PCM
+    // continuity is preserved and the "(loading)" label never appears.
+    position_ms_.store(0, std::memory_order_release);
+    state_.store(PlaybackState::buffering, std::memory_order_release);
+    return true;
+}
+
+void YouTubeMusicSource::maybe_spawn_prefetch_locked() {
+    if (!prebuffer_next_.load(std::memory_order_acquire)) return;
+    if (prefetch_ || !pipe_ || queue_.size() < 2) return;
+    // Only commit a second yt-dlp once the current pipe has proven viable
+    // (~0.5 s of PCM = 96 KB). Saves spawning a prefetch we'll throw away if
+    // the current track turns out to be unfetchable.
+    constexpr std::uint64_t kViableBytes = 96 * 1024;
+    if (pipe_->bytes_written < kViableBytes) return;
+
+    const std::size_t idx = next_queue_idx_locked();
+    prefetch_ = spawn_pipe_locked(queue_[idx], idx);
 }
 
 void YouTubeMusicSource::stop_pipe_locked() {
+    // Note: prefetch_ is intentionally NOT touched here -- start_pipe_locked()
+    // calls stop_pipe_locked() before promotion, and we'd lose the prefetched
+    // pipeline. Callers that want a clean shutdown call discard_prefetch_locked()
+    // explicitly (stop(), shutdown()).
     pipe_.reset();
     state_.store(PlaybackState::stopped, std::memory_order_release);
 }
@@ -360,7 +416,7 @@ bool YouTubeMusicSource::restart_current() {
     std::scoped_lock lk{mu_};
     if (queue_.empty()) return false;
     consecutive_failed_ = 0;
-    start_pipe_locked();   // re-pipe from t=0 at the same queue_idx_
+    start_pipe_locked();   // re-pipe from t=0 at the same queue_idx_; prefetch is still valid
     if (!pipe_) return false;
     state_.store(PlaybackState::playing, std::memory_order_release);
     return true;
@@ -373,7 +429,7 @@ bool YouTubeMusicSource::skip_next() {
     const auto n = static_cast<std::ptrdiff_t>(queue_.size());
     auto i       = static_cast<std::ptrdiff_t>(queue_idx_) + 1;
     queue_idx_   = static_cast<std::size_t>(((i % n) + n) % n);
-    start_pipe_locked();
+    if (!promote_prefetch_locked(queue_idx_)) start_pipe_locked();
     if (!pipe_) return false;
     state_.store(PlaybackState::playing, std::memory_order_release);
     return true;
@@ -381,6 +437,7 @@ bool YouTubeMusicSource::skip_next() {
 
 void YouTubeMusicSource::stop() {
     std::scoped_lock lk{mu_};
+    discard_prefetch_locked();
     stop_pipe_locked();
 }
 
@@ -391,7 +448,7 @@ void YouTubeMusicSource::next() {
     const auto n = static_cast<std::ptrdiff_t>(queue_.size());
     auto i       = static_cast<std::ptrdiff_t>(queue_idx_) + 1;
     queue_idx_   = static_cast<std::size_t>(((i % n) + n) % n);
-    start_pipe_locked();
+    if (!promote_prefetch_locked(queue_idx_)) start_pipe_locked();
     if (pipe_) state_.store(PlaybackState::playing, std::memory_order_release);
 }
 
@@ -402,13 +459,16 @@ void YouTubeMusicSource::previous() {
     const auto n = static_cast<std::ptrdiff_t>(queue_.size());
     auto i       = static_cast<std::ptrdiff_t>(queue_idx_) - 1;
     queue_idx_   = static_cast<std::size_t>(((i % n) + n) % n);
+    // Prefetch targets idx+1; previous() rewinds, so it's stale.
+    discard_prefetch_locked();
     start_pipe_locked();
     if (pipe_) state_.store(PlaybackState::playing, std::memory_order_release);
 }
 
 TrackInfo YouTubeMusicSource::current_track() const {
     std::scoped_lock lk{mu_};
-    TrackInfo t   = info_;
+    TrackInfo t;
+    if (pipe_) t = pipe_->info;
     t.position_ms = position_ms_.load(std::memory_order_acquire);
     return t;
 }
@@ -420,12 +480,69 @@ void YouTubeMusicSource::set_playback_options(const PlaybackConfig& opts) {
     // start_pipe_locked() (track change). Same per-track granularity as
     // local-files ReplayGain -- not re-fetching the current YT track.
     volume_norm_.store(opts.volume_normalization, std::memory_order_release);
+    // Toggling prebuffer off mid-playback drops any in-flight prefetch
+    // process so we don't hold an orphan yt-dlp for the whole track.
+    const bool prev = prebuffer_next_.exchange(opts.prebuffer_next_track,
+                                                std::memory_order_acq_rel);
+    if (prev && !opts.prebuffer_next_track) {
+        std::scoped_lock lk{mu_};
+        discard_prefetch_locked();
+    }
 }
 
 std::string YouTubeMusicSource::auth_instructions() const {
     return "Export your YouTube cookies to a Netscape cookies.txt and set "
            "[youtube_music].cookies_path in config.toml. Public content works "
            "without cookies.";
+}
+
+void YouTubeMusicSource::drain_title_pipe_locked(Pipe* p) {
+    // yt-dlp --print closes its stdout last; the Peek right after may go
+    // ERROR_BROKEN_PIPE before we've drained the buffered "title\nuploader\n
+    // duration\n", so we finalise on broken-pipe too.
+    if (!p || !p->title_pipe) return;
+
+    bool finalise = false;
+    for (int safety = 0; safety < 8; ++safety) {
+        DWORD tavail = 0;
+        BOOL ok      = PeekNamedPipe(p->title_pipe, nullptr, 0, nullptr, &tavail, nullptr);
+        if (!ok) { finalise = true; break; }
+        if (tavail == 0) {
+            DWORD ec = STILL_ACTIVE;
+            if (p->proc_title && GetExitCodeProcess(p->proc_title, &ec) && ec != STILL_ACTIVE)
+                finalise = true;
+            break;
+        }
+        char tbuf[1024];
+        DWORD got = 0;
+        if (!ReadFile(p->title_pipe, tbuf, sizeof(tbuf), &got, nullptr) || got == 0) {
+            finalise = true;
+            break;
+        }
+        p->title_buf.append(tbuf, got);
+    }
+    if (!finalise) return;
+
+    auto& s        = p->title_buf;
+    auto take_line = [&] {
+        auto nl          = s.find('\n');
+        std::string line = (nl == std::string::npos) ? s : s.substr(0, nl);
+        while (!line.empty() && (line.back() == '\r' || line.back() == ' '))
+            line.pop_back();
+        s.erase(0, nl == std::string::npos ? s.size() : nl + 1);
+        return line;
+    };
+    auto title    = take_line();
+    auto uploader = take_line();
+    auto duration = take_line();
+    if (!title.empty() && title != "NA") p->info.title = std::move(title);
+    if (!uploader.empty() && uploader != "NA") p->info.artist = std::move(uploader);
+    try {
+        if (!duration.empty() && duration != "NA")
+            p->info.duration_ms = static_cast<std::uint64_t>(std::stod(duration) * 1000.0);
+    } catch (...) {}
+    CloseHandle(p->title_pipe);
+    p->title_pipe = nullptr;
 }
 
 void YouTubeMusicSource::pump(RingBuffer& ring) {
@@ -438,54 +555,10 @@ void YouTubeMusicSource::pump(RingBuffer& ring) {
     Pipe* p = pipe_.get();
     if (!p) return;
 
-    // ---- Title resolver drain & parse ----
-    // The earlier version only parsed when the child had exited AND tavail==0
-    // in the same tick. In practice yt-dlp --print closes its stdout last; the
-    // very next Peek goes ERROR_BROKEN_PIPE and we used to throw the buffered
-    // "title\nuploader\nduration\n" away. Now we finalise on broken-pipe too.
-    if (p->title_pipe) {
-        bool finalise = false;
-        for (int safety = 0; safety < 8; ++safety) {
-            DWORD tavail = 0;
-            BOOL ok      = PeekNamedPipe(p->title_pipe, nullptr, 0, nullptr, &tavail, nullptr);
-            if (!ok) { finalise = true; break; }
-            if (tavail == 0) {
-                DWORD ec = STILL_ACTIVE;
-                if (p->proc_title && GetExitCodeProcess(p->proc_title, &ec) && ec != STILL_ACTIVE)
-                    finalise = true;
-                break;
-            }
-            char tbuf[1024];
-            DWORD got = 0;
-            if (!ReadFile(p->title_pipe, tbuf, sizeof(tbuf), &got, nullptr) || got == 0) {
-                finalise = true;
-                break;
-            }
-            p->title_buf.append(tbuf, got);
-        }
-        if (finalise) {
-            auto& s        = p->title_buf;
-            auto take_line = [&] {
-                auto nl          = s.find('\n');
-                std::string line = (nl == std::string::npos) ? s : s.substr(0, nl);
-                while (!line.empty() && (line.back() == '\r' || line.back() == ' '))
-                    line.pop_back();
-                s.erase(0, nl == std::string::npos ? s.size() : nl + 1);
-                return line;
-            };
-            auto title    = take_line();
-            auto uploader = take_line();
-            auto duration = take_line();
-            if (!title.empty() && title != "NA") info_.title = std::move(title);
-            if (!uploader.empty() && uploader != "NA") info_.artist = std::move(uploader);
-            try {
-                if (!duration.empty() && duration != "NA")
-                    info_.duration_ms = static_cast<std::uint64_t>(std::stod(duration) * 1000.0);
-            } catch (...) {}
-            CloseHandle(p->title_pipe);
-            p->title_pipe = nullptr;
-        }
-    }
+    // Resolve titles on both the current pipe and the (silently buffering)
+    // prefetch so promotion picks up an already-resolved TrackInfo.
+    drain_title_pipe_locked(p);
+    drain_title_pipe_locked(prefetch_.get());
 
     // ---- PCM drain ----
     auto advance_to_next = [&] {
@@ -493,7 +566,7 @@ void YouTubeMusicSource::pump(RingBuffer& ring) {
         const auto n = static_cast<std::ptrdiff_t>(queue_.size());
         auto i       = static_cast<std::ptrdiff_t>(queue_idx_) + 1;
         queue_idx_   = static_cast<std::size_t>(((i % n) + n) % n);
-        start_pipe_locked();
+        if (!promote_prefetch_locked(queue_idx_)) start_pipe_locked();
         if (pipe_) state_.store(PlaybackState::playing, std::memory_order_release);
     };
 
@@ -566,6 +639,10 @@ void YouTubeMusicSource::pump(RingBuffer& ring) {
     // Even when the read loop didn't run (e.g. ring was full), keep position
     // moving as the mixer drains the ring.
     update_position();
+    // Spawn the next-track pipeline once the current pipe has proven viable;
+    // its OS pipe buffer fills silently in the background (~5 s of PCM) and is
+    // promoted on the next transition.
+    maybe_spawn_prefetch_locked();
 }
 
 } // namespace fh6::sources

--- a/ui/dist/app.js
+++ b/ui/dist/app.js
@@ -160,6 +160,7 @@ const SCHEMA = [
     ["equalizer_enabled",    "Equalizer",                 "checkbox"],
     ["equalizer_bands",      "Equalizer bands",           "bands"],
     ["force_stereo_audio",   "Force stereo audio",        "checkbox"],
+    ["prebuffer_next_track", "Pre-buffer next track",     "checkbox"],
   ]],
 ];
 


### PR DESCRIPTION
- Added support for pre-buffering the next track in LocalFileSource and YouTubeMusicSource.
- Introduced a prefetch mechanism to load the next track in the background, improving playback continuity.
- Updated configuration options to allow enabling/disabling pre-buffering.
- Enhanced JSON configuration handling to include pre-buffering settings.
- Modified UI to provide a checkbox for the pre-buffering option.
- Refactored decoder management to accommodate pre-buffering logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added prebuffering of the next track’s pipeline to eliminate “(loading)” gaps on skip/end-of-track across local files, Jellyfin and YouTube Music playback.

* **Configuration**
  * New playback setting `prebuffer_next_track` (defaults to true); controllable via config file and the /api/config endpoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/g0ldyy/fh6-universal-radio/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->