### PR TITLE
fix(subprocess): make AssignProcessToJobObject best-effort under Wine/Proton

### DIFF
--- a/src/subprocess.cpp
+++ b/src/subprocess.cpp
@@ -147,15 +147,12 @@ HANDLE spawn_in_job(HANDLE job, const std::wstring& cmd, HANDLE stdin_h, HANDLE 
             return nullptr;
         }
     }
-    if (job && !AssignProcessToJobObject(job, pi.hProcess)) {
-        // Preserve the AssignProcessToJobObject error across the cleanup calls so
-        // the caller's GetLastError() reflects the real cause, not CloseHandle's.
-        const DWORD assign_ec = GetLastError();
-        TerminateProcess(pi.hProcess, 1);
-        CloseHandle(pi.hThread);
-        CloseHandle(pi.hProcess);
-        SetLastError(assign_ec);
-        return nullptr;
+    if (job) {
+        // Best-effort: Job Objects are not fully implemented under Wine/Proton.
+        // If AssignProcessToJobObject fails (common under Wine), we continue
+        // without job containment rather than killing the child process.
+        // On native Windows this succeeds and gives us kill-on-close semantics.
+        AssignProcessToJobObject(job, pi.hProcess);
     }
     ResumeThread(pi.hThread);
     CloseHandle(pi.hThread);


### PR DESCRIPTION

## Problem

YouTube Music playback does not work under Wine/Proton on Linux. The dashboard shows YouTube Music permanently stuck in **STOPPED**, the stderr log (`%TEMP%\fh6-stderr.log`) remains empty, and no audio is produced regardless of what URL is cast.

## Root Cause

`AssignProcessToJobObject` fails silently under Wine because Job Objects are not fully implemented in Wine/Proton. The previous code treated this failure as fatal:

```cpp
if (job && !AssignProcessToJobObject(job, pi.hProcess)) {
    TerminateProcess(pi.hProcess, 1);  // kills yt-dlp immediately
    CloseHandle(pi.hThread);
    CloseHandle(pi.hProcess);
    SetLastError(assign_ec);
    return nullptr;  // returns nullptr with no log entry
}
```

This terminated the `yt-dlp` child process before it could produce any output. Because this failure path does not write to the stderr log, there was no diagnostic — the feature appeared broken with no indication of why.

Confirmed by manually running `yt-dlp.exe` inside the Wine prefix, which worked correctly and resolved JS challenges via `deno`:

```
[youtube] Extracting URL: https://www.youtube.com/watch?v=...
[youtube] dQw4w9WgXcQ: Downloading webpage
[youtube] [jsc:deno] Solving JS challenges using deno
```

## Fix

Make `AssignProcessToJobObject` best-effort. On native Windows it succeeds and kill-on-close semantics are preserved as before. Under Wine it fails, but the child process continues running normally without job containment.

```cpp
if (job) {
    // Best-effort: Job Objects are not fully implemented under Wine/Proton.
    // If AssignProcessToJobObject fails (common under Wine), we continue
    // without job containment rather than killing the child process.
    // On native Windows this succeeds and gives us kill-on-close semantics.
    AssignProcessToJobObject(job, pi.hProcess);
}
```

## Testing

- **OS:** Fedora 44
- **Proton:** Proton Hotfix `hotfix-20260529-fh6`
- **Toolchain:** llvm-mingw `20260421-ucrt`
- **Launch options:** `WINEDLLOVERRIDES="version=n,b" %command%`
- Built from source using `scripts/build.sh` + `scripts/install.sh`
- YouTube Music playback (single video URL) confirmed working after the fix
- Local file playback unaffected
- Native Windows behavior unaffected (the assignment still runs, only the fatal error path is removed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced subprocess spawning reliability by making job containment assignment more resilient in limited environments. Spawn operations now proceed gracefully when job containment features aren't available, improving compatibility and reducing unexpected process terminations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->