### PR TITLE
Add optional external audio source

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ add_library(version SHARED
     src/sources/local_file_source.cpp
     src/sources/youtube_music_source.cpp
     src/sources/jellyfin_source.cpp
+    src/sources/external_audio_source.cpp
 )
 
 # MSVC carries the forwarders via pragmas in dll_main.cpp because its .def
@@ -79,6 +80,7 @@ target_include_directories(version PRIVATE
 )
 
 target_link_libraries(version PRIVATE ws2_32 bcrypt psapi winhttp)
+target_link_libraries(version PRIVATE ole32 uuid)
 
 set_target_properties(version PROPERTIES
     OUTPUT_NAME version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ add_library(version SHARED
     src/sources/youtube_music_source.cpp
     src/sources/jellyfin_source.cpp
     src/sources/external_audio_source.cpp
+    src/sources/external_media_session.cpp
 )
 
 # MSVC carries the forwarders via pragmas in dll_main.cpp because its .def
@@ -79,7 +80,7 @@ target_include_directories(version PRIVATE
     third_party/miniaudio
 )
 
-target_link_libraries(version PRIVATE ws2_32 bcrypt psapi winhttp ole32 uuid ksuser)
+target_link_libraries(version PRIVATE ws2_32 bcrypt psapi winhttp ole32 uuid ksuser runtimeobject)
 
 set_target_properties(version PROPERTIES
     OUTPUT_NAME version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,8 +79,7 @@ target_include_directories(version PRIVATE
     third_party/miniaudio
 )
 
-target_link_libraries(version PRIVATE ws2_32 bcrypt psapi winhttp)
-target_link_libraries(version PRIVATE ole32 uuid ksuser)
+target_link_libraries(version PRIVATE ws2_32 bcrypt psapi winhttp ole32 uuid ksuser)
 
 set_target_properties(version PROPERTIES
     OUTPUT_NAME version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ target_include_directories(version PRIVATE
 )
 
 target_link_libraries(version PRIVATE ws2_32 bcrypt psapi winhttp)
-target_link_libraries(version PRIVATE ole32 uuid)
+target_link_libraries(version PRIVATE ole32 uuid ksuser)
 
 set_target_properties(version PROPERTIES
     OUTPUT_NAME version

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center"><img src="assets/banner.png" alt="FH6 Universal Radio" /></p>
 
-An open-source radio mod for **Forza Horizon 6**. Adds a new in-game radio station fed from your **local music**, **YouTube Music**, or **Jellyfin** server, controlled from a browser dashboard.
+An open-source radio mod for **Forza Horizon 6**. Adds a new in-game radio station fed from your **local music**, **YouTube Music**, **Jellyfin** server, or **any Windows app** (Spotify, Deezer, a browser tab...), controlled from a browser dashboard.
 
 <p align="center">
   <img src="assets/ingame.png" alt="In-game radio station" width="49%" />
@@ -18,6 +18,7 @@ An open-source radio mod for **Forza Horizon 6**. Adds a new in-game radio stati
 - **Local files**: point it at any folder. MP3 / FLAC / WAV / OGG play out of the box; M4A / AAC / OPUS / WMA / etc. play if `ffmpeg` is installed (same binary as YouTube Music below).
 - **YouTube Music**: paste any video, playlist, or YT Music URL from the dashboard.
 - **Jellyfin**: stream playlists from your own Jellyfin server.
+- **External audio**: capture any Windows app (Spotify, Deezer, a browser tab) and pipe it into the radio through a virtual audio cable; metadata and next/previous come from the Windows media session.
 - **In-game radio integration**: audio is routed through FH6's radio bus, fades with menus and reacts to in-game volume like every other station.
 - **Live dashboard** at `http://localhost:8420`: switch source, transport controls, volume, settings.
 - **Race start action**: on race begin, advance to next track, restart the current one, or leave it alone.
@@ -50,6 +51,17 @@ Then restart the game.
 `ffmpeg` can also be configured under **Settings > General > ffmpeg path**.
 
 Private/age-restricted content also needs a Netscape `cookies.txt` exported from your browser. Use an extension like **Get cookies.txt LOCALLY** to export it.
+
+### External audio
+
+External Audio is a loopback capture of a Windows playback device, so the app has to play onto a device you don't otherwise hear, or it reaches your speakers directly instead of through the radio. Route it through a virtual audio cable:
+
+1. Install a virtual audio cable, e.g. [VB-Audio Virtual Cable](https://vb-audio.com/Cable/).
+2. Send the app's audio to the cable. Apps without their own output picker (like Deezer) can still be routed from Windows **Settings > System > Sound > Volume mixer**, setting the app's output to `CABLE Input`; for a browser tab, an extension like **AuRo** does the same.
+3. In the dashboard, pick that cable as the **Capture device**.
+4. Pick the app as the **Media session** for the in-game title/artist and the next/previous controls.
+
+The app then pauses and resumes with the game radio (menus, radio off) instead of playing on in the background.
 
 ## Uninstall
 
@@ -94,6 +106,8 @@ Requires **CMake** and **llvm-mingw** (the Clang-based MinGW-w64 toolchain, sinc
 | `[local] failed to open ... .m4a` (or `.opus`, `.aac`, ...) | The built-in decoder handles MP3/FLAC/WAV/OGG only; other formats are routed through `ffmpeg`. Install it (`winget install Gyan.FFmpeg`) and either put it on `PATH` or set the path under **Settings > General > ffmpeg path**. |
 | YouTube Music produces no audio | Check `%TEMP%\fh6-stderr.log` (helper-process stderr lands there). Usually missing yt-dlp/ffmpeg, expired cookies, or geo/format restrictions. |
 | Jellyfin cast returns "fetch failed" (502) | Check server URL, API key, and user ID under **Settings > Jellyfin**, that the playlist ID exists, and that the server is reachable from this machine. Jellyfin transcodes to PCM via `ffmpeg`, so the configured ffmpeg path must be valid. |
+| External Audio plays in the background, not through the radio | You're capturing the same device the app plays on. Route the app's output to a **virtual audio cable** and select that cable as the **Capture device** (see [External audio](#external-audio)). |
+| External Audio has clicks / artifacts | Set the virtual cable to **48000 Hz** (2 ch). Other sample rates caused artifacts in testing. |
 
 ## Why this exists
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -8,7 +8,7 @@
 [general]
 port              = 8420
 ring_buffer_mb    = 4
-default_source    = "local_files"     # local_files | youtube_music | jellyfin
+default_source    = "local_files"     # local_files | youtube_music | jellyfin | external_audio
 fallback_source   = "local_files"
 ffmpeg_path       = ''                # blank = `ffmpeg` on PATH; shared by all sources
 
@@ -37,6 +37,8 @@ shuffle            = true              # true or false
 
 
 [external_audio]
+# Off by default. Enable from the dashboard Settings drawer before using External Audio.
+enabled = false
 # Empty = default Windows playback device. Otherwise use full endpoint id or part of device name, e.g. 'CABLE Input'.
 # This section is read directly by ExternalAudioSource.
 endpoint_id = ''

--- a/config.example.toml
+++ b/config.example.toml
@@ -35,6 +35,12 @@ user_id            = ''                # the ID of the user to track playback ag
 default_playlist   = ''                # jellyfin playlist ID goes here
 shuffle            = true              # true or false
 
+
+[external_audio]
+# Empty = default Windows playback device. Otherwise use full endpoint id or part of device name, e.g. 'CABLE Input'.
+# This section is read directly by ExternalAudioSource.
+endpoint_id = ''
+
 [audio]
 output_gain = 1.0
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -43,6 +43,8 @@ enabled = false
 # Empty = default Windows playback device. Otherwise use full endpoint id or part of device name, e.g. 'CABLE Input'.
 # This section is read directly by ExternalAudioSource.
 endpoint_id = ''
+# Empty = current Windows media session. Select a specific session from the dashboard when needed.
+media_session_id = ''
 
 [audio]
 output_gain = 1.0

--- a/include/fh6/audio_source.hpp
+++ b/include/fh6/audio_source.hpp
@@ -62,6 +62,11 @@ public:
     // EQ band/enable updates land here. No-op for sources that don't care.
     virtual void set_playback_options(const PlaybackConfig& /*opts*/) {}
 
+    // The game stopped (pause menu, radio off) or resumed draining our station.
+    // Sources wrapping a live external player mirror this onto that player's
+    // transport; pull-based sources need nothing -- they pause by not being read.
+    virtual void on_radio_audible(bool /*audible*/) {}
+
     virtual TrackInfo current_track() const               = 0;
     virtual PlaybackState playback_state() const noexcept = 0;
     virtual AuthState auth_state() const noexcept         = 0;

--- a/include/fh6/config.hpp
+++ b/include/fh6/config.hpp
@@ -54,12 +54,21 @@ struct AudioConfig {
     float output_gain = 1.0f;
 };
 
+struct ExternalAudioConfig {
+    bool enabled = false;
+
+    // Empty = current Windows default playback device. Otherwise a full WASAPI
+    // endpoint id, or a stable user-entered substring used by ExternalAudioSource.
+    std::string endpoint_id;
+};
+
 struct Config {
     GeneralConfig general;
     LocalFilesConfig local_files;
     YouTubeMusicConfig youtube_music;
     AudioConfig audio;
     JellyfinConfig jellyfin;
+    ExternalAudioConfig external_audio;
     PlaybackConfig playback;
 };
 

--- a/include/fh6/config.hpp
+++ b/include/fh6/config.hpp
@@ -64,6 +64,11 @@ struct ExternalAudioConfig {
     // Empty = current Windows default playback device. Otherwise a full WASAPI
     // endpoint id, or a stable user-entered substring used by ExternalAudioSource.
     std::string endpoint_id;
+
+    // Empty = current Windows media session. Otherwise a SourceAppUserModelId
+    // returned by GlobalSystemMediaTransportControls. Used for metadata and
+    // transport commands; audio capture still comes from endpoint_id.
+    std::string media_session_id;
 };
 
 struct Config {

--- a/include/fh6/fmod/dsp_control_loop.hpp
+++ b/include/fh6/fmod/dsp_control_loop.hpp
@@ -15,6 +15,8 @@
 #include <stop_token>
 #include <thread>
 
+namespace fh6 { class IAudioSource; }
+
 namespace fh6::fmod_bridge {
 
 class ControlLoop {
@@ -58,8 +60,10 @@ private:
     GameStateProbe game_state_;
     std::uint64_t prev_calls_ = 0;
     int stale_ticks_          = 0;
-    int idle_ticks_           = 0;     // ticks with no read_callback progress
-    bool radio_audible_       = true;  // last audibility reported to the source
+    int idle_ticks_           = 0;        // ticks with no read_callback progress
+    bool radio_audible_       = true;     // last audibility reported to the source
+    bool audible_primed_      = false;    // active source has been read at least once
+    IAudioSource* audible_source_ = nullptr;  // source the two above track
     time_point last_retune_{};  // last off/on station toggle, for cooldown
 
     // std::atomic<std::shared_ptr<T>> would be ideal here but libc++ in

--- a/include/fh6/fmod/dsp_control_loop.hpp
+++ b/include/fh6/fmod/dsp_control_loop.hpp
@@ -58,6 +58,8 @@ private:
     GameStateProbe game_state_;
     std::uint64_t prev_calls_ = 0;
     int stale_ticks_          = 0;
+    int idle_ticks_           = 0;     // ticks with no read_callback progress
+    bool radio_audible_       = true;  // last audibility reported to the source
     time_point last_retune_{};  // last off/on station toggle, for cooldown
 
     // std::atomic<std::shared_ptr<T>> would be ideal here but libc++ in

--- a/include/fh6/sources/external_audio_source.hpp
+++ b/include/fh6/sources/external_audio_source.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+#include "fh6/audio_source.hpp"
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <string_view>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace fh6::sources {
+
+struct ExternalAudioDevice {
+ std::string id;
+ std::string name;
+ bool is_default = false;
+};
+
+std::vector<ExternalAudioDevice> enumerate_external_audio_devices();
+std::string external_audio_configured_endpoint();
+bool set_external_audio_configured_endpoint(std::string_view endpoint_id);
+
+class ExternalAudioSource final : public IAudioSource {
+public:
+ ExternalAudioSource() = default;
+ ~ExternalAudioSource() override;
+
+ std::string_view name() const noexcept override { return "external_audio"; }
+ std::string_view display_name() const noexcept override { return "External Audio"; }
+
+ bool initialize() override;
+ void shutdown() noexcept override;
+
+ void play() override;
+ void pause() override;
+ void stop() override;
+ void pump(RingBuffer& ring) override;
+ void reload_from_config();
+
+ TrackInfo current_track() const override;
+ PlaybackState playback_state() const noexcept override {
+  return state_.load(std::memory_order_acquire);
+ }
+ AuthState auth_state() const noexcept override;
+ std::string auth_instructions() const override;
+ SourceCapabilities capabilities() const noexcept override { return {}; }
+
+private:
+ void start_worker();
+ void stop_worker() noexcept;
+ void capture_loop() noexcept;
+
+ void append_pcm(const int16_t* data, std::size_t samples);
+ void clear_queue();
+
+ mutable std::mutex meta_mu_;
+ std::string device_name_ = "Default playback device";
+ std::string last_error_;
+
+ std::mutex queue_mu_;
+ std::vector<int16_t> pcm_queue_;
+ std::size_t queue_offset_ = 0;
+
+ std::mutex worker_mu_;
+ std::thread worker_;
+ std::atomic<bool> stop_requested_{false};
+
+ std::atomic<PlaybackState> state_{PlaybackState::stopped};
+ std::atomic<uint64_t> position_ms_{0};
+};
+
+} // namespace fh6::sources

--- a/include/fh6/sources/external_audio_source.hpp
+++ b/include/fh6/sources/external_audio_source.hpp
@@ -39,6 +39,7 @@ public:
  void previous() override;
  bool skip_next() override;
  void pump(RingBuffer& ring) override;
+ void on_radio_audible(bool audible) override;
  void set_config(ExternalAudioConfig cfg);
 
  TrackInfo current_track() const override;
@@ -60,6 +61,7 @@ private:
 
  std::string configured_endpoint() const;
  std::string configured_media_session() const;
+ void set_media_transport(bool play);
 
  mutable std::mutex meta_mu_;
  std::string device_name_ = "Default playback device";
@@ -77,6 +79,7 @@ private:
 
  std::atomic<PlaybackState> state_{PlaybackState::stopped};
  std::atomic<uint64_t> position_ms_{0};
+ std::atomic<bool> media_active_{false};
 };
 
 } // namespace fh6::sources

--- a/include/fh6/sources/external_audio_source.hpp
+++ b/include/fh6/sources/external_audio_source.hpp
@@ -36,6 +36,9 @@ public:
  void play() override;
  void pause() override;
  void stop() override;
+ void next() override;
+ void previous() override;
+ bool skip_next() override;
  void pump(RingBuffer& ring) override;
  void reload_from_config();
 
@@ -45,7 +48,7 @@ public:
  }
  AuthState auth_state() const noexcept override;
  std::string auth_instructions() const override;
- SourceCapabilities capabilities() const noexcept override { return {}; }
+ SourceCapabilities capabilities() const noexcept override { return SourceCapabilities{false, true, false}; }
 
 private:
  void start_worker();

--- a/include/fh6/sources/external_audio_source.hpp
+++ b/include/fh6/sources/external_audio_source.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "fh6/audio_source.hpp"
+#include "fh6/config.hpp"
 
 #include <atomic>
 #include <cstdint>
@@ -19,8 +20,6 @@ struct ExternalAudioDevice {
 };
 
 std::vector<ExternalAudioDevice> enumerate_external_audio_devices();
-std::string external_audio_configured_endpoint();
-bool set_external_audio_configured_endpoint(std::string_view endpoint_id);
 
 class ExternalAudioSource final : public IAudioSource {
 public:
@@ -40,7 +39,7 @@ public:
  void previous() override;
  bool skip_next() override;
  void pump(RingBuffer& ring) override;
- void reload_from_config();
+ void set_config(ExternalAudioConfig cfg);
 
  TrackInfo current_track() const override;
  PlaybackState playback_state() const noexcept override {
@@ -57,10 +56,16 @@ private:
 
  void append_pcm(const int16_t* data, std::size_t samples);
  void clear_queue();
+ void compact_queue_locked();
+
+ std::string configured_endpoint() const;
+ std::string configured_media_session() const;
 
  mutable std::mutex meta_mu_;
  std::string device_name_ = "Default playback device";
  std::string last_error_;
+ std::string endpoint_id_;
+ std::string media_session_id_;
 
  std::mutex queue_mu_;
  std::vector<int16_t> pcm_queue_;

--- a/include/fh6/sources/external_media_session.hpp
+++ b/include/fh6/sources/external_media_session.hpp
@@ -24,5 +24,7 @@ std::optional<TrackInfo> external_audio_media_session_track(std::string_view sel
                                                             uint64_t fallback_position_ms = 0);
 bool external_audio_media_session_next(std::string_view selected_id);
 bool external_audio_media_session_previous(std::string_view selected_id);
+bool external_audio_media_session_pause(std::string_view selected_id);
+bool external_audio_media_session_play(std::string_view selected_id);
 
 } // namespace fh6::sources

--- a/include/fh6/sources/external_media_session.hpp
+++ b/include/fh6/sources/external_media_session.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "fh6/audio_source.hpp"
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace fh6::sources {
+
+struct ExternalAudioMediaSession {
+    std::string id;
+    std::string name;
+    std::string title;
+    std::string artist;
+    bool is_current = false;
+    bool is_selected = false;
+};
+
+bool external_audio_media_sessions_available() noexcept;
+std::vector<ExternalAudioMediaSession>
+enumerate_external_audio_media_sessions(std::string_view selected_id = {});
+
+std::optional<TrackInfo> external_audio_media_session_track(std::string_view selected_id,
+                                                            uint64_t fallback_position_ms = 0);
+bool external_audio_media_session_next(std::string_view selected_id);
+bool external_audio_media_session_previous(std::string_view selected_id);
+
+} // namespace fh6::sources

--- a/include/fh6/sources/external_media_session.hpp
+++ b/include/fh6/sources/external_media_session.hpp
@@ -12,8 +12,6 @@ namespace fh6::sources {
 struct ExternalAudioMediaSession {
     std::string id;
     std::string name;
-    std::string title;
-    std::string artist;
     bool is_current = false;
     bool is_selected = false;
 };

--- a/scripts/dist-readme.txt
+++ b/scripts/dist-readme.txt
@@ -4,7 +4,8 @@ FH6 Universal Radio
 Thanks for grabbing this. It's a free, open-source mod that drops a
 brand new station into Forza Horizon 6's radio dial. You feed it audio
 from a folder of music files on your PC, from any YouTube / YouTube
-Music link, or from a Jellyfin server, and the game treats the result
+Music link, from a Jellyfin server, or from any other Windows app
+(Spotify, Deezer, a browser tab), and the game treats the result
 like every other station: it ducks for menus, follows your in-game
 volume slider, and fades on the loading screen.
 
@@ -79,6 +80,15 @@ From there:
     Configure the server URL, API key, user ID, and playlist ID
     under Settings > Jellyfin. Jellyfin transcodes to PCM via
     ffmpeg, so the configured ffmpeg path must be valid.
+
+  * External audio: capture any Windows playback device and pipe a
+    live app (Spotify, Deezer, a browser tab) into the radio. The capture
+    is a loopback of whatever the device plays, so route the app to a
+    virtual audio cable (e.g. VB-Audio Virtual Cable, set to 48000 Hz)
+    and pick that cable as the capture device, otherwise you hear the
+    app directly instead of through the radio. Track info and
+    next/previous come from the selected Windows media session, and the
+    app pauses and resumes together with the game radio.
 
 A handful of in-game extras live under Settings in the dashboard:
 

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -117,24 +117,23 @@ void run_bridge(HMODULE self) noexcept {
         if (c.youtube_music.enabled && !mgr.find("youtube_music")) {
             auto src = std::make_unique<sources::YouTubeMusicSource>(c.youtube_music,
                                                                      c.general.ffmpeg_path);
-
             if (src->initialize()) mgr.register_source(std::move(src));
         } else if (!c.youtube_music.enabled && mgr.find("youtube_music")) {
             mgr.unregister_source("youtube_music");
         }
-			if (c.jellyfin.enabled && !mgr.find("jellyfin")) {
-			  auto src = std::make_unique<sources::JellyfinSource>(c.jellyfin, c.general.ffmpeg_path);
-			  if (src->initialize()) mgr.register_source(std::move(src));
-			} else if (!c.jellyfin.enabled && mgr.find("jellyfin")) {
-			  mgr.unregister_source("jellyfin");
-			}
+        if (c.jellyfin.enabled && !mgr.find("jellyfin")) {
+            auto src = std::make_unique<sources::JellyfinSource>(c.jellyfin, c.general.ffmpeg_path);
+            if (src->initialize()) mgr.register_source(std::move(src));
+        } else if (!c.jellyfin.enabled && mgr.find("jellyfin")) {
+            mgr.unregister_source("jellyfin");
+        }
 
-            if (c.external_audio.enabled && !mgr.find("external_audio")) {
-                auto src = std::make_unique<sources::ExternalAudioSource>();
-                if (src->initialize()) mgr.register_source(std::move(src));
-            } else if (!c.external_audio.enabled && mgr.find("external_audio")) {
-                mgr.unregister_source("external_audio");
-            }
+        if (c.external_audio.enabled && !mgr.find("external_audio")) {
+            auto src = std::make_unique<sources::ExternalAudioSource>();
+            if (src->initialize()) mgr.register_source(std::move(src));
+        } else if (!c.external_audio.enabled && mgr.find("external_audio")) {
+            mgr.unregister_source("external_audio");
+        }
     };
 
     sync_sources(cfg);

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -129,10 +129,12 @@ void run_bridge(HMODULE self) noexcept {
 			  mgr.unregister_source("jellyfin");
 			}
 
-			if (!mgr.find("external_audio")) {
-			  auto src = std::make_unique<sources::ExternalAudioSource>();
-			  if (src->initialize()) mgr.register_source(std::move(src));
-			}
+            if (c.external_audio.enabled && !mgr.find("external_audio")) {
+                auto src = std::make_unique<sources::ExternalAudioSource>();
+                if (src->initialize()) mgr.register_source(std::move(src));
+            } else if (!c.external_audio.enabled && mgr.find("external_audio")) {
+                mgr.unregister_source("external_audio");
+            }
     };
 
     sync_sources(cfg);

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -10,6 +10,7 @@
 #include "fh6/fmod/pe_image.hpp"
 #include "fh6/http/http_server.hpp"
 #include "fh6/sources/local_file_source.hpp"
+#include "fh6/sources/external_audio_source.hpp"
 #include "fh6/sources/youtube_music_source.hpp"
 #include "fh6/sources/jellyfin_source.hpp"
 
@@ -116,16 +117,22 @@ void run_bridge(HMODULE self) noexcept {
         if (c.youtube_music.enabled && !mgr.find("youtube_music")) {
             auto src = std::make_unique<sources::YouTubeMusicSource>(c.youtube_music,
                                                                      c.general.ffmpeg_path);
+
             if (src->initialize()) mgr.register_source(std::move(src));
         } else if (!c.youtube_music.enabled && mgr.find("youtube_music")) {
             mgr.unregister_source("youtube_music");
         }
-        if (c.jellyfin.enabled && !mgr.find("jellyfin")) {
-            auto src = std::make_unique<sources::JellyfinSource>(c.jellyfin, c.general.ffmpeg_path);
-            if (src->initialize()) mgr.register_source(std::move(src));
-        } else if (!c.jellyfin.enabled && mgr.find("jellyfin")) {
-            mgr.unregister_source("jellyfin");
-        }
+			if (c.jellyfin.enabled && !mgr.find("jellyfin")) {
+			  auto src = std::make_unique<sources::JellyfinSource>(c.jellyfin, c.general.ffmpeg_path);
+			  if (src->initialize()) mgr.register_source(std::move(src));
+			} else if (!c.jellyfin.enabled && mgr.find("jellyfin")) {
+			  mgr.unregister_source("jellyfin");
+			}
+
+			if (!mgr.find("external_audio")) {
+			  auto src = std::make_unique<sources::ExternalAudioSource>();
+			  if (src->initialize()) mgr.register_source(std::move(src));
+			}
     };
 
     sync_sources(cfg);

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -181,6 +181,9 @@ void run_bridge(HMODULE self) noexcept {
             jf->set_ffmpeg_path(c.general.ffmpeg_path);
             jf->set_config(c.jellyfin);
         }
+        if (auto* ext = dynamic_cast<sources::ExternalAudioSource*>(mgr.find("external_audio"))) {
+            ext->reload_from_config();
+        }
 
         for (auto* s : mgr.sources_snapshot()) s->set_playback_options(c.playback);
         if (ctrl_ptr) ctrl_ptr->push_playback_options(c.playback);

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -182,7 +182,7 @@ void run_bridge(HMODULE self) noexcept {
             jf->set_config(c.jellyfin);
         }
         if (auto* ext = dynamic_cast<sources::ExternalAudioSource*>(mgr.find("external_audio"))) {
-            ext->reload_from_config();
+            ext->set_config(c.external_audio);
         }
 
         for (auto* s : mgr.sources_snapshot()) s->set_playback_options(c.playback);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -86,6 +86,11 @@ Config load_config(const std::filesystem::path& path) {
     cfg.jellyfin.default_playlist = pick<std::string>(jf, "default_playlist", cfg.jellyfin.default_playlist);
     cfg.jellyfin.shuffle = pick<bool>(jf, "shuffle", cfg.jellyfin.shuffle);
 
+    const auto& ea = section(root, "external_audio");
+    cfg.external_audio.enabled = pick<bool>(ea, "enabled", cfg.external_audio.enabled);
+    cfg.external_audio.endpoint_id =
+        pick<std::string>(ea, "endpoint_id", cfg.external_audio.endpoint_id);
+
     const auto& au = section(root, "audio");
     cfg.audio.output_gain =
         static_cast<float>(pick<double>(au, "output_gain", cfg.audio.output_gain));
@@ -236,6 +241,10 @@ void save_config(const std::filesystem::path& path, const Config& cfg) {
     e.kv("user_id", cfg.jellyfin.user_id);
     e.kv("default_playlist", cfg.jellyfin.default_playlist);
     e.kv("shuffle", cfg.jellyfin.shuffle);
+
+    e.header("external_audio");
+    e.kv("enabled", cfg.external_audio.enabled);
+    e.kv("endpoint_id", cfg.external_audio.endpoint_id);
 
     e.header("audio");
     e.kv("output_gain", (double)cfg.audio.output_gain);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -91,6 +91,8 @@ Config load_config(const std::filesystem::path& path) {
     cfg.external_audio.enabled = pick<bool>(ea, "enabled", cfg.external_audio.enabled);
     cfg.external_audio.endpoint_id =
         pick<std::string>(ea, "endpoint_id", cfg.external_audio.endpoint_id);
+    cfg.external_audio.media_session_id =
+        pick<std::string>(ea, "media_session_id", cfg.external_audio.media_session_id);
 
     const auto& au = section(root, "audio");
     cfg.audio.output_gain =
@@ -249,6 +251,7 @@ void save_config(const std::filesystem::path& path, const Config& cfg) {
     e.header("external_audio");
     e.kv("enabled", cfg.external_audio.enabled);
     e.kv("endpoint_id", cfg.external_audio.endpoint_id);
+    e.kv("media_session_id", cfg.external_audio.media_session_id);
 
     e.header("audio");
     e.kv("output_gain", (double)cfg.audio.output_gain);

--- a/src/fmod/dsp_control_loop.cpp
+++ b/src/fmod/dsp_control_loop.cpp
@@ -20,6 +20,11 @@ constexpr int kDiscoveryTries  = 120; // 10-minute budget; the radio system
 // before we conclude the game tore the radio channel down. 1s @ 20ms.
 constexpr int kStaleTickThreshold = 50;
 
+// Shorter freeze, ~160 ms @ 20ms, before we treat the station as silenced
+// (pause menu, radio off) and tell the active source so it can mirror the
+// state onto any live external player it wraps.
+constexpr int kInaudibleTicks = 8;
+
 // Minimum gap between two off/on station toggles. The toggle blocks ~300ms
 // and the game needs a moment to reallocate the channel, so we leave it well
 // alone in between rather than thrashing the radio.
@@ -109,6 +114,20 @@ void ControlLoop::run(const std::stop_token& tok) {
             }
         } else {
             stale_ticks_ = 0;
+        }
+
+        // Audibility edge: while a source is producing, no read_callback
+        // progress means the game silenced our station. Report the transition
+        // so sources wrapping a live player (External Audio) pause/resume it.
+        if (active && busy) {
+            idle_ticks_        = (c == prev_calls_) ? idle_ticks_ + 1 : 0;
+            const bool audible = idle_ticks_ < kInaudibleTicks;
+            if (audible != radio_audible_) {
+                radio_audible_ = audible;
+                active->on_radio_audible(audible);
+            }
+        } else {
+            idle_ticks_ = 0;
         }
 
         run_playback_state_machines(std::chrono::steady_clock::now());

--- a/src/fmod/dsp_control_loop.cpp
+++ b/src/fmod/dsp_control_loop.cpp
@@ -20,10 +20,12 @@ constexpr int kDiscoveryTries  = 120; // 10-minute budget; the radio system
 // before we conclude the game tore the radio channel down. 1s @ 20ms.
 constexpr int kStaleTickThreshold = 50;
 
-// Shorter freeze, ~160 ms @ 20ms, before we treat the station as silenced
-// (pause menu, radio off) and tell the active source so it can mirror the
-// state onto any live external player it wraps.
-constexpr int kInaudibleTicks = 8;
+// Frozen-read ticks before we treat the station as genuinely silenced (pause
+// menu, radio off) and tell the active source to mirror it onto any live
+// player it wraps. Must clear the stall-retune rebuild window (~1s retune +
+// up to ~2s reacquire), so a rewind or race transition that briefly tears the
+// channel down and rebuilds it doesn't read as a pause. 3.5s @ 20ms.
+constexpr int kInaudibleTicks = 175;
 
 // Minimum gap between two off/on station toggles. The toggle blocks ~300ms
 // and the game needs a moment to reallocate the channel, so we leave it well
@@ -83,9 +85,13 @@ void ControlLoop::run(const std::stop_token& tok) {
         bridge_.retarget_if_needed();
         bridge_.manager().pump_once();
 
+        // Skip refreshing while the station is silenced (pause menu, rewind):
+        // the HUD isn't shown, and freezing the value lets the dedup in
+        // MetadataInjector swallow the resume so the game doesn't re-pop its
+        // now-playing banner on every pause/rewind.
         if (++meta_tick >= kMetaEveryNTicks) {
             meta_tick = 0;
-            push_metadata();
+            if (radio_audible_) push_metadata();
         }
 
         // Staleness watchdog: while a source is actively producing audio,
@@ -116,18 +122,37 @@ void ControlLoop::run(const std::stop_token& tok) {
             stale_ticks_ = 0;
         }
 
-        // Audibility edge: while a source is producing, no read_callback
-        // progress means the game silenced our station. Report the transition
-        // so sources wrapping a live player (External Audio) pause/resume it.
+        // Audibility edge: while a source is producing, a frozen read_callback
+        // means the game silenced our station. Report the transition so a
+        // source wrapping a live player (External Audio) pauses/resumes it.
+        // Re-arm on every source change and only count once that source has
+        // actually been read, so stale loop state can't fire a phantom edge.
+        // The threshold sits above the stall-retune rebuild window, so the
+        // channel churn from a rewind or race transition (which the watchdog
+        // above heals) never trips it; only sustained silence does.
         if (active && busy) {
-            idle_ticks_        = (c == prev_calls_) ? idle_ticks_ + 1 : 0;
+            if (active != audible_source_) {
+                audible_source_ = active;
+                idle_ticks_     = 0;
+                audible_primed_ = false;
+                radio_audible_  = true;
+            }
+            if (c != prev_calls_) {
+                idle_ticks_     = 0;
+                audible_primed_ = true;
+            } else if (audible_primed_) {
+                ++idle_ticks_;
+            }
             const bool audible = idle_ticks_ < kInaudibleTicks;
             if (audible != radio_audible_) {
                 radio_audible_ = audible;
                 active->on_radio_audible(audible);
             }
         } else {
-            idle_ticks_ = 0;
+            idle_ticks_     = 0;
+            audible_primed_ = false;
+            radio_audible_  = true;
+            audible_source_ = nullptr;
         }
 
         run_playback_state_machines(std::chrono::steady_clock::now());

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -135,6 +135,11 @@ json config_to_json(const Config& c) {
              {"default_playlist", c.jellyfin.default_playlist},
              {"shuffle", c.jellyfin.shuffle},
          }},
+        {"external_audio",
+         json{
+             {"enabled", c.external_audio.enabled},
+             {"endpoint_id", c.external_audio.endpoint_id},
+         }},
         {"audio",
          json{
              {"output_gain", c.audio.output_gain},
@@ -195,6 +200,11 @@ void apply_patch(Config& c, const json& j) {
         c.jellyfin.user_id          = pull(*it, "user_id", c.jellyfin.user_id);
         c.jellyfin.default_playlist = pull(*it, "default_playlist", c.jellyfin.default_playlist);
         c.jellyfin.shuffle          = pull(*it, "shuffle", c.jellyfin.shuffle);
+    }
+    if (auto it = j.find("external_audio"); it != j.end()) {
+        c.external_audio.enabled = pull(*it, "enabled", c.external_audio.enabled);
+        c.external_audio.endpoint_id =
+            pull(*it, "endpoint_id", c.external_audio.endpoint_id);
     }
     if (auto it = j.find("audio"); it != j.end()) {
         c.audio.output_gain = pull(*it, "output_gain", c.audio.output_gain);
@@ -501,6 +511,37 @@ struct HttpServer::Impl {
             auto src = json::parse(req.body).at("source").get<std::string>();
             return mgr.switch_to(src) ? ok() : fail(404, "unknown source");
         }
+        if (m == "GET" && p == "/api/external_audio/devices") {
+            json devices = json::array();
+            for (const auto& d : sources::enumerate_external_audio_devices()) {
+                devices.push_back(json{
+                    {"id", d.id},
+                    {"name", d.name},
+                    {"is_default", d.is_default},
+                });
+            }
+            auto snap = store.snapshot();
+            return ok(json{
+                {"enabled", snap.external_audio.enabled},
+                {"endpoint_id", snap.external_audio.endpoint_id},
+                {"devices", devices},
+            });
+        }
+        if (m == "PUT" && p == "/api/external_audio/config") {
+            auto body = req.body.empty() ? json::object() : json::parse(req.body);
+            const auto endpoint = body.value("endpoint_id", std::string{});
+            const auto enabled = body.value("enabled", store.snapshot().external_audio.enabled);
+            store.patch([&](Config& c) {
+                c.external_audio.enabled = enabled;
+                c.external_audio.endpoint_id = endpoint;
+            });
+            if (auto* ext = find_typed<sources::ExternalAudioSource>("external_audio")) {
+                ext->reload_from_config();
+            }
+            auto snap = store.snapshot();
+            return ok(json{{"enabled", snap.external_audio.enabled},
+                           {"endpoint_id", snap.external_audio.endpoint_id}});
+        }
         if (m == "POST" && p == "/api/source/youtube_music/cast") {
             auto* yt = find_typed<sources::YouTubeMusicSource>("youtube_music");
             if (!yt) return fail(404, "youtube_music not registered");
@@ -508,26 +549,6 @@ struct HttpServer::Impl {
             const bool was_active = (mgr.active() == yt);
             yt->set_target(std::move(url));
             yt->stop();
-    if (m == "GET" && p == "/api/external_audio/devices") {
-      json devices = json::array();
-      for (const auto& d : sources::enumerate_external_audio_devices()) {
-        devices.push_back(json{{"id", d.id}, {"name", d.name}, {"is_default", d.is_default}});
-      }
-      return ok(json{{"endpoint_id", sources::external_audio_configured_endpoint()}, {"devices", devices}});
-    }
-
-    if (m == "PUT" && p == "/api/external_audio/config") {
-      auto body = req.body.empty() ? json{} : json::parse(req.body);
-      const auto endpoint = body.value("endpoint_id", std::string{});
-      if (!sources::set_external_audio_configured_endpoint(endpoint)) {
-        return fail(500, "failed to save external_audio config");
-      }
-      if (auto* ext = find_typed<sources::ExternalAudioSource>("external_audio")) {
-        ext->reload_from_config();
-      }
-      return ok(json{{"endpoint_id", sources::external_audio_configured_endpoint()}});
-    }
-
             if (was_active) mgr.ring().drain();
             yt->play();
             mgr.switch_to("youtube_music");

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -6,6 +6,7 @@
 #include "fh6/sources/local_file_source.hpp"
 #include "fh6/sources/youtube_music_source.hpp"
 #include "fh6/sources/jellyfin_source.hpp"
+#include "fh6/sources/external_audio_source.hpp"
 
 #include <nlohmann/json.hpp>
 
@@ -455,7 +456,7 @@ struct HttpServer::Impl {
         Request req;
         if (!read_request(client, req)) return;
 
-        auto ok = [&](const json& j = json::object()) {
+        auto ok = [&](json j = {}) {
             std::string body = j.empty()
                                    ? std::string{R"({"ok":true})"}
                                    : j.dump(-1, ' ', false, json::error_handler_t::replace);
@@ -507,6 +508,26 @@ struct HttpServer::Impl {
             const bool was_active = (mgr.active() == yt);
             yt->set_target(std::move(url));
             yt->stop();
+    if (m == "GET" && p == "/api/external_audio/devices") {
+      json devices = json::array();
+      for (const auto& d : sources::enumerate_external_audio_devices()) {
+        devices.push_back(json{{"id", d.id}, {"name", d.name}, {"is_default", d.is_default}});
+      }
+      return ok(json{{"endpoint_id", sources::external_audio_configured_endpoint()}, {"devices", devices}});
+    }
+
+    if (m == "PUT" && p == "/api/external_audio/config") {
+      auto body = req.body.empty() ? json{} : json::parse(req.body);
+      const auto endpoint = body.value("endpoint_id", std::string{});
+      if (!sources::set_external_audio_configured_endpoint(endpoint)) {
+        return fail(500, "failed to save external_audio config");
+      }
+      if (auto* ext = find_typed<sources::ExternalAudioSource>("external_audio")) {
+        ext->reload_from_config();
+      }
+      return ok(json{{"endpoint_id", sources::external_audio_configured_endpoint()}});
+    }
+
             if (was_active) mgr.ring().drain();
             yt->play();
             mgr.switch_to("youtube_music");

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -536,8 +536,6 @@ struct HttpServer::Impl {
                 sessions.push_back(json{
                     {"id", session.id},
                     {"name", session.name},
-                    {"title", session.title},
-                    {"artist", session.artist},
                     {"is_current", session.is_current},
                     {"is_selected", session.is_selected},
                 });

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -7,6 +7,7 @@
 #include "fh6/sources/youtube_music_source.hpp"
 #include "fh6/sources/jellyfin_source.hpp"
 #include "fh6/sources/external_audio_source.hpp"
+#include "fh6/sources/external_media_session.hpp"
 
 #include <nlohmann/json.hpp>
 
@@ -140,6 +141,7 @@ json config_to_json(const Config& c) {
          json{
              {"enabled", c.external_audio.enabled},
              {"endpoint_id", c.external_audio.endpoint_id},
+             {"media_session_id", c.external_audio.media_session_id},
          }},
         {"audio",
          json{
@@ -208,6 +210,8 @@ void apply_patch(Config& c, const json& j) {
         c.external_audio.enabled = pull(*it, "enabled", c.external_audio.enabled);
         c.external_audio.endpoint_id =
             pull(*it, "endpoint_id", c.external_audio.endpoint_id);
+        c.external_audio.media_session_id =
+            pull(*it, "media_session_id", c.external_audio.media_session_id);
     }
     if (auto it = j.find("audio"); it != j.end()) {
         c.audio.output_gain = pull(*it, "output_gain", c.audio.output_gain);
@@ -526,26 +530,46 @@ struct HttpServer::Impl {
                 });
             }
             auto snap = store.snapshot();
+            json sessions = json::array();
+            for (const auto& session : sources::enumerate_external_audio_media_sessions(
+                     snap.external_audio.media_session_id)) {
+                sessions.push_back(json{
+                    {"id", session.id},
+                    {"name", session.name},
+                    {"title", session.title},
+                    {"artist", session.artist},
+                    {"is_current", session.is_current},
+                    {"is_selected", session.is_selected},
+                });
+            }
             return ok(json{
                 {"enabled", snap.external_audio.enabled},
                 {"endpoint_id", snap.external_audio.endpoint_id},
+                {"media_session_id", snap.external_audio.media_session_id},
+                {"media_sessions_available", sources::external_audio_media_sessions_available()},
+                {"media_sessions", sessions},
                 {"devices", devices},
             });
         }
         if (m == "PUT" && p == "/api/external_audio/config") {
             auto body = req.body.empty() ? json::object() : json::parse(req.body);
-            const auto endpoint = body.value("endpoint_id", std::string{});
-            const auto enabled = body.value("enabled", store.snapshot().external_audio.enabled);
+            auto snap_before = store.snapshot();
+            const auto endpoint = body.value("endpoint_id", snap_before.external_audio.endpoint_id);
+            const auto media_session_id =
+                body.value("media_session_id", snap_before.external_audio.media_session_id);
+            const auto enabled = body.value("enabled", snap_before.external_audio.enabled);
             store.patch([&](Config& c) {
                 c.external_audio.enabled = enabled;
                 c.external_audio.endpoint_id = endpoint;
+                c.external_audio.media_session_id = media_session_id;
             });
             if (auto* ext = find_typed<sources::ExternalAudioSource>("external_audio")) {
                 ext->reload_from_config();
             }
             auto snap = store.snapshot();
             return ok(json{{"enabled", snap.external_audio.enabled},
-                           {"endpoint_id", snap.external_audio.endpoint_id}});
+                           {"endpoint_id", snap.external_audio.endpoint_id},
+                           {"media_session_id", snap.external_audio.media_session_id}});
         }
         if (m == "POST" && p == "/api/source/youtube_music/cast") {
             auto* yt = find_typed<sources::YouTubeMusicSource>("youtube_music");

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -556,14 +556,13 @@ struct HttpServer::Impl {
             const auto media_session_id =
                 body.value("media_session_id", snap_before.external_audio.media_session_id);
             const auto enabled = body.value("enabled", snap_before.external_audio.enabled);
+            // store.patch() notifies the bridge observer synchronously, which
+            // (un)registers the source and pushes the new config via set_config.
             store.patch([&](Config& c) {
                 c.external_audio.enabled = enabled;
                 c.external_audio.endpoint_id = endpoint;
                 c.external_audio.media_session_id = media_session_id;
             });
-            if (auto* ext = find_typed<sources::ExternalAudioSource>("external_audio")) {
-                ext->reload_from_config();
-            }
             auto snap = store.snapshot();
             return ok(json{{"enabled", snap.external_audio.enabled},
                            {"endpoint_id", snap.external_audio.endpoint_id},

--- a/src/sources/external_audio_source.cpp
+++ b/src/sources/external_audio_source.cpp
@@ -511,7 +511,13 @@ bool set_external_audio_configured_endpoint(std::string_view endpoint_id_value) 
  std::string line;
  bool in_external = false;
  bool saw_external = false;
+ bool wrote_enabled = false;
  bool wrote_endpoint = false;
+
+ auto write_enabled_default = [&] {
+  out << "enabled = false\n";
+  wrote_enabled = true;
+ };
 
  auto write_endpoint = [&] {
   out << "endpoint_id = " << toml_quote(endpoint_id_value) << "\n";
@@ -526,8 +532,13 @@ bool set_external_audio_configured_endpoint(std::string_view endpoint_id_value) 
   trimmed = first == std::string::npos ? std::string{} : trimmed.substr(first, last - first + 1);
 
   if (trimmed.size() >= 3 && trimmed.front() == '[' && trimmed.back() == ']') {
-   if (in_external && !wrote_endpoint) write_endpoint();
+   if (in_external) {
+    if (!wrote_enabled) write_enabled_default();
+    if (!wrote_endpoint) write_endpoint();
+   }
    in_external = (trimmed == "[external_audio]");
+   wrote_enabled = false;
+   wrote_endpoint = false;
    if (in_external) saw_external = true;
    out << line << "\n";
    continue;
@@ -537,6 +548,9 @@ bool set_external_audio_configured_endpoint(std::string_view endpoint_id_value) 
    auto eq = trimmed.find('=');
    auto key = eq == std::string::npos ? trimmed : trimmed.substr(0, eq);
    key.erase(std::remove_if(key.begin(), key.end(), [](unsigned char c) { return std::isspace(c); }), key.end());
+   if (key == "enabled") {
+    wrote_enabled = true;
+   }
    if (key == "endpoint_id") {
     write_endpoint();
     continue;
@@ -546,10 +560,14 @@ bool set_external_audio_configured_endpoint(std::string_view endpoint_id_value) 
   out << line << "\n";
  }
 
- if (saw_external && in_external && !wrote_endpoint) write_endpoint();
+ if (saw_external && in_external) {
+  if (!wrote_enabled) write_enabled_default();
+  if (!wrote_endpoint) write_endpoint();
+ }
  if (!saw_external) {
   if (!content.empty() && content.back() != '\n') out << "\n";
   out << "\n[external_audio]\n";
+  write_enabled_default();
   write_endpoint();
  }
 

--- a/src/sources/external_audio_source.cpp
+++ b/src/sources/external_audio_source.cpp
@@ -509,27 +509,39 @@ void ExternalAudioSource::shutdown() noexcept {
 }
 
 void ExternalAudioSource::play() {
- // Source lifecycle only: selecting or resuming External Audio must not
- // send Play to the user's external media application. Metadata and explicit
- // next/previous actions are handled through the selected media session, but
- // play/pause here only control whether this source feeds captured PCM to FH6.
  state_.store(PlaybackState::playing, std::memory_order_release);
  start_worker();
+ set_media_transport(true);
 }
 
 void ExternalAudioSource::pause() {
- // Source lifecycle only: do not pause the selected Windows media session when
- // the user switches away from External Audio or the source manager pauses us.
  state_.store(PlaybackState::paused, std::memory_order_release);
+ set_media_transport(false);
  stop_worker();
  clear_queue();
 }
 
 void ExternalAudioSource::stop() {
  state_.store(PlaybackState::stopped, std::memory_order_release);
+ set_media_transport(false);
  stop_worker();
  clear_queue();
  position_ms_.store(0, std::memory_order_release);
+}
+
+// The game drains our station only while it's audible; when it stops (pause
+// menu, radio off) the control loop reports it here so the live external player
+// pauses in step instead of running on, then resumes when audio flows again.
+void ExternalAudioSource::on_radio_audible(bool audible) {
+ if (state_.load(std::memory_order_acquire) != PlaybackState::playing) return;
+ set_media_transport(audible);
+}
+
+void ExternalAudioSource::set_media_transport(bool play) {
+ if (media_active_.exchange(play) == play) return;
+ const auto session = configured_media_session();
+ if (play) external_audio_media_session_play(session);
+ else      external_audio_media_session_pause(session);
 }
 
 void ExternalAudioSource::next() {

--- a/src/sources/external_audio_source.cpp
+++ b/src/sources/external_audio_source.cpp
@@ -1,0 +1,856 @@
+#include "fh6/sources/external_audio_source.hpp"
+
+#include "fh6/log.hpp"
+#include "fh6/ring_buffer.hpp"
+
+#include <windows.h>
+#include <audioclient.h>
+#include <ksmedia.h>
+#include <mmdeviceapi.h>
+#include <propidl.h>
+#include <propsys.h>
+#include <propkeydef.h>
+#include <functiondiscoverykeys_devpkey.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <cwctype>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <sstream>
+#include <optional>
+#include <string_view>
+
+namespace fh6::sources {
+namespace {
+
+constexpr uint32_t kTargetSampleRate = 48000;
+constexpr uint32_t kTargetChannels = 2;
+constexpr std::size_t kMaxQueuedSamples = kTargetSampleRate * kTargetChannels * 2;
+
+template <class T> class ComPtr {
+public:
+ ComPtr() = default;
+ ComPtr(const ComPtr&) = delete;
+ ComPtr& operator=(const ComPtr&) = delete;
+ ComPtr(ComPtr&& other) noexcept : p_{other.p_} { other.p_ = nullptr; }
+ ComPtr& operator=(ComPtr&& other) noexcept {
+  if (this != &other) {
+   reset();
+   p_ = other.p_;
+   other.p_ = nullptr;
+  }
+  return *this;
+ }
+ ~ComPtr() { reset(); }
+
+ T* get() const noexcept { return p_; }
+ T** put() noexcept {
+  reset();
+  return &p_;
+ }
+ T* operator->() const noexcept { return p_; }
+ explicit operator bool() const noexcept { return p_ != nullptr; }
+
+ void reset(T* p = nullptr) noexcept {
+  if (p_) p_->Release();
+  p_ = p;
+ }
+
+private:
+ T* p_ = nullptr;
+};
+
+struct CoTaskMemWaveFormat {
+ WAVEFORMATEX* p = nullptr;
+ ~CoTaskMemWaveFormat() {
+  if (p) CoTaskMemFree(p);
+ }
+ WAVEFORMATEX** put() {
+  if (p) {
+   CoTaskMemFree(p);
+   p = nullptr;
+  }
+  return &p;
+ }
+};
+
+struct CoTaskMemString {
+ wchar_t* p = nullptr;
+ ~CoTaskMemString() {
+  if (p) CoTaskMemFree(p);
+ }
+ wchar_t** put() {
+  if (p) {
+   CoTaskMemFree(p);
+   p = nullptr;
+  }
+  return &p;
+ }
+};
+
+std::string hresult_string(const char* where, HRESULT hr) {
+ char buf[160];
+ std::snprintf(buf, sizeof(buf), "%s failed: HRESULT 0x%08lX", where,
+  static_cast<unsigned long>(static_cast<uint32_t>(hr)));
+ return buf;
+}
+
+std::wstring utf8_to_wide(std::string_view s) {
+ if (s.empty()) return {};
+ int n = MultiByteToWideChar(CP_UTF8, 0, s.data(), static_cast<int>(s.size()), nullptr, 0);
+ if (n <= 0) return {};
+ std::wstring out(static_cast<std::size_t>(n), L'\0');
+ MultiByteToWideChar(CP_UTF8, 0, s.data(), static_cast<int>(s.size()), out.data(), n);
+ return out;
+}
+
+std::string wide_to_utf8(const wchar_t* s) {
+ if (!s || !*s) return {};
+ int n = WideCharToMultiByte(CP_UTF8, 0, s, -1, nullptr, 0, nullptr, nullptr);
+ if (n <= 1) return {};
+ std::string out(static_cast<std::size_t>(n - 1), '\0');
+ WideCharToMultiByte(CP_UTF8, 0, s, -1, out.data(), n, nullptr, nullptr);
+ return out;
+}
+
+std::wstring lower_copy(std::wstring s) {
+ std::transform(s.begin(), s.end(), s.begin(), [](wchar_t c) {
+  return static_cast<wchar_t>(std::towlower(c));
+ });
+ return s;
+}
+
+std::string friendly_name(IMMDevice* device) {
+ if (!device) return {};
+ ComPtr<IPropertyStore> props;
+ HRESULT hr = device->OpenPropertyStore(STGM_READ, props.put());
+ if (FAILED(hr) || !props) return {};
+
+ PROPVARIANT v;
+ PropVariantInit(&v);
+ std::string out;
+ if (SUCCEEDED(props->GetValue(PKEY_Device_FriendlyName, &v)) && v.vt == VT_LPWSTR) {
+  out = wide_to_utf8(v.pwszVal);
+ }
+ PropVariantClear(&v);
+ return out;
+}
+
+std::string endpoint_id(IMMDevice* device) {
+ if (!device) return {};
+ CoTaskMemString id;
+ if (FAILED(device->GetId(id.put())) || !id.p) return {};
+ return wide_to_utf8(id.p);
+}
+
+std::filesystem::path config_path() {
+ wchar_t buf[MAX_PATH];
+ DWORD n = GetModuleFileNameW(nullptr, buf, MAX_PATH);
+ if (n == 0 || n >= MAX_PATH) return {};
+ return std::filesystem::path{buf}.parent_path() / "fh6-radio" / "config.toml";
+}
+
+std::optional<std::string> parse_endpoint_id_from_config() {
+ std::ifstream in{config_path(), std::ios::binary};
+ if (!in) return std::nullopt;
+
+ bool in_external = false;
+ std::string line;
+ while (std::getline(in, line)) {
+  auto comment = line.find('#');
+  if (comment != std::string::npos) line.resize(comment);
+
+  auto first = line.find_first_not_of(" \t\r\n");
+  if (first == std::string::npos) continue;
+  auto last = line.find_last_not_of(" \t\r\n");
+  line = line.substr(first, last - first + 1);
+
+  if (line.size() >= 3 && line.front() == '[' && line.back() == ']') {
+   in_external = (line == "[external_audio]");
+   continue;
+  }
+
+  if (!in_external) continue;
+  auto eq = line.find('=');
+  if (eq == std::string::npos) continue;
+  auto key = line.substr(0, eq);
+  key.erase(std::remove_if(key.begin(), key.end(), [](unsigned char c) { return std::isspace(c); }), key.end());
+  if (key != "endpoint_id") continue;
+
+  auto value = line.substr(eq + 1);
+  auto a = value.find_first_not_of(" \t\r\n");
+  auto b = value.find_last_not_of(" \t\r\n");
+  if (a == std::string::npos) return std::string{};
+  value = value.substr(a, b - a + 1);
+  if (value.size() >= 2 && ((value.front() == '\'' && value.back() == '\'') ||
+   (value.front() == '"' && value.back() == '"'))) {
+   value = value.substr(1, value.size() - 2);
+  }
+  return value;
+ }
+
+ return std::nullopt;
+}
+
+float clamp_sample(float v) noexcept {
+ if (!std::isfinite(v)) return 0.0f;
+ return std::clamp(v, -1.0f, 1.0f);
+}
+
+int16_t float_to_s16(float v) noexcept {
+ v = clamp_sample(v);
+ if (v >= 0.9999695f) return std::numeric_limits<int16_t>::max();
+ if (v <= -1.0f) return std::numeric_limits<int16_t>::min();
+ return static_cast<int16_t>(std::lrintf(v * 32767.0f));
+}
+
+int32_t read_i24_le(const BYTE* p) noexcept {
+ int32_t v = static_cast<int32_t>(p[0]) |
+  (static_cast<int32_t>(p[1]) << 8) |
+  (static_cast<int32_t>(p[2]) << 16);
+ if (v & 0x00800000) v |= 0xFF000000;
+ return v;
+}
+
+float sample_to_float(const BYTE* p, WORD bits, bool is_float) noexcept {
+ if (is_float) {
+  if (bits == 32) {
+   float v;
+   std::memcpy(&v, p, sizeof(v));
+   return clamp_sample(v);
+  }
+  if (bits == 64) {
+   double v;
+   std::memcpy(&v, p, sizeof(v));
+   return clamp_sample(static_cast<float>(v));
+  }
+  return 0.0f;
+ }
+
+ switch (bits) {
+ case 8:
+  return (static_cast<int>(*p) - 128) / 128.0f;
+ case 16: {
+  int16_t v;
+  std::memcpy(&v, p, sizeof(v));
+  return static_cast<float>(v) / 32768.0f;
+ }
+ case 24:
+  return static_cast<float>(read_i24_le(p)) / 8388608.0f;
+ case 32: {
+  int32_t v;
+  std::memcpy(&v, p, sizeof(v));
+  return static_cast<float>(v) / 2147483648.0f;
+ }
+ default:
+  return 0.0f;
+ }
+}
+
+struct InputFormat {
+ uint32_t sample_rate = 0;
+ uint16_t channels = 0;
+ uint16_t bits = 0;
+ uint16_t block_align = 0;
+ bool is_float = false;
+};
+
+bool parse_input_format(const WAVEFORMATEX& fmt, InputFormat& out, std::string& error) {
+ out.sample_rate = fmt.nSamplesPerSec;
+ out.channels = fmt.nChannels;
+ out.bits = fmt.wBitsPerSample;
+ out.block_align = fmt.nBlockAlign;
+
+ if (out.sample_rate == 0 || out.channels == 0 || out.block_align == 0) {
+  error = "Invalid WASAPI mix format";
+  return false;
+ }
+
+ if (fmt.wFormatTag == WAVE_FORMAT_IEEE_FLOAT) {
+  out.is_float = true;
+  return true;
+ }
+
+ if (fmt.wFormatTag == WAVE_FORMAT_PCM) {
+  out.is_float = false;
+  return true;
+ }
+
+ if (fmt.wFormatTag == WAVE_FORMAT_EXTENSIBLE &&
+  fmt.cbSize >= (sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX))) {
+  const auto& ext = reinterpret_cast<const WAVEFORMATEXTENSIBLE&>(fmt);
+  out.bits = ext.Format.wBitsPerSample;
+  out.block_align = ext.Format.nBlockAlign;
+  if (IsEqualGUID(ext.SubFormat, KSDATAFORMAT_SUBTYPE_IEEE_FLOAT)) {
+   out.is_float = true;
+   return true;
+  }
+  if (IsEqualGUID(ext.SubFormat, KSDATAFORMAT_SUBTYPE_PCM)) {
+   out.is_float = false;
+   return true;
+  }
+ }
+
+ error = "Unsupported WASAPI mix format";
+ return false;
+}
+
+struct Resampler {
+ InputFormat fmt;
+ bool have_prev = false;
+ float prev_l = 0.0f;
+ float prev_r = 0.0f;
+ double pos = 0.0;
+ std::vector<float> in;
+ std::vector<int16_t> out;
+
+ void reset() noexcept {
+  have_prev = false;
+  prev_l = 0.0f;
+  prev_r = 0.0f;
+  pos = 0.0;
+ }
+
+ void push_packet(const BYTE* data, UINT32 frame_count, DWORD flags) {
+  if (flags & AUDCLNT_BUFFERFLAGS_DATA_DISCONTINUITY) reset();
+
+  in.clear();
+  in.reserve((static_cast<std::size_t>(frame_count) + (have_prev ? 1u : 0u)) * 2u);
+
+  if (have_prev) {
+   in.push_back(prev_l);
+   in.push_back(prev_r);
+  }
+
+  const bool silent = (flags & AUDCLNT_BUFFERFLAGS_SILENT) != 0;
+  const uint16_t bytes_per_sample = static_cast<uint16_t>((fmt.bits + 7u) / 8u);
+
+  for (UINT32 f = 0; f < frame_count; ++f) {
+   float l = 0.0f;
+   float r = 0.0f;
+
+   if (!silent && data) {
+    const BYTE* frame = data + static_cast<std::size_t>(f) * fmt.block_align;
+    l = sample_to_float(frame, fmt.bits, fmt.is_float);
+    if (fmt.channels == 1) {
+     r = l;
+    } else {
+     r = sample_to_float(frame + bytes_per_sample, fmt.bits, fmt.is_float);
+    }
+   }
+
+   in.push_back(l);
+   in.push_back(r);
+  }
+
+  const std::size_t frames = in.size() / 2u;
+  if (frames == 0) return;
+
+  prev_l = in[(frames - 1u) * 2u + 0u];
+  prev_r = in[(frames - 1u) * 2u + 1u];
+  have_prev = true;
+
+  if (frames < 2) return;
+
+  const double step = static_cast<double>(fmt.sample_rate) / static_cast<double>(kTargetSampleRate);
+
+  while (pos + 1.0 < static_cast<double>(frames)) {
+   const auto i = static_cast<std::size_t>(pos);
+   const float a = static_cast<float>(pos - static_cast<double>(i));
+
+   const float l0 = in[i * 2u + 0u];
+   const float r0 = in[i * 2u + 1u];
+   const float l1 = in[(i + 1u) * 2u + 0u];
+   const float r1 = in[(i + 1u) * 2u + 1u];
+
+   out.push_back(float_to_s16(l0 + (l1 - l0) * a));
+   out.push_back(float_to_s16(r0 + (r1 - r0) * a));
+
+   pos += step;
+  }
+
+  pos -= static_cast<double>(frames - 1u);
+ }
+};
+
+HRESULT get_configured_endpoint(IMMDeviceEnumerator* enumerator, IMMDevice** out_device) {
+ const auto endpoint = parse_endpoint_id_from_config().value_or(std::string{});
+ if (endpoint.empty()) {
+  return enumerator->GetDefaultAudioEndpoint(eRender, eConsole, out_device);
+ }
+
+ const auto wanted = utf8_to_wide(endpoint);
+ HRESULT hr = enumerator->GetDevice(wanted.c_str(), out_device);
+ if (SUCCEEDED(hr)) return hr;
+
+ ComPtr<IMMDeviceCollection> devices;
+ hr = enumerator->EnumAudioEndpoints(eRender, DEVICE_STATE_ACTIVE, devices.put());
+ if (FAILED(hr) || !devices) return hr;
+
+ UINT count = 0;
+ if (FAILED(devices->GetCount(&count))) return E_NOTFOUND;
+
+ const auto wanted_l = lower_copy(wanted);
+ for (UINT i = 0; i < count; ++i) {
+  ComPtr<IMMDevice> dev;
+  if (FAILED(devices->Item(i, dev.put())) || !dev) continue;
+
+  const auto name_l = lower_copy(utf8_to_wide(friendly_name(dev.get())));
+  const auto id_l = lower_copy(utf8_to_wide(endpoint_id(dev.get())));
+  if ((!name_l.empty() && name_l.find(wanted_l) != std::wstring::npos) ||
+   (!id_l.empty() && id_l.find(wanted_l) != std::wstring::npos)) {
+   *out_device = dev.get();
+   (*out_device)->AddRef();
+   return S_OK;
+  }
+ }
+
+ return E_NOTFOUND;
+}
+
+} // namespace
+
+std::string toml_quote(std::string_view s) {
+ std::string out;
+ out.reserve(s.size() + 2);
+ out.push_back('"');
+ for (char c : s) {
+  if (c == '\\' || c == '"') out.push_back('\\');
+  out.push_back(c);
+ }
+ out.push_back('"');
+ return out;
+}
+
+std::vector<ExternalAudioDevice> enumerate_external_audio_devices() {
+ std::vector<ExternalAudioDevice> out;
+
+ HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+ const bool co_initialized = SUCCEEDED(hr);
+ if (FAILED(hr) && hr != RPC_E_CHANGED_MODE) return out;
+
+ auto co_uninit = [&] {
+  if (co_initialized) CoUninitialize();
+ };
+
+ ComPtr<IMMDeviceEnumerator> enumerator;
+ hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL,
+  IID_PPV_ARGS(enumerator.put()));
+ if (FAILED(hr) || !enumerator) {
+  co_uninit();
+  return out;
+ }
+
+ std::string default_id;
+ {
+  ComPtr<IMMDevice> def;
+  if (SUCCEEDED(enumerator->GetDefaultAudioEndpoint(eRender, eConsole, def.put())) && def) {
+   default_id = endpoint_id(def.get());
+  }
+ }
+
+ ComPtr<IMMDeviceCollection> devices;
+ hr = enumerator->EnumAudioEndpoints(eRender, DEVICE_STATE_ACTIVE, devices.put());
+ if (FAILED(hr) || !devices) {
+  co_uninit();
+  return out;
+ }
+
+ UINT count = 0;
+ if (FAILED(devices->GetCount(&count))) {
+  co_uninit();
+  return out;
+ }
+
+ out.reserve(count);
+ for (UINT i = 0; i < count; ++i) {
+  ComPtr<IMMDevice> dev;
+  if (FAILED(devices->Item(i, dev.put())) || !dev) continue;
+
+  ExternalAudioDevice d;
+  d.id = endpoint_id(dev.get());
+  d.name = friendly_name(dev.get());
+  if (d.name.empty()) d.name = d.id.empty() ? "Unknown playback device" : d.id;
+  d.is_default = !default_id.empty() && d.id == default_id;
+  if (!d.id.empty()) out.push_back(std::move(d));
+ }
+
+ std::stable_sort(out.begin(), out.end(), [](const auto& a, const auto& b) {
+  if (a.is_default != b.is_default) return a.is_default && !b.is_default;
+  return a.name < b.name;
+ });
+
+ co_uninit();
+ return out;
+}
+
+std::string external_audio_configured_endpoint() {
+ return parse_endpoint_id_from_config().value_or(std::string{});
+}
+
+bool set_external_audio_configured_endpoint(std::string_view endpoint_id_value) {
+ const auto path = config_path();
+ if (path.empty()) return false;
+
+ std::string content;
+ {
+  std::ifstream in{path, std::ios::binary};
+  if (in) {
+   std::ostringstream ss;
+   ss << in.rdbuf();
+   content = ss.str();
+  }
+ }
+
+ std::istringstream in{content};
+ std::ostringstream out;
+ std::string line;
+ bool in_external = false;
+ bool saw_external = false;
+ bool wrote_endpoint = false;
+
+ auto write_endpoint = [&] {
+  out << "endpoint_id = " << toml_quote(endpoint_id_value) << "\n";
+  wrote_endpoint = true;
+ };
+
+ while (std::getline(in, line)) {
+  std::string trimmed = line;
+  if (!trimmed.empty() && trimmed.back() == '\r') trimmed.pop_back();
+  auto first = trimmed.find_first_not_of(" \t");
+  auto last = trimmed.find_last_not_of(" \t");
+  trimmed = first == std::string::npos ? std::string{} : trimmed.substr(first, last - first + 1);
+
+  if (trimmed.size() >= 3 && trimmed.front() == '[' && trimmed.back() == ']') {
+   if (in_external && !wrote_endpoint) write_endpoint();
+   in_external = (trimmed == "[external_audio]");
+   if (in_external) saw_external = true;
+   out << line << "\n";
+   continue;
+  }
+
+  if (in_external) {
+   auto eq = trimmed.find('=');
+   auto key = eq == std::string::npos ? trimmed : trimmed.substr(0, eq);
+   key.erase(std::remove_if(key.begin(), key.end(), [](unsigned char c) { return std::isspace(c); }), key.end());
+   if (key == "endpoint_id") {
+    write_endpoint();
+    continue;
+   }
+  }
+
+  out << line << "\n";
+ }
+
+ if (saw_external && in_external && !wrote_endpoint) write_endpoint();
+ if (!saw_external) {
+  if (!content.empty() && content.back() != '\n') out << "\n";
+  out << "\n[external_audio]\n";
+  write_endpoint();
+ }
+
+ std::ofstream file{path, std::ios::binary | std::ios::trunc};
+ if (!file) return false;
+ file << out.str();
+ return true;
+}
+
+void ExternalAudioSource::reload_from_config() {
+ const bool was_playing = state_.load(std::memory_order_acquire) == PlaybackState::playing;
+ if (was_playing) {
+  stop_worker();
+  clear_queue();
+  start_worker();
+ }
+}
+
+
+ExternalAudioSource::~ExternalAudioSource() {
+ shutdown();
+}
+
+bool ExternalAudioSource::initialize() {
+ return true;
+}
+
+void ExternalAudioSource::shutdown() noexcept {
+ stop_worker();
+ clear_queue();
+ state_.store(PlaybackState::stopped, std::memory_order_release);
+}
+
+void ExternalAudioSource::play() {
+ state_.store(PlaybackState::playing, std::memory_order_release);
+ start_worker();
+}
+
+void ExternalAudioSource::pause() {
+ state_.store(PlaybackState::paused, std::memory_order_release);
+ stop_worker();
+ clear_queue();
+}
+
+void ExternalAudioSource::stop() {
+ state_.store(PlaybackState::stopped, std::memory_order_release);
+ stop_worker();
+ clear_queue();
+ position_ms_.store(0, std::memory_order_release);
+}
+
+void ExternalAudioSource::pump(RingBuffer& ring) {
+ if (state_.load(std::memory_order_acquire) != PlaybackState::playing) return;
+
+ std::vector<int16_t> chunk;
+ {
+  std::scoped_lock lk{queue_mu_};
+  const std::size_t available = pcm_queue_.size() - queue_offset_;
+  if (available == 0) return;
+
+  std::size_t writable_samples = ring.writable() / sizeof(int16_t);
+  writable_samples &= ~std::size_t{1};
+  const std::size_t to_write = std::min(available, writable_samples);
+  if (to_write == 0) return;
+
+  chunk.assign(pcm_queue_.begin() + static_cast<std::ptrdiff_t>(queue_offset_),
+   pcm_queue_.begin() + static_cast<std::ptrdiff_t>(queue_offset_ + to_write));
+  queue_offset_ += to_write;
+
+  if (queue_offset_ > 0 &&
+   (queue_offset_ >= pcm_queue_.size() / 2u || queue_offset_ > 32768u)) {
+   pcm_queue_.erase(pcm_queue_.begin(),
+    pcm_queue_.begin() + static_cast<std::ptrdiff_t>(queue_offset_));
+   queue_offset_ = 0;
+  }
+ }
+
+ if (!chunk.empty()) {
+  const std::size_t bytes = chunk.size() * sizeof(int16_t);
+  if (ring.write(chunk.data(), bytes) == bytes) {
+   const auto frames = static_cast<uint64_t>(chunk.size() / kTargetChannels);
+   position_ms_.fetch_add((frames * 1000u) / kTargetSampleRate, std::memory_order_acq_rel);
+  }
+ }
+}
+
+TrackInfo ExternalAudioSource::current_track() const {
+ std::scoped_lock lk{meta_mu_};
+ TrackInfo t;
+ t.title = "System Audio";
+ t.artist = device_name_.empty() ? "Default playback device" : device_name_;
+ t.album = "External Audio";
+ t.position_ms = position_ms_.load(std::memory_order_acquire);
+ return t;
+}
+
+AuthState ExternalAudioSource::auth_state() const noexcept {
+ std::scoped_lock lk{meta_mu_};
+ return last_error_.empty() ? AuthState::none_required : AuthState::error;
+}
+
+std::string ExternalAudioSource::auth_instructions() const {
+ std::scoped_lock lk{meta_mu_};
+ return last_error_;
+}
+
+void ExternalAudioSource::start_worker() {
+ std::scoped_lock lk{worker_mu_};
+ if (worker_.joinable()) return;
+
+ {
+  std::scoped_lock meta_lk{meta_mu_};
+  last_error_.clear();
+ }
+
+ stop_requested_.store(false, std::memory_order_release);
+ worker_ = std::thread([this] { capture_loop(); });
+}
+
+void ExternalAudioSource::stop_worker() noexcept {
+ std::thread t;
+ {
+  std::scoped_lock lk{worker_mu_};
+  stop_requested_.store(true, std::memory_order_release);
+  if (worker_.joinable()) t = std::move(worker_);
+ }
+
+ if (t.joinable()) {
+  try {
+   t.join();
+  } catch (...) {
+  }
+ }
+}
+
+void ExternalAudioSource::append_pcm(const int16_t* data, std::size_t samples) {
+ if (!data || samples == 0) return;
+
+ std::scoped_lock lk{queue_mu_};
+ if (queue_offset_ > 0 &&
+  (queue_offset_ >= pcm_queue_.size() / 2u || queue_offset_ > 32768u)) {
+  pcm_queue_.erase(pcm_queue_.begin(),
+   pcm_queue_.begin() + static_cast<std::ptrdiff_t>(queue_offset_));
+  queue_offset_ = 0;
+ }
+
+ const std::size_t queued = pcm_queue_.size() - queue_offset_;
+ if (queued + samples > kMaxQueuedSamples) {
+  const std::size_t drop = queued + samples - kMaxQueuedSamples;
+  queue_offset_ = std::min(queue_offset_ + drop, pcm_queue_.size());
+ }
+
+ pcm_queue_.insert(pcm_queue_.end(), data, data + samples);
+}
+
+void ExternalAudioSource::clear_queue() {
+ std::scoped_lock lk{queue_mu_};
+ pcm_queue_.clear();
+ queue_offset_ = 0;
+}
+
+void ExternalAudioSource::capture_loop() noexcept {
+ auto set_error = [this](std::string msg) {
+  std::scoped_lock lk{meta_mu_};
+  last_error_ = std::move(msg);
+  log::warn("[external_audio] {}", last_error_);
+ };
+
+ HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+ const bool co_initialized = SUCCEEDED(hr);
+ if (FAILED(hr) && hr != RPC_E_CHANGED_MODE) {
+  set_error(hresult_string("CoInitializeEx", hr));
+  return;
+ }
+
+ auto co_uninit = [&] {
+  if (co_initialized) CoUninitialize();
+ };
+
+ ComPtr<IMMDeviceEnumerator> enumerator;
+ hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL,
+  IID_PPV_ARGS(enumerator.put()));
+ if (FAILED(hr) || !enumerator) {
+  set_error(hresult_string("CoCreateInstance(MMDeviceEnumerator)", hr));
+  co_uninit();
+  return;
+ }
+
+ ComPtr<IMMDevice> device;
+ hr = get_configured_endpoint(enumerator.get(), device.put());
+ if (FAILED(hr) || !device) {
+  set_error(hresult_string("Get audio endpoint", hr));
+  co_uninit();
+  return;
+ }
+
+ {
+  auto name = friendly_name(device.get());
+  std::scoped_lock lk{meta_mu_};
+  device_name_ = name.empty() ? "Default playback device" : std::move(name);
+ }
+
+ ComPtr<IAudioClient> client;
+ hr = device->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr,
+  reinterpret_cast<void**>(client.put()));
+ if (FAILED(hr) || !client) {
+  set_error(hresult_string("IMMDevice::Activate(IAudioClient)", hr));
+  co_uninit();
+  return;
+ }
+
+ CoTaskMemWaveFormat mix;
+ hr = client->GetMixFormat(mix.put());
+ if (FAILED(hr) || !mix.p) {
+  set_error(hresult_string("IAudioClient::GetMixFormat", hr));
+  co_uninit();
+  return;
+ }
+
+ InputFormat input;
+ std::string parse_error;
+ if (!parse_input_format(*mix.p, input, parse_error)) {
+  set_error(parse_error);
+  co_uninit();
+  return;
+ }
+
+ constexpr REFERENCE_TIME buffer_duration_100ns = 10'000'000;
+ hr = client->Initialize(AUDCLNT_SHAREMODE_SHARED, AUDCLNT_STREAMFLAGS_LOOPBACK,
+  buffer_duration_100ns, 0, mix.p, nullptr);
+ if (FAILED(hr)) {
+  set_error(hresult_string("IAudioClient::Initialize(loopback)", hr));
+  co_uninit();
+  return;
+ }
+
+ ComPtr<IAudioCaptureClient> capture;
+ hr = client->GetService(__uuidof(IAudioCaptureClient), reinterpret_cast<void**>(capture.put()));
+ if (FAILED(hr) || !capture) {
+  set_error(hresult_string("IAudioClient::GetService(IAudioCaptureClient)", hr));
+  co_uninit();
+  return;
+ }
+
+ hr = client->Start();
+ if (FAILED(hr)) {
+  set_error(hresult_string("IAudioClient::Start", hr));
+  co_uninit();
+  return;
+ }
+
+ log::info("[external_audio] capturing {} ch, {} Hz, {}-bit {} from '{}'",
+  input.channels, input.sample_rate, input.bits, input.is_float ? "float" : "pcm",
+  current_track().artist);
+
+ Resampler resampler;
+ resampler.fmt = input;
+
+ while (!stop_requested_.load(std::memory_order_acquire)) {
+  UINT32 next_packet_frames = 0;
+  hr = capture->GetNextPacketSize(&next_packet_frames);
+  if (FAILED(hr)) {
+   set_error(hresult_string("IAudioCaptureClient::GetNextPacketSize", hr));
+   break;
+  }
+
+  if (next_packet_frames == 0) {
+   Sleep(5);
+   continue;
+  }
+
+  while (next_packet_frames > 0 && !stop_requested_.load(std::memory_order_acquire)) {
+   BYTE* data = nullptr;
+   UINT32 frames = 0;
+   DWORD flags = 0;
+
+   hr = capture->GetBuffer(&data, &frames, &flags, nullptr, nullptr);
+   if (FAILED(hr)) {
+    set_error(hresult_string("IAudioCaptureClient::GetBuffer", hr));
+    break;
+   }
+
+   resampler.push_packet(data, frames, flags);
+   if (!resampler.out.empty()) {
+    append_pcm(resampler.out.data(), resampler.out.size());
+    resampler.out.clear();
+   }
+
+   capture->ReleaseBuffer(frames);
+
+   hr = capture->GetNextPacketSize(&next_packet_frames);
+   if (FAILED(hr)) {
+    set_error(hresult_string("IAudioCaptureClient::GetNextPacketSize", hr));
+    next_packet_frames = 0;
+    break;
+   }
+  }
+ }
+
+ client->Stop();
+ co_uninit();
+}
+
+} // namespace fh6::sources

--- a/src/sources/external_audio_source.cpp
+++ b/src/sources/external_audio_source.cpp
@@ -28,6 +28,11 @@ constexpr uint32_t kTargetSampleRate = 48000;
 constexpr uint32_t kTargetChannels = 2;
 constexpr std::size_t kMaxQueuedSamples = kTargetSampleRate * kTargetChannels * 2;
 
+// Upper bound on audio in flight (ring + queue) so captured audio stays close
+// to real time and the live media-session metadata lines up with what's heard.
+// 250 ms at 48 kHz stereo.
+constexpr std::size_t kMaxInFlightSamples = kTargetSampleRate * kTargetChannels / 4;
+
 template <class T> class ComPtr {
 public:
  ComPtr() = default;
@@ -562,17 +567,29 @@ void ExternalAudioSource::pump(RingBuffer& ring) {
  std::vector<int16_t> chunk;
  {
   std::scoped_lock lk{queue_mu_};
-  const std::size_t available = pcm_queue_.size() - queue_offset_;
+  std::size_t available = pcm_queue_.size() - queue_offset_;
   if (available == 0) return;
+
+  // Real-time capture must not accumulate latency: the media-session metadata
+  // is read live, so any audio backlog makes the next track show that far
+  // ahead of when it's heard. Cap what's in flight (ring + queue) and skip the
+  // oldest captured samples past it rather than letting the ring fill deep.
+  const std::size_t backlog = ring.readable() / sizeof(int16_t);
+  if (backlog + available > kMaxInFlightSamples) {
+   const std::size_t drop =
+    std::min(backlog + available - kMaxInFlightSamples, available) & ~std::size_t{1};
+   queue_offset_ += drop;
+   available -= drop;
+  }
 
   std::size_t writable_samples = ring.writable() / sizeof(int16_t);
   writable_samples &= ~std::size_t{1};
   const std::size_t to_write = std::min(available, writable_samples);
-  if (to_write == 0) return;
-
-  chunk.assign(pcm_queue_.begin() + static_cast<std::ptrdiff_t>(queue_offset_),
-   pcm_queue_.begin() + static_cast<std::ptrdiff_t>(queue_offset_ + to_write));
-  queue_offset_ += to_write;
+  if (to_write > 0) {
+   chunk.assign(pcm_queue_.begin() + static_cast<std::ptrdiff_t>(queue_offset_),
+    pcm_queue_.begin() + static_cast<std::ptrdiff_t>(queue_offset_ + to_write));
+   queue_offset_ += to_write;
+  }
   compact_queue_locked();
  }
 

--- a/src/sources/external_audio_source.cpp
+++ b/src/sources/external_audio_source.cpp
@@ -259,14 +259,14 @@ int32_t read_i24_le(const BYTE* p) noexcept {
  return v;
 }
 
-float sample_to_float(const BYTE* p, WORD bits, bool is_float) noexcept {
+float sample_to_float(const BYTE* p, WORD container_bits, WORD valid_bits, bool is_float) noexcept {
  if (is_float) {
-  if (bits == 32) {
+  if (container_bits == 32) {
    float v;
    std::memcpy(&v, p, sizeof(v));
    return clamp_sample(v);
   }
-  if (bits == 64) {
+  if (container_bits == 64) {
    double v;
    std::memcpy(&v, p, sizeof(v));
    return clamp_sample(static_cast<float>(v));
@@ -274,30 +274,45 @@ float sample_to_float(const BYTE* p, WORD bits, bool is_float) noexcept {
   return 0.0f;
  }
 
- switch (bits) {
- case 8:
-  return (static_cast<int>(*p) - 128) / 128.0f;
+ if (valid_bits == 0 || valid_bits > container_bits) valid_bits = container_bits;
+ if (valid_bits == 0 || valid_bits > 32) return 0.0f;
+
+ if (container_bits == 8) {
+  const int32_t signed_value = static_cast<int32_t>(*p) - 128;
+  return clamp_sample(static_cast<float>(signed_value) / 128.0f);
+ }
+
+ int32_t signed_value = 0;
+ switch (container_bits) {
  case 16: {
   int16_t v;
   std::memcpy(&v, p, sizeof(v));
-  return static_cast<float>(v) / 32768.0f;
+  signed_value = v;
+  break;
  }
  case 24:
-  return static_cast<float>(read_i24_le(p)) / 8388608.0f;
- case 32: {
-  int32_t v;
-  std::memcpy(&v, p, sizeof(v));
-  return static_cast<float>(v) / 2147483648.0f;
- }
+  signed_value = read_i24_le(p);
+  break;
+ case 32:
+  std::memcpy(&signed_value, p, sizeof(signed_value));
+  break;
  default:
   return 0.0f;
  }
+
+ if (valid_bits < container_bits) {
+  signed_value >>= static_cast<int>(container_bits - valid_bits);
+ }
+
+ const double scale = static_cast<double>(int64_t{1} << (valid_bits - 1u));
+ return clamp_sample(static_cast<float>(static_cast<double>(signed_value) / scale));
 }
 
 struct InputFormat {
  uint32_t sample_rate = 0;
  uint16_t channels = 0;
- uint16_t bits = 0;
+ uint16_t container_bits = 0;
+ uint16_t valid_bits = 0;
  uint16_t block_align = 0;
  bool is_float = false;
 };
@@ -305,10 +320,11 @@ struct InputFormat {
 bool parse_input_format(const WAVEFORMATEX& fmt, InputFormat& out, std::string& error) {
  out.sample_rate = fmt.nSamplesPerSec;
  out.channels = fmt.nChannels;
- out.bits = fmt.wBitsPerSample;
+ out.container_bits = fmt.wBitsPerSample;
+ out.valid_bits = fmt.wBitsPerSample;
  out.block_align = fmt.nBlockAlign;
 
- if (out.sample_rate == 0 || out.channels == 0 || out.block_align == 0) {
+ if (out.sample_rate == 0 || out.channels == 0 || out.block_align == 0 || out.container_bits == 0) {
   error = "Invalid WASAPI mix format";
   return false;
  }
@@ -326,8 +342,10 @@ bool parse_input_format(const WAVEFORMATEX& fmt, InputFormat& out, std::string& 
  if (fmt.wFormatTag == WAVE_FORMAT_EXTENSIBLE &&
   fmt.cbSize >= (sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX))) {
   const auto& ext = reinterpret_cast<const WAVEFORMATEXTENSIBLE&>(fmt);
-  out.bits = ext.Format.wBitsPerSample;
+  out.container_bits = ext.Format.wBitsPerSample;
+  out.valid_bits = ext.Samples.wValidBitsPerSample ? ext.Samples.wValidBitsPerSample : out.container_bits;
   out.block_align = ext.Format.nBlockAlign;
+  if (out.valid_bits > out.container_bits) out.valid_bits = out.container_bits;
   if (IsEqualGUID(ext.SubFormat, KSDATAFORMAT_SUBTYPE_IEEE_FLOAT)) {
    out.is_float = true;
    return true;
@@ -370,7 +388,7 @@ struct Resampler {
   }
 
   const bool silent = (flags & AUDCLNT_BUFFERFLAGS_SILENT) != 0;
-  const uint16_t bytes_per_sample = static_cast<uint16_t>((fmt.bits + 7u) / 8u);
+  const uint16_t bytes_per_sample = static_cast<uint16_t>((fmt.container_bits + 7u) / 8u);
 
   for (UINT32 f = 0; f < frame_count; ++f) {
    float l = 0.0f;
@@ -378,11 +396,35 @@ struct Resampler {
 
    if (!silent && data) {
     const BYTE* frame = data + static_cast<std::size_t>(f) * fmt.block_align;
-    l = sample_to_float(frame, fmt.bits, fmt.is_float);
     if (fmt.channels == 1) {
+     l = sample_to_float(frame, fmt.container_bits, fmt.valid_bits, fmt.is_float);
      r = l;
+    } else if (fmt.channels == 2) {
+     l = sample_to_float(frame, fmt.container_bits, fmt.valid_bits, fmt.is_float);
+     r = sample_to_float(frame + bytes_per_sample, fmt.container_bits, fmt.valid_bits, fmt.is_float);
     } else {
-     r = sample_to_float(frame + bytes_per_sample, fmt.bits, fmt.is_float);
+     double lsum = 0.0;
+     double rsum = 0.0;
+     double lw = 0.0;
+     double rw = 0.0;
+     for (uint16_t ch = 0; ch < fmt.channels; ++ch) {
+      const float v = sample_to_float(frame + static_cast<std::size_t>(ch) * bytes_per_sample,
+       fmt.container_bits, fmt.valid_bits, fmt.is_float);
+      if (ch == 0) {
+       lsum += v;
+       lw += 1.0;
+      } else if (ch == 1) {
+       rsum += v;
+       rw += 1.0;
+      } else {
+       lsum += v;
+       rsum += v;
+       lw += 1.0;
+       rw += 1.0;
+      }
+     }
+     l = static_cast<float>(lsum / std::max(1.0, lw));
+     r = static_cast<float>(rsum / std::max(1.0, rw));
     }
    }
 
@@ -798,10 +840,17 @@ void ExternalAudioSource::clear_queue() {
 }
 
 void ExternalAudioSource::capture_loop() noexcept {
- auto set_error = [this](std::string msg) {
-  std::scoped_lock lk{meta_mu_};
-  last_error_ = std::move(msg);
-  log::warn("[external_audio] {}", last_error_);
+ bool had_error = false;
+ auto set_error = [this, &had_error](std::string msg) {
+  had_error = true;
+  {
+   std::scoped_lock lk{meta_mu_};
+   last_error_ = std::move(msg);
+   log::warn("[external_audio] {}", last_error_);
+  }
+  if (!stop_requested_.load(std::memory_order_acquire)) {
+   state_.store(PlaybackState::stopped, std::memory_order_release);
+  }
  };
 
  HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
@@ -887,14 +936,14 @@ void ExternalAudioSource::capture_loop() noexcept {
   return;
  }
 
- log::info("[external_audio] capturing {} ch, {} Hz, {}-bit {} from '{}'",
-  input.channels, input.sample_rate, input.bits, input.is_float ? "float" : "pcm",
-  current_track().artist);
+ log::info("[external_audio] capturing {} ch, {} Hz, {}-bit container / {}-bit valid {} from '{}'",
+  input.channels, input.sample_rate, input.container_bits, input.valid_bits,
+  input.is_float ? "float" : "pcm", current_track().artist);
 
  Resampler resampler;
  resampler.fmt = input;
 
- while (!stop_requested_.load(std::memory_order_acquire)) {
+ while (!had_error && !stop_requested_.load(std::memory_order_acquire)) {
   UINT32 next_packet_frames = 0;
   hr = capture->GetNextPacketSize(&next_packet_frames);
   if (FAILED(hr)) {
@@ -907,7 +956,7 @@ void ExternalAudioSource::capture_loop() noexcept {
    continue;
   }
 
-  while (next_packet_frames > 0 && !stop_requested_.load(std::memory_order_acquire)) {
+  while (next_packet_frames > 0 && !had_error && !stop_requested_.load(std::memory_order_acquire)) {
    BYTE* data = nullptr;
    UINT32 frames = 0;
    DWORD flags = 0;

--- a/src/sources/external_audio_source.cpp
+++ b/src/sources/external_audio_source.cpp
@@ -1,4 +1,5 @@
 #include "fh6/sources/external_audio_source.hpp"
+#include "fh6/sources/external_media_session.hpp"
 
 #include "fh6/log.hpp"
 #include "fh6/ring_buffer.hpp"
@@ -180,6 +181,48 @@ std::optional<std::string> parse_endpoint_id_from_config() {
   auto key = line.substr(0, eq);
   key.erase(std::remove_if(key.begin(), key.end(), [](unsigned char c) { return std::isspace(c); }), key.end());
   if (key != "endpoint_id") continue;
+
+  auto value = line.substr(eq + 1);
+  auto a = value.find_first_not_of(" \t\r\n");
+  auto b = value.find_last_not_of(" \t\r\n");
+  if (a == std::string::npos) return std::string{};
+  value = value.substr(a, b - a + 1);
+  if (value.size() >= 2 && ((value.front() == '\'' && value.back() == '\'') ||
+   (value.front() == '"' && value.back() == '"'))) {
+   value = value.substr(1, value.size() - 2);
+  }
+  return value;
+ }
+
+ return std::nullopt;
+}
+
+std::optional<std::string> parse_media_session_id_from_config() {
+ std::ifstream in{config_path(), std::ios::binary};
+ if (!in) return std::nullopt;
+
+ bool in_external = false;
+ std::string line;
+ while (std::getline(in, line)) {
+  auto comment = line.find('#');
+  if (comment != std::string::npos) line.resize(comment);
+
+  auto first = line.find_first_not_of(" \t\r\n");
+  if (first == std::string::npos) continue;
+  auto last = line.find_last_not_of(" \t\r\n");
+  line = line.substr(first, last - first + 1);
+
+  if (line.size() >= 3 && line.front() == '[' && line.back() == ']') {
+   in_external = (line == "[external_audio]");
+   continue;
+  }
+
+  if (!in_external) continue;
+  auto eq = line.find('=');
+  if (eq == std::string::npos) continue;
+  auto key = line.substr(0, eq);
+  key.erase(std::remove_if(key.begin(), key.end(), [](unsigned char c) { return std::isspace(c); }), key.end());
+  if (key != "media_session_id") continue;
 
   auto value = line.substr(eq + 1);
   auto a = value.find_first_not_of(" \t\r\n");
@@ -602,11 +645,17 @@ void ExternalAudioSource::shutdown() noexcept {
 }
 
 void ExternalAudioSource::play() {
+ // Source lifecycle only: selecting or resuming External Audio must not
+ // send Play to the user's external media application. Metadata and explicit
+ // next/previous actions are handled through the selected media session, but
+ // play/pause here only control whether this source feeds captured PCM to FH6.
  state_.store(PlaybackState::playing, std::memory_order_release);
  start_worker();
 }
 
 void ExternalAudioSource::pause() {
+ // Source lifecycle only: do not pause the selected Windows media session when
+ // the user switches away from External Audio or the source manager pauses us.
  state_.store(PlaybackState::paused, std::memory_order_release);
  stop_worker();
  clear_queue();
@@ -617,6 +666,18 @@ void ExternalAudioSource::stop() {
  stop_worker();
  clear_queue();
  position_ms_.store(0, std::memory_order_release);
+}
+
+void ExternalAudioSource::next() {
+ (void)skip_next();
+}
+
+void ExternalAudioSource::previous() {
+ (void)external_audio_media_session_previous(parse_media_session_id_from_config().value_or(std::string{}));
+}
+
+bool ExternalAudioSource::skip_next() {
+ return external_audio_media_session_next(parse_media_session_id_from_config().value_or(std::string{}));
 }
 
 void ExternalAudioSource::pump(RingBuffer& ring) {
@@ -655,12 +716,19 @@ void ExternalAudioSource::pump(RingBuffer& ring) {
 }
 
 TrackInfo ExternalAudioSource::current_track() const {
+ const auto fallback_position = position_ms_.load(std::memory_order_acquire);
+ const auto selected_session = parse_media_session_id_from_config().value_or(std::string{});
+ if (auto t = external_audio_media_session_track(selected_session, fallback_position)) {
+  if (t->album.empty()) t->album = "External Audio";
+  return *t;
+ }
+
  std::scoped_lock lk{meta_mu_};
  TrackInfo t;
- t.title = "System Audio";
- t.artist = device_name_.empty() ? "Default playback device" : device_name_;
+ t.title = "External Audio";
+ t.artist = device_name_.empty() ? "No media session metadata" : device_name_;
  t.album = "External Audio";
- t.position_ms = position_ms_.load(std::memory_order_acquire);
+ t.position_ms = fallback_position;
  return t;
 }
 

--- a/src/sources/external_audio_source.cpp
+++ b/src/sources/external_audio_source.cpp
@@ -18,11 +18,7 @@
 #include <cstdio>
 #include <cstring>
 #include <cwctype>
-#include <filesystem>
-#include <fstream>
 #include <limits>
-#include <sstream>
-#include <optional>
 #include <string_view>
 
 namespace fh6::sources {
@@ -146,97 +142,6 @@ std::string endpoint_id(IMMDevice* device) {
  CoTaskMemString id;
  if (FAILED(device->GetId(id.put())) || !id.p) return {};
  return wide_to_utf8(id.p);
-}
-
-std::filesystem::path config_path() {
- wchar_t buf[MAX_PATH];
- DWORD n = GetModuleFileNameW(nullptr, buf, MAX_PATH);
- if (n == 0 || n >= MAX_PATH) return {};
- return std::filesystem::path{buf}.parent_path() / "fh6-radio" / "config.toml";
-}
-
-std::optional<std::string> parse_endpoint_id_from_config() {
- std::ifstream in{config_path(), std::ios::binary};
- if (!in) return std::nullopt;
-
- bool in_external = false;
- std::string line;
- while (std::getline(in, line)) {
-  auto comment = line.find('#');
-  if (comment != std::string::npos) line.resize(comment);
-
-  auto first = line.find_first_not_of(" \t\r\n");
-  if (first == std::string::npos) continue;
-  auto last = line.find_last_not_of(" \t\r\n");
-  line = line.substr(first, last - first + 1);
-
-  if (line.size() >= 3 && line.front() == '[' && line.back() == ']') {
-   in_external = (line == "[external_audio]");
-   continue;
-  }
-
-  if (!in_external) continue;
-  auto eq = line.find('=');
-  if (eq == std::string::npos) continue;
-  auto key = line.substr(0, eq);
-  key.erase(std::remove_if(key.begin(), key.end(), [](unsigned char c) { return std::isspace(c); }), key.end());
-  if (key != "endpoint_id") continue;
-
-  auto value = line.substr(eq + 1);
-  auto a = value.find_first_not_of(" \t\r\n");
-  auto b = value.find_last_not_of(" \t\r\n");
-  if (a == std::string::npos) return std::string{};
-  value = value.substr(a, b - a + 1);
-  if (value.size() >= 2 && ((value.front() == '\'' && value.back() == '\'') ||
-   (value.front() == '"' && value.back() == '"'))) {
-   value = value.substr(1, value.size() - 2);
-  }
-  return value;
- }
-
- return std::nullopt;
-}
-
-std::optional<std::string> parse_media_session_id_from_config() {
- std::ifstream in{config_path(), std::ios::binary};
- if (!in) return std::nullopt;
-
- bool in_external = false;
- std::string line;
- while (std::getline(in, line)) {
-  auto comment = line.find('#');
-  if (comment != std::string::npos) line.resize(comment);
-
-  auto first = line.find_first_not_of(" \t\r\n");
-  if (first == std::string::npos) continue;
-  auto last = line.find_last_not_of(" \t\r\n");
-  line = line.substr(first, last - first + 1);
-
-  if (line.size() >= 3 && line.front() == '[' && line.back() == ']') {
-   in_external = (line == "[external_audio]");
-   continue;
-  }
-
-  if (!in_external) continue;
-  auto eq = line.find('=');
-  if (eq == std::string::npos) continue;
-  auto key = line.substr(0, eq);
-  key.erase(std::remove_if(key.begin(), key.end(), [](unsigned char c) { return std::isspace(c); }), key.end());
-  if (key != "media_session_id") continue;
-
-  auto value = line.substr(eq + 1);
-  auto a = value.find_first_not_of(" \t\r\n");
-  auto b = value.find_last_not_of(" \t\r\n");
-  if (a == std::string::npos) return std::string{};
-  value = value.substr(a, b - a + 1);
-  if (value.size() >= 2 && ((value.front() == '\'' && value.back() == '\'') ||
-   (value.front() == '"' && value.back() == '"'))) {
-   value = value.substr(1, value.size() - 2);
-  }
-  return value;
- }
-
- return std::nullopt;
 }
 
 float clamp_sample(float v) noexcept {
@@ -462,8 +367,8 @@ struct Resampler {
  }
 };
 
-HRESULT get_configured_endpoint(IMMDeviceEnumerator* enumerator, IMMDevice** out_device) {
- const auto endpoint = parse_endpoint_id_from_config().value_or(std::string{});
+HRESULT get_configured_endpoint(IMMDeviceEnumerator* enumerator, const std::string& endpoint,
+ IMMDevice** out_device) {
  if (endpoint.empty()) {
   return enumerator->GetDefaultAudioEndpoint(eRender, eConsole, out_device);
  }
@@ -498,18 +403,6 @@ HRESULT get_configured_endpoint(IMMDeviceEnumerator* enumerator, IMMDevice** out
 }
 
 } // namespace
-
-std::string toml_quote(std::string_view s) {
- std::string out;
- out.reserve(s.size() + 2);
- out.push_back('"');
- for (char c : s) {
-  if (c == '\\' || c == '"') out.push_back('\\');
-  out.push_back(c);
- }
- out.push_back('"');
- return out;
-}
 
 std::vector<ExternalAudioDevice> enumerate_external_audio_devices() {
  std::vector<ExternalAudioDevice> out;
@@ -573,104 +466,33 @@ std::vector<ExternalAudioDevice> enumerate_external_audio_devices() {
  return out;
 }
 
-std::string external_audio_configured_endpoint() {
- return parse_endpoint_id_from_config().value_or(std::string{});
-}
-
-bool set_external_audio_configured_endpoint(std::string_view endpoint_id_value) {
- const auto path = config_path();
- if (path.empty()) return false;
-
- std::string content;
+void ExternalAudioSource::set_config(ExternalAudioConfig cfg) {
+ bool endpoint_changed;
  {
-  std::ifstream in{path, std::ios::binary};
-  if (in) {
-   std::ostringstream ss;
-   ss << in.rdbuf();
-   content = ss.str();
-  }
+  std::scoped_lock lk{meta_mu_};
+  endpoint_changed = endpoint_id_ != cfg.endpoint_id;
+  endpoint_id_ = std::move(cfg.endpoint_id);
+  media_session_id_ = std::move(cfg.media_session_id);
  }
 
- std::istringstream in{content};
- std::ostringstream out;
- std::string line;
- bool in_external = false;
- bool saw_external = false;
- bool wrote_enabled = false;
- bool wrote_endpoint = false;
-
- auto write_enabled_default = [&] {
-  out << "enabled = false\n";
-  wrote_enabled = true;
- };
-
- auto write_endpoint = [&] {
-  out << "endpoint_id = " << toml_quote(endpoint_id_value) << "\n";
-  wrote_endpoint = true;
- };
-
- while (std::getline(in, line)) {
-  std::string trimmed = line;
-  if (!trimmed.empty() && trimmed.back() == '\r') trimmed.pop_back();
-  auto first = trimmed.find_first_not_of(" \t");
-  auto last = trimmed.find_last_not_of(" \t");
-  trimmed = first == std::string::npos ? std::string{} : trimmed.substr(first, last - first + 1);
-
-  if (trimmed.size() >= 3 && trimmed.front() == '[' && trimmed.back() == ']') {
-   if (in_external) {
-    if (!wrote_enabled) write_enabled_default();
-    if (!wrote_endpoint) write_endpoint();
-   }
-   in_external = (trimmed == "[external_audio]");
-   wrote_enabled = false;
-   wrote_endpoint = false;
-   if (in_external) saw_external = true;
-   out << line << "\n";
-   continue;
-  }
-
-  if (in_external) {
-   auto eq = trimmed.find('=');
-   auto key = eq == std::string::npos ? trimmed : trimmed.substr(0, eq);
-   key.erase(std::remove_if(key.begin(), key.end(), [](unsigned char c) { return std::isspace(c); }), key.end());
-   if (key == "enabled") {
-    wrote_enabled = true;
-   }
-   if (key == "endpoint_id") {
-    write_endpoint();
-    continue;
-   }
-  }
-
-  out << line << "\n";
- }
-
- if (saw_external && in_external) {
-  if (!wrote_enabled) write_enabled_default();
-  if (!wrote_endpoint) write_endpoint();
- }
- if (!saw_external) {
-  if (!content.empty() && content.back() != '\n') out << "\n";
-  out << "\n[external_audio]\n";
-  write_enabled_default();
-  write_endpoint();
- }
-
- std::ofstream file{path, std::ios::binary | std::ios::trunc};
- if (!file) return false;
- file << out.str();
- return true;
-}
-
-void ExternalAudioSource::reload_from_config() {
- const bool was_playing = state_.load(std::memory_order_acquire) == PlaybackState::playing;
- if (was_playing) {
+ // Only the capture endpoint needs a worker restart; the media session is read
+ // live by current_track()/next()/previous(), so a change there costs nothing.
+ if (endpoint_changed && state_.load(std::memory_order_acquire) == PlaybackState::playing) {
   stop_worker();
   clear_queue();
   start_worker();
  }
 }
 
+std::string ExternalAudioSource::configured_endpoint() const {
+ std::scoped_lock lk{meta_mu_};
+ return endpoint_id_;
+}
+
+std::string ExternalAudioSource::configured_media_session() const {
+ std::scoped_lock lk{meta_mu_};
+ return media_session_id_;
+}
 
 ExternalAudioSource::~ExternalAudioSource() {
  shutdown();
@@ -715,11 +537,11 @@ void ExternalAudioSource::next() {
 }
 
 void ExternalAudioSource::previous() {
- (void)external_audio_media_session_previous(parse_media_session_id_from_config().value_or(std::string{}));
+ (void)external_audio_media_session_previous(configured_media_session());
 }
 
 bool ExternalAudioSource::skip_next() {
- return external_audio_media_session_next(parse_media_session_id_from_config().value_or(std::string{}));
+ return external_audio_media_session_next(configured_media_session());
 }
 
 void ExternalAudioSource::pump(RingBuffer& ring) {
@@ -739,13 +561,7 @@ void ExternalAudioSource::pump(RingBuffer& ring) {
   chunk.assign(pcm_queue_.begin() + static_cast<std::ptrdiff_t>(queue_offset_),
    pcm_queue_.begin() + static_cast<std::ptrdiff_t>(queue_offset_ + to_write));
   queue_offset_ += to_write;
-
-  if (queue_offset_ > 0 &&
-   (queue_offset_ >= pcm_queue_.size() / 2u || queue_offset_ > 32768u)) {
-   pcm_queue_.erase(pcm_queue_.begin(),
-    pcm_queue_.begin() + static_cast<std::ptrdiff_t>(queue_offset_));
-   queue_offset_ = 0;
-  }
+  compact_queue_locked();
  }
 
  if (!chunk.empty()) {
@@ -759,7 +575,7 @@ void ExternalAudioSource::pump(RingBuffer& ring) {
 
 TrackInfo ExternalAudioSource::current_track() const {
  const auto fallback_position = position_ms_.load(std::memory_order_acquire);
- const auto selected_session = parse_media_session_id_from_config().value_or(std::string{});
+ const auto selected_session = configured_media_session();
  if (auto t = external_audio_media_session_track(selected_session, fallback_position)) {
   if (t->album.empty()) t->album = "External Audio";
   return *t;
@@ -817,12 +633,7 @@ void ExternalAudioSource::append_pcm(const int16_t* data, std::size_t samples) {
  if (!data || samples == 0) return;
 
  std::scoped_lock lk{queue_mu_};
- if (queue_offset_ > 0 &&
-  (queue_offset_ >= pcm_queue_.size() / 2u || queue_offset_ > 32768u)) {
-  pcm_queue_.erase(pcm_queue_.begin(),
-   pcm_queue_.begin() + static_cast<std::ptrdiff_t>(queue_offset_));
-  queue_offset_ = 0;
- }
+ compact_queue_locked();
 
  const std::size_t queued = pcm_queue_.size() - queue_offset_;
  if (queued + samples > kMaxQueuedSamples) {
@@ -837,6 +648,17 @@ void ExternalAudioSource::clear_queue() {
  std::scoped_lock lk{queue_mu_};
  pcm_queue_.clear();
  queue_offset_ = 0;
+}
+
+// Drop already-consumed samples once they dominate the buffer, so the queue
+// doesn't grow unboundedly from the front. Caller must hold queue_mu_.
+void ExternalAudioSource::compact_queue_locked() {
+ if (queue_offset_ > 0 &&
+  (queue_offset_ >= pcm_queue_.size() / 2u || queue_offset_ > 32768u)) {
+  pcm_queue_.erase(pcm_queue_.begin(),
+   pcm_queue_.begin() + static_cast<std::ptrdiff_t>(queue_offset_));
+  queue_offset_ = 0;
+ }
 }
 
 void ExternalAudioSource::capture_loop() noexcept {
@@ -874,17 +696,19 @@ void ExternalAudioSource::capture_loop() noexcept {
  }
 
  ComPtr<IMMDevice> device;
- hr = get_configured_endpoint(enumerator.get(), device.put());
+ hr = get_configured_endpoint(enumerator.get(), configured_endpoint(), device.put());
  if (FAILED(hr) || !device) {
   set_error(hresult_string("Get audio endpoint", hr));
   co_uninit();
   return;
  }
 
+ std::string device_label;
  {
   auto name = friendly_name(device.get());
+  device_label = name.empty() ? "Default playback device" : std::move(name);
   std::scoped_lock lk{meta_mu_};
-  device_name_ = name.empty() ? "Default playback device" : std::move(name);
+  device_name_ = device_label;
  }
 
  ComPtr<IAudioClient> client;
@@ -938,7 +762,7 @@ void ExternalAudioSource::capture_loop() noexcept {
 
  log::info("[external_audio] capturing {} ch, {} Hz, {}-bit container / {}-bit valid {} from '{}'",
   input.channels, input.sample_rate, input.container_bits, input.valid_bits,
-  input.is_float ? "float" : "pcm", current_track().artist);
+  input.is_float ? "float" : "pcm", device_label);
 
  Resampler resampler;
  resampler.fmt = input;

--- a/src/sources/external_media_session.cpp
+++ b/src/sources/external_media_session.cpp
@@ -110,6 +110,20 @@ TrackInfo track_from_session(media::GlobalSystemMediaTransportControlsSession co
     return info;
 }
 
+// Run a transport command against the selected (or current) session. Returns
+// false when nothing matches or the call throws.
+template <class Fn>
+bool with_session(std::string_view selected_id, Fn&& fn) {
+    try {
+        RoApartment apartment;
+        auto manager = session_manager();
+        auto session = pick_session(manager, selected_id);
+        return session ? fn(*session) : false;
+    } catch (...) {
+        return false;
+    }
+}
+
 #endif
 
 } // namespace
@@ -178,12 +192,7 @@ std::optional<TrackInfo> external_audio_media_session_track(std::string_view sel
 
 bool external_audio_media_session_next(std::string_view selected_id) {
 #if FH6_EXTERNAL_AUDIO_HAS_CPPWINRT
-    try {
-        RoApartment apartment;
-        auto manager = session_manager();
-        auto session = pick_session(manager, selected_id);
-        return session ? session->TrySkipNextAsync().get() : false;
-    } catch (...) { return false; }
+    return with_session(selected_id, [](auto& s) { return s.TrySkipNextAsync().get(); });
 #else
     (void)selected_id;
     return false;
@@ -192,17 +201,29 @@ bool external_audio_media_session_next(std::string_view selected_id) {
 
 bool external_audio_media_session_previous(std::string_view selected_id) {
 #if FH6_EXTERNAL_AUDIO_HAS_CPPWINRT
-    try {
-        RoApartment apartment;
-        auto manager = session_manager();
-        auto session = pick_session(manager, selected_id);
-        return session ? session->TrySkipPreviousAsync().get() : false;
-    } catch (...) { return false; }
+    return with_session(selected_id, [](auto& s) { return s.TrySkipPreviousAsync().get(); });
 #else
     (void)selected_id;
     return false;
 #endif
 }
 
+bool external_audio_media_session_pause(std::string_view selected_id) {
+#if FH6_EXTERNAL_AUDIO_HAS_CPPWINRT
+    return with_session(selected_id, [](auto& s) { return s.TryPauseAsync().get(); });
+#else
+    (void)selected_id;
+    return false;
+#endif
+}
+
+bool external_audio_media_session_play(std::string_view selected_id) {
+#if FH6_EXTERNAL_AUDIO_HAS_CPPWINRT
+    return with_session(selected_id, [](auto& s) { return s.TryPlayAsync().get(); });
+#else
+    (void)selected_id;
+    return false;
+#endif
+}
 
 } // namespace fh6::sources

--- a/src/sources/external_media_session.cpp
+++ b/src/sources/external_media_session.cpp
@@ -68,19 +68,20 @@ std::string display_name(std::string_view app_id) {
 std::optional<media::GlobalSystemMediaTransportControlsSession>
 pick_session(media::GlobalSystemMediaTransportControlsSessionManager const& manager,
              std::string_view selected_id) {
-    const auto current = manager.GetCurrentSession();
+    const auto sessions = manager.GetSessions();
 
     if (!selected_id.empty()) {
-        const auto sessions = manager.GetSessions();
+        // A configured selection must match exactly. Never fall back to another
+        // app, or we'd read or control the wrong one while the chosen session
+        // is momentarily absent (e.g. when it's paused).
         for (uint32_t i = 0; i < sessions.Size(); ++i) {
             auto session = sessions.GetAt(i);
             if (s(session.SourceAppUserModelId()) == selected_id) return session;
         }
+        return std::nullopt;
     }
 
-    if (current) return current;
-
-    const auto sessions = manager.GetSessions();
+    if (const auto current = manager.GetCurrentSession()) return current;
     if (sessions.Size() > 0) return sessions.GetAt(0);
     return std::nullopt;
 }

--- a/src/sources/external_media_session.cpp
+++ b/src/sources/external_media_session.cpp
@@ -1,0 +1,219 @@
+#include "fh6/sources/external_media_session.hpp"
+
+#include "fh6/log.hpp"
+
+#include <algorithm>
+#include <chrono>
+
+#if __has_include(<winrt/Windows.Media.Control.h>) && \
+    __has_include(<winrt/Windows.Foundation.Collections.h>)
+#define FH6_EXTERNAL_AUDIO_HAS_CPPWINRT 1
+#include <roapi.h>
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.Media.Control.h>
+#else
+#define FH6_EXTERNAL_AUDIO_HAS_CPPWINRT 0
+#endif
+
+namespace fh6::sources {
+namespace {
+
+#if FH6_EXTERNAL_AUDIO_HAS_CPPWINRT
+namespace media = winrt::Windows::Media::Control;
+
+struct RoApartment {
+    bool uninit = false;
+
+    RoApartment() noexcept {
+        const HRESULT hr = RoInitialize(RO_INIT_MULTITHREADED);
+        uninit = SUCCEEDED(hr);
+    }
+
+    ~RoApartment() {
+        if (uninit) RoUninitialize();
+    }
+};
+
+std::string s(winrt::hstring const& value) {
+    return winrt::to_string(value);
+}
+
+uint64_t ms_from_timespan(winrt::Windows::Foundation::TimeSpan const& ts) noexcept {
+    using namespace std::chrono;
+    const auto ms = duration_cast<milliseconds>(ts);
+    return ms.count() > 0 ? static_cast<uint64_t>(ms.count()) : 0;
+}
+
+media::GlobalSystemMediaTransportControlsSessionManager session_manager() {
+    return media::GlobalSystemMediaTransportControlsSessionManager::RequestAsync().get();
+}
+
+std::string display_name(std::string_view app_id) {
+    if (app_id.empty()) return "Unknown media session";
+
+    std::string out{app_id};
+    const auto bang = out.rfind('!');
+    if (bang != std::string::npos && bang + 1u < out.size()) out = out.substr(bang + 1u);
+
+    const auto dot = out.rfind('.');
+    if (dot != std::string::npos && dot + 1u < out.size()) {
+        const auto tail = out.substr(dot + 1u);
+        if (!tail.empty() && tail.size() <= 32u) out = tail;
+    }
+
+    std::replace(out.begin(), out.end(), '_', ' ');
+    return out.empty() ? std::string{"Unknown media session"} : out;
+}
+
+std::optional<media::GlobalSystemMediaTransportControlsSession>
+pick_session(media::GlobalSystemMediaTransportControlsSessionManager const& manager,
+             std::string_view selected_id) {
+    const auto current = manager.GetCurrentSession();
+
+    if (!selected_id.empty()) {
+        const auto sessions = manager.GetSessions();
+        for (uint32_t i = 0; i < sessions.Size(); ++i) {
+            auto session = sessions.GetAt(i);
+            if (s(session.SourceAppUserModelId()) == selected_id) return session;
+        }
+    }
+
+    if (current) return current;
+
+    const auto sessions = manager.GetSessions();
+    if (sessions.Size() > 0) return sessions.GetAt(0);
+    return std::nullopt;
+}
+
+TrackInfo track_from_session(media::GlobalSystemMediaTransportControlsSession const& session,
+                             uint64_t fallback_position_ms) {
+    TrackInfo info;
+    const auto props = session.TryGetMediaPropertiesAsync().get();
+
+    info.title = s(props.Title());
+    info.artist = s(props.Artist());
+    if (info.artist.empty()) info.artist = s(props.AlbumArtist());
+    info.album = s(props.AlbumTitle());
+
+    try {
+        const auto timeline = session.GetTimelineProperties();
+        info.position_ms = ms_from_timespan(timeline.Position());
+        const auto start = ms_from_timespan(timeline.StartTime());
+        const auto end = ms_from_timespan(timeline.EndTime());
+        if (end > start) info.duration_ms = end - start;
+    } catch (...) {
+        info.position_ms = fallback_position_ms;
+    }
+
+    if (info.position_ms == 0 && fallback_position_ms != 0) {
+        info.position_ms = fallback_position_ms;
+    }
+
+    if (info.title.empty()) info.title = "External Audio";
+    if (info.artist.empty()) info.artist = display_name(s(session.SourceAppUserModelId()));
+    return info;
+}
+
+#endif
+
+} // namespace
+
+bool external_audio_media_sessions_available() noexcept {
+#if FH6_EXTERNAL_AUDIO_HAS_CPPWINRT
+    return true;
+#else
+    return false;
+#endif
+}
+
+std::vector<ExternalAudioMediaSession>
+enumerate_external_audio_media_sessions(std::string_view selected_id) {
+    std::vector<ExternalAudioMediaSession> out;
+#if FH6_EXTERNAL_AUDIO_HAS_CPPWINRT
+    try {
+        RoApartment apartment;
+        auto manager = session_manager();
+        const auto current = manager.GetCurrentSession();
+        const auto current_id = current ? s(current.SourceAppUserModelId()) : std::string{};
+        const auto sessions = manager.GetSessions();
+
+        out.reserve(sessions.Size());
+        for (uint32_t i = 0; i < sessions.Size(); ++i) {
+            auto session = sessions.GetAt(i);
+            ExternalAudioMediaSession item;
+            item.id = s(session.SourceAppUserModelId());
+            item.name = display_name(item.id);
+            item.is_current = !current_id.empty() && item.id == current_id;
+            item.is_selected = !selected_id.empty() && item.id == selected_id;
+
+            try {
+                const auto props = session.TryGetMediaPropertiesAsync().get();
+                item.title = s(props.Title());
+                item.artist = s(props.Artist());
+                if (item.artist.empty()) item.artist = s(props.AlbumArtist());
+            } catch (...) {}
+
+            if (!item.id.empty()) out.push_back(std::move(item));
+        }
+
+        std::stable_sort(out.begin(), out.end(), [](const auto& a, const auto& b) {
+            if (a.is_current != b.is_current) return a.is_current && !b.is_current;
+            if (a.is_selected != b.is_selected) return a.is_selected && !b.is_selected;
+            return a.name < b.name;
+        });
+    } catch (...) {}
+#else
+    (void)selected_id;
+#endif
+    return out;
+}
+
+std::optional<TrackInfo> external_audio_media_session_track(std::string_view selected_id,
+                                                            uint64_t fallback_position_ms) {
+#if FH6_EXTERNAL_AUDIO_HAS_CPPWINRT
+    try {
+        RoApartment apartment;
+        auto manager = session_manager();
+        auto session = pick_session(manager, selected_id);
+        if (!session) return std::nullopt;
+        return track_from_session(*session, fallback_position_ms);
+    } catch (...) {
+        return std::nullopt;
+    }
+#else
+    (void)selected_id;
+    (void)fallback_position_ms;
+    return std::nullopt;
+#endif
+}
+
+bool external_audio_media_session_next(std::string_view selected_id) {
+#if FH6_EXTERNAL_AUDIO_HAS_CPPWINRT
+    try {
+        RoApartment apartment;
+        auto manager = session_manager();
+        auto session = pick_session(manager, selected_id);
+        return session ? session->TrySkipNextAsync().get() : false;
+    } catch (...) { return false; }
+#else
+    (void)selected_id;
+    return false;
+#endif
+}
+
+bool external_audio_media_session_previous(std::string_view selected_id) {
+#if FH6_EXTERNAL_AUDIO_HAS_CPPWINRT
+    try {
+        RoApartment apartment;
+        auto manager = session_manager();
+        auto session = pick_session(manager, selected_id);
+        return session ? session->TrySkipPreviousAsync().get() : false;
+    } catch (...) { return false; }
+#else
+    (void)selected_id;
+    return false;
+#endif
+}
+
+
+} // namespace fh6::sources

--- a/src/sources/external_media_session.cpp
+++ b/src/sources/external_media_session.cpp
@@ -105,10 +105,6 @@ TrackInfo track_from_session(media::GlobalSystemMediaTransportControlsSession co
         info.position_ms = fallback_position_ms;
     }
 
-    if (info.position_ms == 0 && fallback_position_ms != 0) {
-        info.position_ms = fallback_position_ms;
-    }
-
     if (info.title.empty()) info.title = "External Audio";
     if (info.artist.empty()) info.artist = display_name(s(session.SourceAppUserModelId()));
     return info;
@@ -145,13 +141,6 @@ enumerate_external_audio_media_sessions(std::string_view selected_id) {
             item.name = display_name(item.id);
             item.is_current = !current_id.empty() && item.id == current_id;
             item.is_selected = !selected_id.empty() && item.id == selected_id;
-
-            try {
-                const auto props = session.TryGetMediaPropertiesAsync().get();
-                item.title = s(props.Title());
-                item.artist = s(props.Artist());
-                if (item.artist.empty()) item.artist = s(props.AlbumArtist());
-            } catch (...) {}
 
             if (!item.id.empty()) out.push_back(std::move(item));
         }

--- a/ui/dist/app.js
+++ b/ui/dist/app.js
@@ -31,94 +31,6 @@ const toast = (msg, isErr = false) => {
   const el = document.createElement("div");
   el.className = "toast" + (isErr ? " err" : "");
   el.textContent = msg;
-
-(() => {
-  let extDevices = [];
-  let extEndpoint = "";
-  let extLoaded = false;
-
-  function ensureExternalAudioCard() {
-    let card = $("#external-audio-card");
-    if (card) return card;
-
-    card = document.createElement("section");
-    card.id = "external-audio-card";
-    card.className = "card";
-    card.hidden = true;
-    card.innerHTML = `
-      <h2>External Audio Device</h2>
-      <p class="muted">Select the Windows playback device captured by External Audio.</p>
-      <div class="row">
-        <select id="external-audio-device"></select>
-        <button id="external-audio-refresh" type="button">Refresh</button>
-        <button id="external-audio-save" type="button">Save</button>
-      </div>
-      <p id="external-audio-hint" class="muted"></p>
-    `;
-
-    const sources = $("#sources");
-    const sourceCard = sources?.closest?.(".card") || sources?.parentElement;
-    if (sourceCard?.parentElement) sourceCard.insertAdjacentElement("afterend", card);
-    else document.body.appendChild(card);
-
-    $("#external-audio-refresh", card).addEventListener("click", async () => {
-      await loadExternalAudioDevices(true);
-    });
-
-    $("#external-audio-save", card).addEventListener("click", async () => {
-      const select = $("#external-audio-device", card);
-      try {
-        const r = await api.send("/api/external_audio/config", { endpoint_id: select.value }, "PUT");
-        extEndpoint = r.endpoint_id ?? select.value;
-        toast("External Audio device saved");
-        await loadExternalAudioDevices(true);
-      } catch (e) {
-        toast(e.message, true);
-      }
-    });
-
-    return card;
-  }
-
-  async function loadExternalAudioDevices(force = false) {
-    if (extLoaded && !force) return;
-    try {
-      const r = await api.get("/api/external_audio/devices");
-      extDevices = Array.isArray(r.devices) ? r.devices : [];
-      extEndpoint = r.endpoint_id || "";
-      extLoaded = true;
-      renderExternalAudioCard();
-    } catch {
-      extDevices = [];
-    }
-  }
-
-  function renderExternalAudioCard() {
-    const card = ensureExternalAudioCard();
-    const available = state?.sources?.available?.some(s => s.name === "external_audio");
-    card.hidden = !available;
-    if (!available) return;
-
-    loadExternalAudioDevices();
-
-    const select = $("#external-audio-device", card);
-    const sig = extEndpoint + "|" + extDevices.map(d => `${d.id}:${d.name}:${d.is_default}`).join("|");
-    if (select.dataset.sig === sig) return;
-    select.dataset.sig = sig;
-    select.innerHTML = "";
-    select.add(new Option("Default Windows playback device", "", false, extEndpoint === ""));
-    for (const d of extDevices) {
-      select.add(new Option(`${d.name || d.id}${d.is_default ? " (current default)" : ""}`, d.id, false, extEndpoint === d.id));
-    }
-    $("#external-audio-hint", card).textContent = extEndpoint ? "Saved endpoint id is selected." : "Empty value follows the current Windows default playback device.";
-  }
-
-  const baseRenderSources = renderSources;
-  renderSources = function() {
-    baseRenderSources();
-    renderExternalAudioCard();
-  };
-})();
   document.body.appendChild(el);
   setTimeout(() => el.remove(), 2400);
 };
@@ -160,7 +72,9 @@ function sourceDetailLine(s) {
 
 function renderSources() {
   const wrap = $("#sources");
-  const available = state?.sources?.available || [];
+  const allAvailable = state?.sources?.available || [];
+  const externalAudioEnabled = !!cfg?.external_audio?.enabled;
+  const available = allAvailable.filter(s => s.name !== "external_audio" || externalAudioEnabled);
   const active = state?.sources?.active;
   const sig = available.map(s =>
     `${s.name}:${s.playback_state}:${s.auth_state}:${s.details?.track_count ?? ""}:${s.name===active}`
@@ -194,6 +108,110 @@ function renderSources() {
 
   // Cast box only makes sense while Jellyfin is registered.
   $("#jf-cast-card").hidden = !available.some(s => s.name === "jellyfin");
+
+  renderExternalAudioCard();
+}
+
+let extDevices = [];
+let extEndpoint = "";
+let extLoaded = false;
+let extLoading = false;
+
+function ensureExternalAudioCard() {
+  let card = $("#external-audio-card");
+  if (card) return card;
+
+  card = document.createElement("section");
+  card.id = "external-audio-card";
+  card.className = "card";
+  card.hidden = true;
+  card.innerHTML = `
+    <h2>External Audio Device</h2>
+    <p class="muted">Select the Windows playback device captured by External Audio. Leave Default selected to follow the current Windows default playback device.</p>
+    <div class="row external-audio-row">
+      <select id="external-audio-device" aria-label="External Audio capture device"></select>
+      <button id="external-audio-refresh" class="ghost" type="button">Refresh</button>
+      <button id="external-audio-save" class="primary" type="button">Save</button>
+    </div>
+    <p id="external-audio-hint" class="muted"></p>
+  `;
+
+  const sources = $("#sources");
+  const sourceCard = sources?.closest?.(".card") || sources?.parentElement;
+  if (sourceCard?.parentElement) sourceCard.insertAdjacentElement("afterend", card);
+  else document.querySelector("main")?.appendChild(card);
+
+  $("#external-audio-refresh", card).addEventListener("click", async () => {
+    await loadExternalAudioDevices(true);
+  });
+
+  $("#external-audio-save", card).addEventListener("click", async () => {
+    const select = $("#external-audio-device", card);
+    try {
+      const enabled = !!cfg?.external_audio?.enabled;
+      const r = await api.send("/api/external_audio/config", { enabled, endpoint_id: select.value }, "PUT");
+      cfg = { ...(cfg || {}), external_audio: { ...(cfg?.external_audio || {}), enabled: !!r.enabled, endpoint_id: r.endpoint_id ?? select.value } };
+      extEndpoint = r.endpoint_id ?? select.value;
+      extLoaded = false;
+      state = await api.get("/api/state");
+      await loadExternalAudioDevices(true);
+      render();
+      toast("External Audio device saved");
+    } catch (e) {
+      toast(e.message, true);
+    }
+  });
+
+  return card;
+}
+
+async function loadExternalAudioDevices(force = false) {
+  if ((extLoaded && !force) || extLoading) return;
+  extLoading = true;
+  try {
+    const r = await api.get("/api/external_audio/devices");
+    extDevices = Array.isArray(r.devices) ? r.devices : [];
+    extEndpoint = r.endpoint_id || "";
+    extLoaded = true;
+  } catch {
+    extDevices = [];
+    extLoaded = false;
+  } finally {
+    extLoading = false;
+  }
+  renderExternalAudioCard();
+}
+
+function renderExternalAudioCard() {
+  const card = ensureExternalAudioCard();
+  const available = state?.sources?.available?.some(s => s.name === "external_audio");
+  const enabled = !!cfg?.external_audio?.enabled;
+  card.hidden = !enabled;
+  if (!enabled) return;
+
+  loadExternalAudioDevices();
+
+  const select = $("#external-audio-device", card);
+  const sig = `${extEndpoint}|${extDevices.map(d => `${d.id}:${d.name}:${d.is_default}`).join("|")}`;
+  if (select.dataset.sig !== sig) {
+    select.dataset.sig = sig;
+    select.innerHTML = "";
+    select.add(new Option("Default Windows playback device", "", false, extEndpoint === ""));
+    for (const d of extDevices) {
+      const label = `${d.name || d.id}${d.is_default ? " (current default)" : ""}`;
+      select.add(new Option(label, d.id, false, extEndpoint === d.id));
+    }
+  }
+
+  const active = state?.sources?.active === "external_audio";
+  const selected = extEndpoint
+    ? extDevices.find(d => d.id === extEndpoint)?.name || "saved endpoint"
+    : "current Windows default playback device";
+  $("#external-audio-hint", card).textContent = !available
+    ? `External Audio is enabled in settings, but the source is not registered yet. Saved capture device: ${selected}.`
+    : active
+      ? `External Audio is active. Capturing: ${selected}.`
+      : `External Audio is available. Saved capture device: ${selected}.`;
 }
 
 let volDirty = false;
@@ -236,6 +254,9 @@ const SCHEMA = [
     ["api_key",          "API Key",          "text"],
     ["default_playlist", "Default Playlist", "text"],
     ["shuffle",          "Shuffle",          "checkbox"],
+  ]],
+  ["external_audio", "External Audio", [
+    ["enabled",          "Enabled",          "checkbox"],
   ]],
   ["audio", "Audio", [
     ["output_gain", "Output gain", "number", 0, 1, 0.01],
@@ -395,6 +416,9 @@ function wire() {
   $("#save-config").onclick    = async () => {
     try {
       cfg = await api.send("/api/config", collectSettings(), "PUT");
+      extLoaded = false;
+      state = await api.get("/api/state");
+      render();
       toast("Saved");
       closeDrawer();
     } catch (e) { toast(e.message, true); }
@@ -434,5 +458,11 @@ function render() {
   }
 }
 
+async function startDashboard() {
+  try { cfg = await api.get("/api/config"); }
+  catch { cfg = {}; }
+  connect();
+}
+
 wire();
-connect();
+startDashboard();

--- a/ui/dist/app.js
+++ b/ui/dist/app.js
@@ -246,17 +246,11 @@ function renderExternalAudioCard() {
   }
 
   const active = state?.sources?.active === "external_audio";
-  const selected = extEndpoint
-    ? extDevices.find(d => d.id === extEndpoint)?.name || "saved endpoint"
-    : "current Windows default playback device";
-  const session = extMediaSessionId
-    ? extMediaSessions.find(s => s.id === extMediaSessionId)?.name || "saved media session"
-    : "current Windows media session";
   $("#external-audio-hint", card).textContent = !available
-    ? `External Audio is enabled in settings, but the source is not registered yet. Capture: ${selected}. Media session: ${session}.`
+    ? "Enabled, but the source hasn't registered yet."
     : active
-      ? `External Audio is active. Capturing: ${selected}. Metadata/control: ${session}.`
-      : `External Audio is available. Capture: ${selected}. Metadata/control: ${session}.`;
+      ? "Active and on air."
+      : "Ready. Switch to External Audio in Sources to go on air.";
 }
 
 let volDirty = false;

--- a/ui/dist/app.js
+++ b/ui/dist/app.js
@@ -31,6 +31,94 @@ const toast = (msg, isErr = false) => {
   const el = document.createElement("div");
   el.className = "toast" + (isErr ? " err" : "");
   el.textContent = msg;
+
+(() => {
+  let extDevices = [];
+  let extEndpoint = "";
+  let extLoaded = false;
+
+  function ensureExternalAudioCard() {
+    let card = $("#external-audio-card");
+    if (card) return card;
+
+    card = document.createElement("section");
+    card.id = "external-audio-card";
+    card.className = "card";
+    card.hidden = true;
+    card.innerHTML = `
+      <h2>External Audio Device</h2>
+      <p class="muted">Select the Windows playback device captured by External Audio.</p>
+      <div class="row">
+        <select id="external-audio-device"></select>
+        <button id="external-audio-refresh" type="button">Refresh</button>
+        <button id="external-audio-save" type="button">Save</button>
+      </div>
+      <p id="external-audio-hint" class="muted"></p>
+    `;
+
+    const sources = $("#sources");
+    const sourceCard = sources?.closest?.(".card") || sources?.parentElement;
+    if (sourceCard?.parentElement) sourceCard.insertAdjacentElement("afterend", card);
+    else document.body.appendChild(card);
+
+    $("#external-audio-refresh", card).addEventListener("click", async () => {
+      await loadExternalAudioDevices(true);
+    });
+
+    $("#external-audio-save", card).addEventListener("click", async () => {
+      const select = $("#external-audio-device", card);
+      try {
+        const r = await api.send("/api/external_audio/config", { endpoint_id: select.value }, "PUT");
+        extEndpoint = r.endpoint_id ?? select.value;
+        toast("External Audio device saved");
+        await loadExternalAudioDevices(true);
+      } catch (e) {
+        toast(e.message, true);
+      }
+    });
+
+    return card;
+  }
+
+  async function loadExternalAudioDevices(force = false) {
+    if (extLoaded && !force) return;
+    try {
+      const r = await api.get("/api/external_audio/devices");
+      extDevices = Array.isArray(r.devices) ? r.devices : [];
+      extEndpoint = r.endpoint_id || "";
+      extLoaded = true;
+      renderExternalAudioCard();
+    } catch {
+      extDevices = [];
+    }
+  }
+
+  function renderExternalAudioCard() {
+    const card = ensureExternalAudioCard();
+    const available = state?.sources?.available?.some(s => s.name === "external_audio");
+    card.hidden = !available;
+    if (!available) return;
+
+    loadExternalAudioDevices();
+
+    const select = $("#external-audio-device", card);
+    const sig = extEndpoint + "|" + extDevices.map(d => `${d.id}:${d.name}:${d.is_default}`).join("|");
+    if (select.dataset.sig === sig) return;
+    select.dataset.sig = sig;
+    select.innerHTML = "";
+    select.add(new Option("Default Windows playback device", "", false, extEndpoint === ""));
+    for (const d of extDevices) {
+      select.add(new Option(`${d.name || d.id}${d.is_default ? " (current default)" : ""}`, d.id, false, extEndpoint === d.id));
+    }
+    $("#external-audio-hint", card).textContent = extEndpoint ? "Saved endpoint id is selected." : "Empty value follows the current Windows default playback device.";
+  }
+
+  const baseRenderSources = renderSources;
+  renderSources = function() {
+    baseRenderSources();
+    renderExternalAudioCard();
+  };
+})();
   document.body.appendChild(el);
   setTimeout(() => el.remove(), 2400);
 };

--- a/ui/dist/app.js
+++ b/ui/dist/app.js
@@ -228,14 +228,13 @@ function renderExternalAudioCard() {
   }
 
   const sessionSelect = $("#external-audio-session", card);
-  const sessionSig = `${extMediaSessionId}|${extMediaSessionsAvailable}|${extMediaSessions.map(s => `${s.id}:${s.name}:${s.title}:${s.artist}:${s.is_current}`).join("|")}`;
+  const sessionSig = `${extMediaSessionId}|${extMediaSessionsAvailable}|${extMediaSessions.map(s => `${s.id}:${s.name}:${s.is_current}`).join("|")}`;
   if (sessionSelect.dataset.sig !== sessionSig) {
     sessionSelect.dataset.sig = sessionSig;
     sessionSelect.innerHTML = "";
     sessionSelect.add(new Option("Current Windows media session", "", false, extMediaSessionId === ""));
     for (const s of extMediaSessions) {
-      const now = s.title ? ` — ${s.title}${s.artist ? " / " + s.artist : ""}` : "";
-      const label = `${s.name || s.id}${s.is_current ? " (current)" : ""}${now}`;
+      const label = `${s.name || s.id}${s.is_current ? " (current)" : ""}`;
       sessionSelect.add(new Option(label, s.id, false, extMediaSessionId === s.id));
     }
     if (!extMediaSessionsAvailable) {

--- a/ui/dist/app.js
+++ b/ui/dist/app.js
@@ -114,6 +114,9 @@ function renderSources() {
 
 let extDevices = [];
 let extEndpoint = "";
+let extMediaSessions = [];
+let extMediaSessionId = "";
+let extMediaSessionsAvailable = false;
 let extLoaded = false;
 let extLoading = false;
 
@@ -126,11 +129,16 @@ function ensureExternalAudioCard() {
   card.className = "card";
   card.hidden = true;
   card.innerHTML = `
-    <h2>External Audio Device</h2>
-    <p class="muted">Select the Windows playback device captured by External Audio. Leave Default selected to follow the current Windows default playback device.</p>
+    <h2>External Audio</h2>
+    <p class="muted">Select the Windows playback device used for audio capture and the media session used for metadata and next/previous commands.</p>
+    <label class="external-audio-label" for="external-audio-device">Capture device</label>
     <div class="row external-audio-row">
       <select id="external-audio-device" aria-label="External Audio capture device"></select>
       <button id="external-audio-refresh" class="ghost" type="button">Refresh</button>
+    </div>
+    <label class="external-audio-label" for="external-audio-session">Media session</label>
+    <div class="row external-audio-row">
+      <select id="external-audio-session" aria-label="External Audio media session"></select>
       <button id="external-audio-save" class="primary" type="button">Save</button>
     </div>
     <p id="external-audio-hint" class="muted"></p>
@@ -146,17 +154,28 @@ function ensureExternalAudioCard() {
   });
 
   $("#external-audio-save", card).addEventListener("click", async () => {
-    const select = $("#external-audio-device", card);
+    const deviceSelect = $("#external-audio-device", card);
+    const sessionSelect = $("#external-audio-session", card);
     try {
       const enabled = !!cfg?.external_audio?.enabled;
-      const r = await api.send("/api/external_audio/config", { enabled, endpoint_id: select.value }, "PUT");
-      cfg = { ...(cfg || {}), external_audio: { ...(cfg?.external_audio || {}), enabled: !!r.enabled, endpoint_id: r.endpoint_id ?? select.value } };
-      extEndpoint = r.endpoint_id ?? select.value;
+      const r = await api.send("/api/external_audio/config", {
+        enabled,
+        endpoint_id: deviceSelect.value,
+        media_session_id: sessionSelect.value,
+      }, "PUT");
+      cfg = { ...(cfg || {}), external_audio: {
+        ...(cfg?.external_audio || {}),
+        enabled: !!r.enabled,
+        endpoint_id: r.endpoint_id ?? deviceSelect.value,
+        media_session_id: r.media_session_id ?? sessionSelect.value,
+      } };
+      extEndpoint = r.endpoint_id ?? deviceSelect.value;
+      extMediaSessionId = r.media_session_id ?? sessionSelect.value;
       extLoaded = false;
       state = await api.get("/api/state");
       await loadExternalAudioDevices(true);
       render();
-      toast("External Audio device saved");
+      toast("External Audio settings saved");
     } catch (e) {
       toast(e.message, true);
     }
@@ -172,9 +191,14 @@ async function loadExternalAudioDevices(force = false) {
     const r = await api.get("/api/external_audio/devices");
     extDevices = Array.isArray(r.devices) ? r.devices : [];
     extEndpoint = r.endpoint_id || "";
+    extMediaSessions = Array.isArray(r.media_sessions) ? r.media_sessions : [];
+    extMediaSessionId = r.media_session_id || "";
+    extMediaSessionsAvailable = !!r.media_sessions_available;
     extLoaded = true;
   } catch {
     extDevices = [];
+    extMediaSessions = [];
+    extMediaSessionsAvailable = false;
     extLoaded = false;
   } finally {
     extLoading = false;
@@ -191,15 +215,34 @@ function renderExternalAudioCard() {
 
   loadExternalAudioDevices();
 
-  const select = $("#external-audio-device", card);
-  const sig = `${extEndpoint}|${extDevices.map(d => `${d.id}:${d.name}:${d.is_default}`).join("|")}`;
-  if (select.dataset.sig !== sig) {
-    select.dataset.sig = sig;
-    select.innerHTML = "";
-    select.add(new Option("Default Windows playback device", "", false, extEndpoint === ""));
+  const deviceSelect = $("#external-audio-device", card);
+  const deviceSig = `${extEndpoint}|${extDevices.map(d => `${d.id}:${d.name}:${d.is_default}`).join("|")}`;
+  if (deviceSelect.dataset.sig !== deviceSig) {
+    deviceSelect.dataset.sig = deviceSig;
+    deviceSelect.innerHTML = "";
+    deviceSelect.add(new Option("Default Windows playback device", "", false, extEndpoint === ""));
     for (const d of extDevices) {
       const label = `${d.name || d.id}${d.is_default ? " (current default)" : ""}`;
-      select.add(new Option(label, d.id, false, extEndpoint === d.id));
+      deviceSelect.add(new Option(label, d.id, false, extEndpoint === d.id));
+    }
+  }
+
+  const sessionSelect = $("#external-audio-session", card);
+  const sessionSig = `${extMediaSessionId}|${extMediaSessionsAvailable}|${extMediaSessions.map(s => `${s.id}:${s.name}:${s.title}:${s.artist}:${s.is_current}`).join("|")}`;
+  if (sessionSelect.dataset.sig !== sessionSig) {
+    sessionSelect.dataset.sig = sessionSig;
+    sessionSelect.innerHTML = "";
+    sessionSelect.add(new Option("Current Windows media session", "", false, extMediaSessionId === ""));
+    for (const s of extMediaSessions) {
+      const now = s.title ? ` — ${s.title}${s.artist ? " / " + s.artist : ""}` : "";
+      const label = `${s.name || s.id}${s.is_current ? " (current)" : ""}${now}`;
+      sessionSelect.add(new Option(label, s.id, false, extMediaSessionId === s.id));
+    }
+    if (!extMediaSessionsAvailable) {
+      sessionSelect.add(new Option("Media session API is not available in this build", "", false, true));
+      sessionSelect.disabled = true;
+    } else {
+      sessionSelect.disabled = false;
     }
   }
 
@@ -207,11 +250,14 @@ function renderExternalAudioCard() {
   const selected = extEndpoint
     ? extDevices.find(d => d.id === extEndpoint)?.name || "saved endpoint"
     : "current Windows default playback device";
+  const session = extMediaSessionId
+    ? extMediaSessions.find(s => s.id === extMediaSessionId)?.name || "saved media session"
+    : "current Windows media session";
   $("#external-audio-hint", card).textContent = !available
-    ? `External Audio is enabled in settings, but the source is not registered yet. Saved capture device: ${selected}.`
+    ? `External Audio is enabled in settings, but the source is not registered yet. Capture: ${selected}. Media session: ${session}.`
     : active
-      ? `External Audio is active. Capturing: ${selected}.`
-      : `External Audio is available. Saved capture device: ${selected}.`;
+      ? `External Audio is active. Capturing: ${selected}. Metadata/control: ${session}.`
+      : `External Audio is available. Capture: ${selected}. Metadata/control: ${session}.`;
 }
 
 let volDirty = false;

--- a/ui/dist/styles.css
+++ b/ui/dist/styles.css
@@ -35,7 +35,7 @@ body {
 
 button { font: inherit; color: inherit; }
 
-input, output { font: inherit; color: inherit; }
+input, output, select { font: inherit; color: inherit; }
 
 h1, h2 { margin: 0; font-weight: 600; letter-spacing: .2px; }
 
@@ -200,13 +200,15 @@ main {
   display: flex; gap: 8px; align-items: center;
 }
 
-input[type="text"], input[type="number"] {
+.external-audio-row select { flex: 1; min-width: 0; }
+
+input[type="text"], input[type="number"], select {
   flex: 1; min-width: 0;
   background: var(--panel-2); border: 1px solid var(--line); border-radius: 8px;
   padding: 10px 12px; color: var(--text);
 }
 
-input[type="text"]:focus, input[type="number"]:focus {
+input[type="text"]:focus, input[type="number"]:focus, select:focus {
   outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px rgba(182,255,60,0.15);
 }
 

--- a/ui/dist/styles.css
+++ b/ui/dist/styles.css
@@ -201,6 +201,7 @@ main {
 }
 
 .external-audio-row select { flex: 1; min-width: 0; }
+
 .external-audio-label { display: block; margin: 12px 0 6px; color: var(--muted); font-size: 0.9rem; }
 
 input[type="text"], input[type="number"], select {

--- a/ui/dist/styles.css
+++ b/ui/dist/styles.css
@@ -201,6 +201,7 @@ main {
 }
 
 .external-audio-row select { flex: 1; min-width: 0; }
+.external-audio-label { display: block; margin: 12px 0 6px; color: var(--muted); font-size: 0.9rem; }
 
 input[type="text"], input[type="number"], select {
   flex: 1; min-width: 0;


### PR DESCRIPTION
## Summary

This PR adds an optional `external_audio` source.

It allows the dashboard to enable External Audio, select a Windows playback/capture endpoint for audio capture, and select a Windows media session for metadata and media controls.

The feature is disabled by default.

Default config:

* `[external_audio]`
* `enabled = false`
* `endpoint_id = ""`
* `media_session_id = ""`

When disabled, External Audio is not registered as a source and is hidden from the dashboard.

## Behavior

* External Audio is hidden by default.
* External Audio can be enabled from the Settings drawer.
* The dashboard allows selecting a capture device.
* The dashboard allows selecting a media session for metadata/control.
* Metadata is read from the selected Windows media session.
* Next/Previous actions are sent to the selected media session.
* Switching to/from External Audio does not send Play/Pause to the external media session.

## Notes

The existing `local_files`, `youtube_music`, `jellyfin`, FMOD/DSP, and playback pipeline are not modified.

External Audio is added as a separate source and is only registered when `external_audio.enabled` is true.

## Tested

* Local Windows build with `scripts/build.ps1`
* GitHub Actions build
* `npm run check`
* External Audio hidden by default
* External Audio enable/disable persists to `config.toml`
* Capture device selection from dashboard
* Media session selection from dashboard
* Metadata appears from the selected media session
* Next/quick station skip controls the selected media session
* Switching sources does not pause/play the selected external media session

## Test setup

The audio device used for testing was `HiFiCableAsioBridge`.

Browser tab audio routing was tested with the `AuRo` browser extension.

The virtual cable devices were configured as:

* 2 channels
* 24-bit
* 48000 Hz

During testing, higher sample rates caused audible clicks and audio artifacts. Using 48000 Hz avoided those issues in this setup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External Audio: capture system playback with device enumeration, selection, and media-session metadata + transport controls.
  * Configurable: enable/disable external audio, choose capture endpoint and media session, and control playback/position.
  * HTTP API: list devices/media sessions and update external-audio settings remotely.
  * Playback behavior: improved audibility detection that pauses/resumes sources and gates metadata updates when station is silent.

* **Documentation**
  * README and examples updated with External Audio setup and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->