### PR TITLE
fix: watch?v=...&list=... YouTube playlists cause infinite loop

### DIFF
--- a/src/sources/youtube_music_source.cpp
+++ b/src/sources/youtube_music_source.cpp
@@ -38,7 +38,7 @@ std::string drain_to_eof(HANDLE pipe) {
 }
 
 bool is_playlist_url(std::string_view url) {
-    return url.find("playlist?") != std::string_view::npos;
+    return url.find("playlist?") != std::string_view::npos || url.find("list=") != std::string_view::npos;;
 }
 
 std::string watch_url_for_id(std::string_view id) {


### PR DESCRIPTION
Hi! Thanks for the awesome mod.

I found a small bug: pasting a playlist URL directly from an active video (which has the format watch?v=...&list=...) causes the radio to repeat the same track infinitely instead of advancing. This happens because is_playlist_url in src/sources/youtube_music_source.cpp strictly checks for "playlist?".

I fixed it locally by also checking for the "list=" parameter. This approach adds two great benefits:

- It allows users to directly paste auto-generated YouTube Mixes without issues.

- It fully maintains support for clean links copied from a playlist's root page.

Here is the updated function:

```
bool is_playlist_url(std::string_view url) {
    return url.find("playlist?") != std::string_view::npos || 
           url.find("list=") != std::string_view::npos;
}
```

Tested locally and works perfectly. Would be great to see this merged!



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced YouTube Music playlist detection to properly recognize a broader range of playlist URL formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->