### PR TITLE
feat(dashboard): redesign UI with tabbed navigation and interactive player

### DIFF
--- a/include/fh6/http/http_server.hpp
+++ b/include/fh6/http/http_server.hpp
@@ -22,7 +22,7 @@ namespace fh6::http {
 //
 //   GET  /api/sources                     registered sources
 //   POST /api/source/switch               body {"source":"name"}
-//   POST /api/source/<name>/{play,pause,stop,next,previous}
+//   POST /api/source/<name>/{play,pause,stop,next,previous,seek}
 //
 //   POST /api/source/youtube_music/cast   body {"url":"..."}
 //   POST /api/source/local_files/rescan   body {"music_dir":"...","recursive":bool}

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -643,6 +643,12 @@ struct HttpServer::Impl {
             else if (act == "stop")     { s->stop();     if (is_active) mgr.ring().drain(); }
             else if (act == "next")     { s->next();     if (is_active) mgr.ring().drain(); }
             else if (act == "previous") { s->previous(); if (is_active) mgr.ring().drain(); }
+            else if (act == "seek") {
+                auto j = req.body.empty() ? json::object() : json::parse(req.body);
+                const auto pos = static_cast<uint64_t>(std::max<int64_t>(0, j.value("position_ms", int64_t{0})));
+                s->seek(pos);
+                if (is_active) mgr.ring().drain();
+            }
             else return fail(404, "unknown action");
             return ok();
         }

--- a/ui/dist/app.js
+++ b/ui/dist/app.js
@@ -38,27 +38,90 @@ const toast = (msg, isErr = false) => {
 // Only write when the displayed value changes, to avoid cursor jumps in inputs.
 const setText = (el, v) => { if (el && el.textContent !== String(v)) el.textContent = v; };
 
+// ── Smooth progress interpolation ──────────────────────────────────────────
+// Between server updates (~1 s), animate the fill in real time.
+let _raf = null;
+let _progressBase = { pos: 0, ts: 0, dur: 0 };
+
+function stopProgressTick() {
+  if (_raf) { cancelAnimationFrame(_raf); _raf = null; }
+}
+
+function startProgressTick() {
+  stopProgressTick();
+  const tick = () => {
+    if (!_progressBase.dur) { _raf = null; return; }
+    const pos = Math.min(_progressBase.pos + (Date.now() - _progressBase.ts), _progressBase.dur);
+    const pct = (pos / _progressBase.dur) * 100;
+    const fill = $("#np-fill");
+    if (fill) fill.style.width = pct + "%";
+    const posEl = $("#np-pos");
+    const str = fmt(pos);
+    if (posEl && posEl.textContent !== str) posEl.textContent = str;
+    _raf = requestAnimationFrame(tick);
+  };
+  _raf = requestAnimationFrame(tick);
+}
+
+// ── Tab navigation ─────────────────────────────────────────────────────────
+function switchTab(name) {
+  $$(".tab").forEach(t => t.classList.toggle("active", t.dataset.tab === name));
+  $$(".tab-panel").forEach(p => p.classList.toggle("hidden", p.id !== `panel-${name}`));
+}
+
+// ── Render functions ───────────────────────────────────────────────────────
 function renderStatus() {
   const ok = state?.game?.attached;
-  const sub = $("#status");
-  sub.className = "subtitle " + (ok ? "ok" : "err");
-  sub.textContent = ok ? "connected" : "bridge offline";
+  const el = $("#status");
+  el.className = "status-pill " + (ok ? "ok" : "err");
+  el.textContent = ok ? "connected" : "bridge offline";
 }
 
 function renderNowPlaying() {
-  const t = state?.track || {};
-  const a = state?.sources?.active;
-  setText($("#np-title"),  t.title  || "Nothing playing");
-  setText($("#np-artist"), t.artist ? `${t.artist}${t.album ? " · " + t.album : ""}` : "");
-  setText($("#np-pos"), fmt(t.position_ms));
-  setText($("#np-dur"), fmt(t.duration_ms));
-  const pct = (t.duration_ms && t.position_ms)
-    ? Math.min(100, (t.position_ms / t.duration_ms) * 100)
-    : 0;
-  $("#np-fill").style.width = pct + "%";
-
+  const t   = state?.track || {};
+  const a   = state?.sources?.active;
   const src = state?.sources?.available?.find(s => s.name === a);
   const playing = src?.playback_state === "playing";
+
+  setText($("#np-title"),  t.title  || "Nothing playing");
+  setText($("#np-artist"), t.artist ? `${t.artist}${t.album ? " · " + t.album : ""}` : "");
+
+  // Source name pill above the track title.
+  setText($("#np-source"), src?.display_name || "");
+
+  // Album artwork — show real image when available, CSS vinyl ring otherwise.
+  const art = $("#np-art");
+  const artUrl = t.artwork_url || "";
+  if (art.dataset.artUrl !== artUrl) {
+    art.dataset.artUrl = artUrl;
+    if (artUrl) {
+      art.classList.add("has-art");
+      art.innerHTML = `<img src="${artUrl}" alt="">`;
+    } else {
+      art.classList.remove("has-art");
+      art.innerHTML = "";
+    }
+  }
+
+  // Seekable bar — only interactive when the active source supports it.
+  const bar = $("#np-bar");
+  const canSeek = !!(src?.capabilities?.seek) && !!t.duration_ms;
+  bar.classList.toggle("seekable", canSeek);
+
+  // Progress — live RAF interpolation while playing, static update otherwise.
+  const pos = t.position_ms || 0;
+  const dur = t.duration_ms || 0;
+  if (playing && dur) {
+    _progressBase = { pos, ts: Date.now(), dur };
+    startProgressTick();
+  } else {
+    stopProgressTick();
+    const pct = dur ? Math.min(100, (pos / dur) * 100) : 0;
+    $("#np-fill").style.width = pct + "%";
+    setText($("#np-pos"), fmt(pos));
+  }
+  setText($("#np-dur"), fmt(dur));
+
   $("#t-play").textContent = playing ? "⏸" : "▶";
 }
 
@@ -77,7 +140,7 @@ function renderSources() {
   const available = allAvailable.filter(s => s.name !== "external_audio" || externalAudioEnabled);
   const active = state?.sources?.active;
   const sig = available.map(s =>
-    `${s.name}:${s.playback_state}:${s.auth_state}:${s.details?.track_count ?? ""}:${s.name===active}`
+    `${s.name}:${s.playback_state}:${s.auth_state}:${s.details?.track_count ?? ""}:${s.name===active}:${s.details?.shuffle ?? ""}`
   ).join("|");
   if (wrap.dataset.sig === sig) return;
   wrap.dataset.sig = sig;
@@ -89,11 +152,22 @@ function renderSources() {
     tile.type = "button";
     const stateCls = s.auth_state === "needs_auth" ? "warn"
                    : s.auth_state === "error"       ? "err" : "";
-    const detail = sourceDetailLine(s);
+    const detail   = sourceDetailLine(s);
     const showNote = (s.auth_state === "needs_auth" || s.auth_state === "error") && s.auth_instructions;
+    const isPlaying = s.name === active && s.playback_state === "playing";
+
+    const waveform = isPlaying
+      ? `<span class="waveform" aria-hidden="true"><i></i><i></i><i></i><i></i></span>` : "";
+    const shuffleBadge = s.name === "youtube_music" && s.details?.shuffle
+      ? ` <span class="src-badge">shuffle</span>` : "";
+
+    const stateText = `${s.playback_state}`
+      + (s.auth_state !== "none_required" ? " · " + s.auth_state.replace("_", " ") : "")
+      + (detail ? " · " + detail : "");
+
     tile.innerHTML = `
-      <div class="name">${s.display_name}</div>
-      <div class="state ${stateCls}">${s.playback_state}${s.auth_state !== "none_required" ? " - " + s.auth_state.replace("_", " ") : ""}${detail ? " - " + detail : ""}</div>
+      <div class="name">${s.display_name}${waveform}${shuffleBadge}</div>
+      <div class="state ${stateCls}">${stateText}</div>
       ${showNote ? `<div class="auth-note">${s.auth_instructions}</div>` : ""}
     `;
     tile.addEventListener("click", async () => {
@@ -103,15 +177,13 @@ function renderSources() {
     wrap.appendChild(tile);
   }
 
-  // Cast box only makes sense while YT is registered.
   $("#yt-cast-card").hidden = !available.some(s => s.name === "youtube_music");
-
-  // Cast box only makes sense while Jellyfin is registered.
   $("#jf-cast-card").hidden = !available.some(s => s.name === "jellyfin");
 
   renderExternalAudioCard();
 }
 
+// ── External Audio card (dynamically injected into Sources tab) ────────────
 let extDevices = [];
 let extEndpoint = "";
 let extMediaSessions = [];
@@ -124,7 +196,7 @@ function ensureExternalAudioCard() {
   let card = $("#external-audio-card");
   if (card) return card;
 
-  card = document.createElement("section");
+  card = document.createElement("div");
   card.id = "external-audio-card";
   card.className = "card";
   card.hidden = true;
@@ -154,31 +226,29 @@ function ensureExternalAudioCard() {
   });
 
   $("#external-audio-save", card).addEventListener("click", async () => {
-    const deviceSelect = $("#external-audio-device", card);
+    const deviceSelect  = $("#external-audio-device", card);
     const sessionSelect = $("#external-audio-session", card);
     try {
       const enabled = !!cfg?.external_audio?.enabled;
       const r = await api.send("/api/external_audio/config", {
         enabled,
-        endpoint_id: deviceSelect.value,
+        endpoint_id:      deviceSelect.value,
         media_session_id: sessionSelect.value,
       }, "PUT");
       cfg = { ...(cfg || {}), external_audio: {
         ...(cfg?.external_audio || {}),
-        enabled: !!r.enabled,
-        endpoint_id: r.endpoint_id ?? deviceSelect.value,
+        enabled:          !!r.enabled,
+        endpoint_id:      r.endpoint_id      ?? deviceSelect.value,
         media_session_id: r.media_session_id ?? sessionSelect.value,
       } };
-      extEndpoint = r.endpoint_id ?? deviceSelect.value;
+      extEndpoint      = r.endpoint_id      ?? deviceSelect.value;
       extMediaSessionId = r.media_session_id ?? sessionSelect.value;
       extLoaded = false;
       state = await api.get("/api/state");
       await loadExternalAudioDevices(true);
       render();
       toast("External Audio settings saved");
-    } catch (e) {
-      toast(e.message, true);
-    }
+    } catch (e) { toast(e.message, true); }
   });
 
   return card;
@@ -189,28 +259,22 @@ async function loadExternalAudioDevices(force = false) {
   extLoading = true;
   try {
     const r = await api.get("/api/external_audio/devices");
-    extDevices = Array.isArray(r.devices) ? r.devices : [];
-    extEndpoint = r.endpoint_id || "";
-    extMediaSessions = Array.isArray(r.media_sessions) ? r.media_sessions : [];
-    extMediaSessionId = r.media_session_id || "";
+    extDevices             = Array.isArray(r.devices)       ? r.devices       : [];
+    extEndpoint            = r.endpoint_id || "";
+    extMediaSessions       = Array.isArray(r.media_sessions) ? r.media_sessions : [];
+    extMediaSessionId      = r.media_session_id || "";
     extMediaSessionsAvailable = !!r.media_sessions_available;
     extLoaded = true;
   } catch {
-    extDevices = [];
-    extMediaSessions = [];
-    extMediaSessionsAvailable = false;
-    extLoaded = false;
-  } finally {
-    extLoading = false;
-  }
+    extDevices = []; extMediaSessions = []; extMediaSessionsAvailable = false; extLoaded = false;
+  } finally { extLoading = false; }
   renderExternalAudioCard();
 }
 
 function renderExternalAudioCard() {
-  const card = ensureExternalAudioCard();
-  const available = state?.sources?.available?.some(s => s.name === "external_audio");
+  const card    = ensureExternalAudioCard();
   const enabled = !!cfg?.external_audio?.enabled;
-  card.hidden = !enabled;
+  card.hidden   = !enabled;
   if (!enabled) return;
 
   loadExternalAudioDevices();
@@ -237,32 +301,57 @@ function renderExternalAudioCard() {
       const label = `${s.name || s.id}${s.is_current ? " (current)" : ""}`;
       sessionSelect.add(new Option(label, s.id, false, extMediaSessionId === s.id));
     }
-    if (!extMediaSessionsAvailable) {
+    sessionSelect.disabled = !extMediaSessionsAvailable;
+    if (!extMediaSessionsAvailable)
       sessionSelect.add(new Option("Media session API is not available in this build", "", false, true));
-      sessionSelect.disabled = true;
-    } else {
-      sessionSelect.disabled = false;
-    }
   }
 
   const active = state?.sources?.active === "external_audio";
+  const available = state?.sources?.available?.some(s => s.name === "external_audio");
   $("#external-audio-hint", card).textContent = !available
     ? "Enabled, but the source hasn't registered yet."
-    : active
-      ? "Active and on air."
-      : "Ready. Switch to External Audio in Sources to go on air.";
+    : active ? "Active and on air."
+             : "Ready. Switch to External Audio in Sources to go on air.";
 }
 
+// ── Output ─────────────────────────────────────────────────────────────────
 let volDirty = false;
+
 function renderOutput() {
   const gain = state?.audio?.output_gain ?? 0;
   if (!volDirty) {
     const slider = $("#vol");
     if (Math.abs(parseFloat(slider.value) - gain) > 0.005) slider.value = gain;
-    $("#vol-out").value = Math.round(gain * 100) + "%";
+    const pct = Math.round(gain * 100);
+    $("#vol-out").value = pct + "%";
+    setVolFill(slider, pct);
   }
 }
 
+function setVolFill(slider, pct) {
+  slider.style.background =
+    `linear-gradient(to right, var(--accent) ${pct}%, var(--line) ${pct}%)`;
+}
+
+function renderAudioStats() {
+  const panel = $("#audio-stats");
+  if (!panel) return;
+  const audio = state?.audio || {};
+  const rows = [
+    { label: "DSP Mode",  value: audio.native_dsp_mode || "—" },
+    { label: "Underruns", value: audio.underruns ?? "—", warn: (audio.underruns ?? 0) > 0 },
+    { label: "Ring",      value: audio.ring_capacity ? `${audio.ring_avail}/${audio.ring_capacity}` : "—" },
+    { label: "Channels",  value: audio.out_channels ?? "—" },
+  ];
+  const sig = rows.map(r => r.value).join("|");
+  if (panel.dataset.sig === sig) return;
+  panel.dataset.sig = sig;
+  panel.innerHTML = rows.map(r =>
+    `<div class="stat"><div class="label">${r.label}</div><div class="value${r.warn ? " warn" : ""}">${r.value}</div></div>`
+  ).join("");
+}
+
+// ── Settings schema ────────────────────────────────────────────────────────
 const EQ_BAND_LABELS = ["60 Hz", "250 Hz", "1 kHz", "4 kHz", "12 kHz"];
 
 const SCHEMA = [
@@ -274,10 +363,10 @@ const SCHEMA = [
     ["ffmpeg_path",     "ffmpeg path (optional)", "text"],
   ]],
   ["local_files", "Local files", [
-    ["enabled",     "Enabled",        "checkbox"],
-    ["music_dir",   "Music directory","text"],
-    ["recursive",   "Scan subfolders","checkbox"],
-    ["shuffle",     "Shuffle",        "checkbox"],
+    ["enabled",   "Enabled",        "checkbox"],
+    ["music_dir", "Music directory","text"],
+    ["recursive", "Scan subfolders","checkbox"],
+    ["shuffle",   "Shuffle",        "checkbox"],
   ]],
   ["youtube_music", "YouTube Music", [
     ["enabled",          "Enabled",                "checkbox"],
@@ -296,19 +385,19 @@ const SCHEMA = [
     ["shuffle",          "Shuffle",          "checkbox"],
   ]],
   ["external_audio", "External Audio", [
-    ["enabled",          "Enabled",          "checkbox"],
+    ["enabled", "Enabled", "checkbox"],
   ]],
   ["audio", "Audio", [
     ["output_gain", "Output gain", "number", 0, 1, 0.01],
   ]],
   ["playback", "Playback", [
-    ["race_start_playback",  "Race start",                "select",   ["next", "restart", "ignore"]],
-    ["quick_station_skip",   "Quick station skip",        "checkbox"],
-    ["volume_normalization", "Normalize loudness",        "checkbox"],
-    ["equalizer_enabled",    "Equalizer",                 "checkbox"],
-    ["equalizer_bands",      "Equalizer bands",           "bands"],
-    ["force_stereo_audio",   "Force stereo audio",        "checkbox"],
-    ["prebuffer_next_track", "Pre-buffer next track",     "checkbox"],
+    ["race_start_playback",  "Race start",            "select",   ["next", "restart", "ignore"]],
+    ["quick_station_skip",   "Quick station skip",    "checkbox"],
+    ["volume_normalization", "Normalize loudness",    "checkbox"],
+    ["equalizer_enabled",    "Equalizer",             "checkbox"],
+    ["equalizer_bands",      "Equalizer bands",       "bands"],
+    ["force_stereo_audio",   "Force stereo audio",    "checkbox"],
+    ["prebuffer_next_track", "Pre-buffer next track", "checkbox"],
   ]],
 ];
 
@@ -340,9 +429,7 @@ function field(section, [key, label, type, a, b, c]) {
       </div>`).join("");
     return `<div class="field bands"><label>${label}</label>${rows}</div>`;
   }
-  const attrs = type === "number"
-    ? ` min="${a ?? ''}" max="${b ?? ''}" step="${c ?? 1}"`
-    : "";
+  const attrs = type === "number" ? ` min="${a ?? ''}" max="${b ?? ''}" step="${c ?? 1}"` : "";
   return `<div class="field">
     <label for="${id}">${label}</label>
     <input id="${id}" type="${type}" data-section="${section}" data-key="${key}"${attrs} value="${cur ?? ''}">
@@ -354,7 +441,6 @@ function renderSettings() {
   form.innerHTML = SCHEMA.map(([sec, title, fields]) =>
     `<fieldset><legend>${title}</legend>${fields.map(f => field(sec, f)).join("")}</fieldset>`
   ).join("");
-  // Live "X.X dB" readout next to each EQ slider.
   $$(".field.bands input[type='range']", form).forEach(r => {
     const out = r.nextElementSibling;
     r.addEventListener("input", () => { out.textContent = `${parseFloat(r.value).toFixed(1)} dB`; });
@@ -372,14 +458,14 @@ function collectSettings() {
       arr[parseInt(el.dataset.index, 10)] = parseFloat(el.value);
       return;
     }
-    if (el.type === "checkbox")     patch[sec][key] = el.checked;
-    else if (el.type === "number" ||
-             el.type === "range")   patch[sec][key] = parseFloat(el.value);
-    else                            patch[sec][key] = el.value;
+    if (el.type === "checkbox")                    patch[sec][key] = el.checked;
+    else if (el.type === "number" || el.type === "range") patch[sec][key] = parseFloat(el.value);
+    else                                           patch[sec][key] = el.value;
   });
   return patch;
 }
 
+// ── Drawer ─────────────────────────────────────────────────────────────────
 function openDrawer() {
   $("#drawer").classList.add("open");
   $("#scrim").hidden = false;
@@ -391,10 +477,10 @@ function closeDrawer() {
   $("#drawer").setAttribute("aria-hidden", "true");
 }
 
+// ── Transport ──────────────────────────────────────────────────────────────
 async function transport(action) {
   const src = state?.sources?.active;
   if (!src) return;
-  // Centre button is a smart play/pause toggle.
   if (action === "play") {
     const s = state.sources.available.find(x => x.name === src);
     if (s?.playback_state === "playing") action = "pause";
@@ -403,15 +489,38 @@ async function transport(action) {
   catch (e) { toast(e.message, true); }
 }
 
+// ── Wire up all interactivity ──────────────────────────────────────────────
 function wire() {
+  // Tab navigation
+  $$(".tab").forEach(tab => tab.addEventListener("click", () => switchTab(tab.dataset.tab)));
+
+  // Transport buttons
   $("#t-play").onclick = () => transport("play");
   $("#t-next").onclick = () => transport("next");
   $("#t-prev").onclick = () => transport("previous");
 
+  // Seekable progress bar — click jumps to that position.
+  $("#np-bar").addEventListener("click", async e => {
+    const src = state?.sources?.active;
+    if (!src) return;
+    const s = state?.sources?.available?.find(x => x.name === src);
+    if (!s?.capabilities?.seek || !state?.track?.duration_ms) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const pct  = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+    const pos  = Math.floor(pct * state.track.duration_ms);
+    _progressBase = { pos, ts: Date.now(), dur: state.track.duration_ms };
+    $("#np-fill").style.width = (pct * 100) + "%";
+    try { await api.send(`/api/source/${src}/seek`, { position_ms: pos }); }
+    catch (err) { toast(err.message, true); }
+  });
+
+  // Volume slider with accent fill
   const vol = $("#vol");
   vol.addEventListener("input", () => {
     volDirty = true;
-    $("#vol-out").value = Math.round(parseFloat(vol.value) * 100) + "%";
+    const pct = Math.round(parseFloat(vol.value) * 100);
+    $("#vol-out").value = pct + "%";
+    setVolFill(vol, pct);
   });
   vol.addEventListener("change", async () => {
     try { await api.send("/api/options", { output_gain: parseFloat(vol.value) }); }
@@ -419,38 +528,41 @@ function wire() {
     setTimeout(() => { volDirty = false; }, 400);
   });
 
+  // Keyboard shortcuts: Space = play/pause, ← = previous, → = next
+  document.addEventListener("keydown", e => {
+    if (e.target.matches("input, select, textarea, [contenteditable]")) return;
+    if      (e.code === "Space")      { e.preventDefault(); transport("play"); }
+    else if (e.code === "ArrowRight") { e.preventDefault(); transport("next"); }
+    else if (e.code === "ArrowLeft")  { e.preventDefault(); transport("previous"); }
+  });
+
+  // YouTube Music cast
   $("#yt-cast").addEventListener("submit", async e => {
     e.preventDefault();
     const url = $("#yt-url").value.trim();
     if (!url) return;
-    try {
-      await api.send("/api/source/youtube_music/cast", { url });
-      $("#yt-url").value = "";
-      toast("Casting...");
-    } catch (err) { toast(err.message, true); }
+    try { await api.send("/api/source/youtube_music/cast", { url }); $("#yt-url").value = ""; toast("Casting..."); }
+    catch (err) { toast(err.message, true); }
   });
 
   $("#yt-shuffle").addEventListener("click", async () => {
     const yt = state?.sources?.available?.find(s => s.name === "youtube_music");
     if (!yt) return;
     const shuffle = !yt.details?.shuffle;
-    try {
-      await api.send("/api/source/youtube_music/shuffle", { shuffle });
-      toast(shuffle ? "Shuffle on" : "Shuffle off");
-    } catch (err) { toast(err.message, true); }
+    try { await api.send("/api/source/youtube_music/shuffle", { shuffle }); toast(shuffle ? "Shuffle on" : "Shuffle off"); }
+    catch (err) { toast(err.message, true); }
   });
 
+  // Jellyfin cast
   $("#jf-cast").addEventListener("submit", async e => {
     e.preventDefault();
     const playlist_id = $("#jf-url").value.trim();
     if (!playlist_id) return;
-    try {
-      await api.send("/api/source/jellyfin/cast", { playlist_id });
-      $("#jf-url").value = "";
-      toast("Playing playlist...");
-    } catch (err) { toast(err.message, true); }
+    try { await api.send("/api/source/jellyfin/cast", { playlist_id }); $("#jf-url").value = ""; toast("Playing playlist..."); }
+    catch (err) { toast(err.message, true); }
   });
 
+  // Settings drawer
   $("#open-settings").onclick  = async () => { cfg = await api.get("/api/config"); renderSettings(); openDrawer(); };
   $("#close-settings").onclick = closeDrawer;
   $("#scrim").onclick          = closeDrawer;
@@ -464,14 +576,14 @@ function wire() {
       closeDrawer();
     } catch (e) { toast(e.message, true); }
   };
-  $("#reload-config").onclick  = async () => {
+  $("#reload-config").onclick = async () => {
     cfg = await api.send("/api/config/reload");
     renderSettings();
     toast("Reloaded from disk");
   };
 }
 
-// SSE if available, polling fallback otherwise.
+// ── SSE + polling ──────────────────────────────────────────────────────────
 function connect() {
   let es;
   try {
@@ -486,17 +598,17 @@ async function poll() {
   setTimeout(poll, 1000);
 }
 
+// ── Main render ────────────────────────────────────────────────────────────
 function render() {
   renderStatus();
   renderNowPlaying();
   renderSources();
   renderOutput();
+  renderAudioStats();
 
   const yt = state?.sources?.available?.find(s => s.name === "youtube_music");
   const shuffleBtn = $("#yt-shuffle");
-  if (shuffleBtn) {
-    shuffleBtn.classList.toggle("active", !!yt?.details?.shuffle);
-  }
+  if (shuffleBtn) shuffleBtn.classList.toggle("active", !!yt?.details?.shuffle);
 }
 
 async function startDashboard() {

--- a/ui/dist/index.html
+++ b/ui/dist/index.html
@@ -7,96 +7,120 @@
 <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+
+<!-- ─── Header ──────────────────────────────────────────────────────────── -->
 <header>
   <div class="brand">
     <span class="mark"></span>
-    <div>
-      <h1>FH6 Universal Radio</h1>
-      <span class="subtitle" id="status">connecting...</span>
-    </div>
+    <h1>FH6 Universal Radio</h1>
   </div>
-  <button class="ghost" id="open-settings" aria-label="Settings">
-    <svg viewBox="0 0 24 24" width="22" height="22" aria-hidden="true">
-      <path fill="currentColor" d="M19.4 13a7.5 7.5 0 0 0 0-2l2-1.6-2-3.4-2.4.9a7.6 7.6 0 0 0-1.7-1L14.9 3h-3.8l-.4 2.9c-.6.3-1.2.6-1.7 1L6.6 6 4.6 9.4 6.6 11a7.5 7.5 0 0 0 0 2l-2 1.6 2 3.4 2.4-.9c.5.4 1.1.7 1.7 1l.4 2.9h3.8l.4-2.9c.6-.3 1.2-.6 1.7-1l2.4.9 2-3.4-2-1.6Zm-7.4 2.5a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7Z"/>
-    </svg>
-  </button>
+
+  <nav class="tabs" id="main-tabs" aria-label="Main navigation">
+    <button class="tab active" data-tab="player">Player</button>
+    <button class="tab" data-tab="sources">Sources</button>
+    <button class="tab" data-tab="output">Output</button>
+  </nav>
+
+  <div class="header-end">
+    <span class="status-pill" id="status">connecting...</span>
+    <button class="icon-btn" id="open-settings" aria-label="Settings">
+      <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+        <path fill="currentColor" d="M19.4 13a7.5 7.5 0 0 0 0-2l2-1.6-2-3.4-2.4.9a7.6 7.6 0 0 0-1.7-1L14.9 3h-3.8l-.4 2.9c-.6.3-1.2.6-1.7 1L6.6 6 4.6 9.4 6.6 11a7.5 7.5 0 0 0 0 2l-2 1.6 2 3.4 2.4-.9c.5.4 1.1.7 1.7 1l.4 2.9h3.8l.4-2.9c.6-.3 1.2-.6 1.7-1l2.4.9 2-3.4-2-1.6Zm-7.4 2.5a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7Z"/>
+      </svg>
+    </button>
+  </div>
 </header>
 
+<!-- ─── Body ─────────────────────────────────────────────────────────────── -->
 <main>
-  <section class="now-playing card">
-    <div class="art" id="np-art" aria-hidden="true"></div>
-    <div class="meta">
-      <div class="title" id="np-title">Nothing playing</div>
-      <div class="artist" id="np-artist"></div>
-      <div class="progress">
-        <div class="bar"><div class="fill" id="np-fill"></div></div>
-        <div class="times"><span id="np-pos">0:00</span><span id="np-dur">0:00</span></div>
+
+  <!-- Player tab ─────────────────────────────────────────────────────────── -->
+  <div class="tab-panel" id="panel-player">
+    <div class="player-card card">
+      <div class="art" id="np-art" aria-hidden="true"></div>
+      <div class="player-meta">
+        <span class="source-pill" id="np-source"></span>
+        <div class="title" id="np-title">Nothing playing</div>
+        <div class="artist" id="np-artist"></div>
+      </div>
+      <div class="player-foot">
+        <div class="progress">
+          <div class="bar" id="np-bar"><div class="fill" id="np-fill"></div></div>
+          <div class="times"><span id="np-pos">0:00</span><span id="np-dur">0:00</span></div>
+        </div>
+        <div class="transport">
+          <button class="icon" id="t-prev" title="Previous">⏮</button>
+          <button class="icon primary" id="t-play" title="Play / pause">▶</button>
+          <button class="icon" id="t-next" title="Next">⏭</button>
+        </div>
       </div>
     </div>
-    <div class="transport">
-      <button class="icon" id="t-prev" title="Previous">⏮</button>
-      <button class="icon primary" id="t-play" title="Play / pause">▶</button>
-      <button class="icon" id="t-next" title="Next">⏭</button>
+  </div>
+
+  <!-- Sources tab ────────────────────────────────────────────────────────── -->
+  <div class="tab-panel hidden" id="panel-sources">
+    <div class="card">
+      <h2>Source</h2>
+      <div class="sources" id="sources"></div>
     </div>
-  </section>
 
-  <section class="card">
-    <h2>Source</h2>
-    <div class="sources" id="sources"></div>
-  </section>
+    <div class="card" id="yt-cast-card" hidden>
+      <h2>Cast to YouTube Music</h2>
+      <p class="muted">Paste any YouTube or YouTube Music URL (single video or playlist). The radio will switch sources and start streaming immediately.</p>
+      <form id="yt-cast" class="row">
+        <input type="text" id="yt-url" placeholder="https://music.youtube.com/playlist?list=..." autocomplete="off">
+        <button type="submit" class="primary">Cast</button>
+        <button type="button" id="yt-shuffle" class="icon" title="Shuffle playlist">🔀</button>
+      </form>
+    </div>
 
-  <section class="card" id="yt-cast-card" hidden>
-    <h2>Cast to YouTube Music</h2>
-    <p class="muted">Paste any YouTube or YouTube Music URL (single video or playlist). The radio will switch sources and start streaming immediately.</p>
-    <form id="yt-cast" class="row">
-      <input type="text" id="yt-url" placeholder="https://music.youtube.com/playlist?list=..." autocomplete="off">
-      <button type="submit" class="primary">Cast</button>
-      <button type="button" id="yt-shuffle" class="icon" title="Shuffle playlist">🔀</button>
-    </form>
-  </section>
+    <div class="card" id="jf-cast-card" hidden>
+      <h2>Play Jellyfin Playlist</h2>
+      <p class="muted">Enter a Jellyfin Playlist ID. The radio will switch sources and start streaming immediately.</p>
+      <form id="jf-cast" class="row">
+        <input type="text" id="jf-url" placeholder="Playlist ID..." autocomplete="off">
+        <button type="submit" class="primary">Play</button>
+      </form>
+    </div>
+  </div>
 
-  <section class="card" id="jf-cast-card" hidden>
-    <h2>Play Jellyfin Playlist</h2>
-    <p class="muted">Enter a Jellyfin Playlist ID. The radio will switch sources and start streaming immediately.</p>
-    <form id="jf-cast" class="row">
-      <input type="text" id="jf-url" autocomplete="off">
-      <button type="submit" class="primary">Play</button>
-    </form>
-  </section>
+  <!-- Output tab ─────────────────────────────────────────────────────────── -->
+  <div class="tab-panel hidden" id="panel-output">
+    <div class="card">
+      <h2>Volume</h2>
+      <label class="slider">
+        <span>Output</span>
+        <input type="range" id="vol" min="0" max="1" step="0.01">
+        <output id="vol-out">100%</output>
+      </label>
+    </div>
 
-  <section class="card">
-    <h2>Output</h2>
-    <label class="slider">
-      <span>Volume</span>
-      <input type="range" id="vol" min="0" max="1" step="0.01">
-      <output id="vol-out">100%</output>
-    </label>
-  </section>
+    <div class="card">
+      <h2>Diagnostics</h2>
+      <div class="stat-grid" id="audio-stats"></div>
+    </div>
+  </div>
+
 </main>
 
-<footer class="credits" id="credits">
-  <p class="credit-line">
-    <strong>FH6 Universal Radio</strong> &mdash; an open-source mod by
-    <a href="https://github.com/g0ldyy" target="_blank" rel="noopener noreferrer">g0ldyy</a>
-    and <a href="https://github.com/g0ldyy/fh6-universal-radio/graphs/contributors" target="_blank" rel="noopener noreferrer">contributors</a>.
-    Released under <a href="https://github.com/g0ldyy/fh6-universal-radio/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">GPLv3</a>.
-  </p>
-  <p class="donate-line">
-    If this mod makes your drives better, consider supporting development:
-  </p>
-  <div class="donate-links">
-    <a class="donate-btn sponsors" href="https://github.com/sponsors/g0ldyy" target="_blank" rel="noopener noreferrer">
-      <span aria-hidden="true">&hearts;</span> GitHub Sponsors
-    </a>
-    <a class="donate-btn kofi" href="https://ko-fi.com/g0ldyy" target="_blank" rel="noopener noreferrer">
-      <span aria-hidden="true">&#9749;</span> Ko-fi
-    </a>
-    <a class="donate-btn repo" href="https://github.com/g0ldyy/fh6-universal-radio" target="_blank" rel="noopener noreferrer">
-      <span aria-hidden="true">&#9733;</span> Star the repo
-    </a>
+<!-- ─── Footer ──────────────────────────────────────────────────────────── -->
+<footer>
+  <div class="footer-inner">
+    <p class="footer-credit">
+      <strong>FH6 Universal Radio</strong> &mdash;
+      <a href="https://github.com/g0ldyy" target="_blank" rel="noopener noreferrer">g0ldyy</a>
+      &amp; <a href="https://github.com/g0ldyy/fh6-universal-radio/graphs/contributors" target="_blank" rel="noopener noreferrer">contributors</a>
+      &middot; <a href="https://github.com/g0ldyy/fh6-universal-radio/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">GPLv3</a>
+    </p>
+    <div class="footer-links">
+      <a class="footer-link sponsors" href="https://github.com/sponsors/g0ldyy" target="_blank" rel="noopener noreferrer">♥ Sponsor</a>
+      <a class="footer-link kofi"     href="https://ko-fi.com/g0ldyy"            target="_blank" rel="noopener noreferrer">☕ Ko-fi</a>
+      <a class="footer-link repo"     href="https://github.com/g0ldyy/fh6-universal-radio" target="_blank" rel="noopener noreferrer">★ GitHub</a>
+    </div>
   </div>
 </footer>
 
+<!-- ─── Settings drawer ──────────────────────────────────────────────────── -->
 <aside class="drawer" id="drawer" aria-hidden="true">
   <div class="drawer-head">
     <h2>Settings</h2>

--- a/ui/dist/styles.css
+++ b/ui/dist/styles.css
@@ -2,20 +2,20 @@
 
 :root {
   color-scheme: dark;
-  --bg:           #0b0c10;
-  --panel:        #14161d;
-  --panel-2:      #1c1f29;
-  --line:         #262a36;
-  --text:         #eaeaf0;
-  --text-dim:     #9aa0b4;
-  --muted:        #6b7080;
-  --accent:       #b6ff3c;
-  --accent-soft:  #1f2a12;
-  --warn:         #ffb454;
-  --danger:       #ff5d6c;
-  --radius:       12px;
-  --shadow-1:     0 1px 0 rgba(255,255,255,0.04) inset, 0 10px 30px rgba(0,0,0,0.45);
-  --shadow-2:     0 24px 48px rgba(0,0,0,0.55);
+  --bg:          #0b0c10;
+  --panel:       #14161d;
+  --panel-2:     #1c1f29;
+  --line:        #262a36;
+  --text:        #eaeaf0;
+  --text-dim:    #9aa0b4;
+  --muted:       #6b7080;
+  --accent:      #b6ff3c;
+  --accent-soft: #1f2a12;
+  --warn:        #ffb454;
+  --danger:      #ff5d6c;
+  --radius:      12px;
+  --shadow-1:    0 1px 0 rgba(255,255,255,0.04) inset, 0 10px 30px rgba(0,0,0,0.45);
+  --shadow-2:    0 24px 48px rgba(0,0,0,0.55);
 }
 
 * { box-sizing: border-box; }
@@ -31,53 +31,111 @@ body {
     radial-gradient(900px 600px at -10% 110%, #15192a 0%, transparent 55%),
     var(--bg);
   min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
 button { font: inherit; color: inherit; }
-
 input, output, select { font: inherit; color: inherit; }
-
 h1, h2 { margin: 0; font-weight: 600; letter-spacing: .2px; }
-
-h1 { font-size: 18px; }
-
-h2 { font-size: 13px; text-transform: uppercase; letter-spacing: 1.2px; color: var(--text-dim); margin-bottom: 14px; }
-
+h1 { font-size: 16px; }
+h2 { font-size: 11px; text-transform: uppercase; letter-spacing: 1.4px; color: var(--text-dim); margin-bottom: 16px; }
 .muted { color: var(--muted); font-size: 13px; margin: 0 0 12px; }
 
-/* Header */
+/* ─── Header ──────────────────────────────────────────────────────────── */
 header {
-  display: flex; align-items: center; justify-content: space-between;
-  padding: 22px 32px; border-bottom: 1px solid var(--line);
-  position: sticky; top: 0;
-  background: linear-gradient(180deg, rgba(11,12,16,0.92), rgba(11,12,16,0.7));
-  backdrop-filter: blur(14px);
-  z-index: 5;
-}
-
-.brand { display: flex; align-items: center; gap: 14px; }
-
-.mark {
-  width: 36px; height: 36px; border-radius: 10px;
-  background: linear-gradient(135deg, var(--accent), #62c828);
-  box-shadow: 0 6px 18px rgba(182,255,60,0.3), inset 0 0 0 1px rgba(255,255,255,0.15);
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: stretch;
+  height: 60px;
+  padding: 0 28px;
+  border-bottom: 1px solid var(--line);
+  position: sticky; top: 0; z-index: 5;
+  background: linear-gradient(180deg, rgba(11,12,16,0.96), rgba(11,12,16,0.82));
+  backdrop-filter: blur(18px);
   flex-shrink: 0;
 }
 
-.subtitle { color: var(--text-dim); font-size: 12px; }
-
-.subtitle.ok::before { content: "● "; color: var(--accent); }
-
-.subtitle.warn::before { content: "● "; color: var(--warn); }
-
-.subtitle.err::before { content: "● "; color: var(--danger); }
-
-/* Layout */
-main {
-  max-width: 960px; margin: 0 auto; padding: 32px;
-  display: grid; gap: 20px;
+.brand {
+  display: flex; align-items: center; gap: 12px;
+  justify-self: start;
 }
 
+.mark {
+  width: 28px; height: 28px; border-radius: 7px; flex-shrink: 0;
+  background: linear-gradient(135deg, var(--accent), #62c828);
+  box-shadow: 0 4px 12px rgba(182,255,60,0.3), inset 0 0 0 1px rgba(255,255,255,0.15);
+}
+
+/* ─── Nav tabs ──────────────────────────────────────────────────────────── */
+.tabs { display: flex; align-items: stretch; }
+
+.tab {
+  position: relative;
+  padding: 0 22px;
+  background: transparent; border: 0;
+  color: var(--text-dim); font-size: 14px; font-weight: 500;
+  cursor: pointer; transition: color .15s;
+  display: flex; align-items: center; white-space: nowrap;
+}
+
+.tab::after {
+  content: "";
+  position: absolute; bottom: 0; left: 14px; right: 14px;
+  height: 2px;
+  background: var(--accent); border-radius: 2px 2px 0 0;
+  transform: scaleX(0);
+  transition: transform .2s cubic-bezier(.4, 0, .2, 1);
+}
+
+.tab:hover { color: var(--text); }
+
+.tab.active { color: var(--text); }
+
+.tab.active::after { transform: scaleX(1); }
+
+/* ─── Header end ────────────────────────────────────────────────────────── */
+.header-end {
+  display: flex; align-items: center; gap: 10px;
+  justify-self: end;
+}
+
+.status-pill {
+  font-size: 11px; font-weight: 500; letter-spacing: 0.3px;
+  padding: 4px 10px; border-radius: 999px;
+  border: 1px solid var(--line); color: var(--text-dim);
+  transition: color .2s, border-color .2s, background .2s;
+  white-space: nowrap;
+}
+
+.status-pill::before { content: "● "; font-size: 8px; vertical-align: 1px; }
+
+.status-pill.ok  { color: var(--accent); border-color: rgba(182,255,60,.3); background: var(--accent-soft); }
+
+.status-pill.err { color: var(--danger); border-color: rgba(255,93,108,.3); background: rgba(255,93,108,.08); }
+
+.icon-btn {
+  width: 34px; height: 34px; border-radius: 8px;
+  border: 1px solid var(--line); background: transparent; cursor: pointer;
+  display: inline-flex; align-items: center; justify-content: center;
+  color: var(--text-dim); transition: color .15s, background .15s;
+}
+
+.icon-btn:hover { color: var(--text); background: var(--panel-2); }
+
+/* ─── Main / tab panels ─────────────────────────────────────────────────── */
+main {
+  flex: 1;
+  max-width: 860px; width: 100%;
+  margin: 0 auto;
+  padding: 28px 28px 20px;
+}
+
+.tab-panel { display: grid; gap: 16px; }
+
+.tab-panel.hidden { display: none; }
+
+/* ─── Card ──────────────────────────────────────────────────────────────── */
 .card {
   background: var(--panel);
   border: 1px solid var(--line);
@@ -86,51 +144,84 @@ main {
   box-shadow: var(--shadow-1);
 }
 
-/* Now playing */
-.now-playing {
+/* ─── Player card ───────────────────────────────────────────────────────── */
+.player-card {
   display: grid;
-  grid-template-columns: 96px 1fr auto;
-  gap: 20px; align-items: center;
+  grid-template-columns: 140px 1fr;
+  grid-template-rows: 1fr auto;
+  column-gap: 26px;
+  row-gap: 22px;
+  align-items: center;
 }
 
+/* ─── Album art ─────────────────────────────────────────────────────────── */
 .art {
-  width: 96px; height: 96px; border-radius: 10px;
+  grid-row: 1; grid-column: 1;
+  width: 140px; height: 140px;
+  border-radius: 12px;
   background:
     radial-gradient(circle at 30% 30%, rgba(255,255,255,0.18), transparent 60%),
     linear-gradient(135deg, #2a3147, #11141d);
   border: 1px solid var(--line);
-  position: relative;
+  position: relative; overflow: hidden; flex-shrink: 0;
 }
 
 .art::after {
-  content: ""; position: absolute; inset: 36px;
+  content: ""; position: absolute; inset: 44px;
   border-radius: 50%;
   background: radial-gradient(circle, #2a2d38 35%, #15171f 36%, #15171f 60%, #2a2d38 61%);
   box-shadow: 0 0 0 1px rgba(255,255,255,0.04);
 }
 
-.meta { min-width: 0; }
-
-.source-pill {
-  display: inline-block; font-size: 11px; letter-spacing: 1px; text-transform: uppercase;
-  padding: 3px 9px; border-radius: 999px;
-  background: var(--accent-soft); color: var(--accent);
-  margin-bottom: 6px;
+.art img {
+  width: 100%; height: 100%;
+  object-fit: cover; border-radius: 12px; display: block;
 }
 
-.title  { font-size: 22px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.art.has-art::after { display: none; }
 
-.artist { color: var(--text-dim); margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+/* ─── Player meta (title / artist / source pill) ───────────────────────── */
+.player-meta {
+  grid-row: 1; grid-column: 2;
+  min-width: 0; align-self: center;
+}
 
-.progress { margin-top: 14px; }
+.source-pill {
+  display: inline-block;
+  font-size: 10px; letter-spacing: 1px; text-transform: uppercase;
+  padding: 3px 8px; border-radius: 999px;
+  background: var(--accent-soft); color: var(--accent);
+  margin-bottom: 10px;
+}
 
-.bar { height: 4px; background: var(--line); border-radius: 4px; overflow: hidden; }
+.source-pill:empty { display: none; }
+
+.title  { font-size: 24px; font-weight: 700; line-height: 1.2; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+.artist { color: var(--text-dim); margin-top: 5px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 14px; }
+
+/* ─── Player foot (progress + transport) ───────────────────────────────── */
+.player-foot { grid-row: 2; grid-column: 1 / -1; }
+
+/* ─── Progress bar ──────────────────────────────────────────────────────── */
+.progress { margin-bottom: 16px; }
+
+.bar { height: 4px; background: var(--line); border-radius: 4px; overflow: hidden; transition: height .12s ease; }
 
 .fill { height: 100%; background: var(--accent); width: 0%; transition: width .25s linear; }
 
-.times { display: flex; justify-content: space-between; font-size: 11px; color: var(--muted); margin-top: 5px; font-variant-numeric: tabular-nums; }
+.times { display: flex; justify-content: space-between; font-size: 11px; color: var(--muted); margin-top: 6px; font-variant-numeric: tabular-nums; }
 
-.transport { display: flex; gap: 6px; align-items: center; }
+#np-bar { cursor: default; }
+
+#np-bar.seekable { cursor: pointer; }
+
+#np-bar.seekable:hover { height: 7px; }
+
+#np-bar.seekable:hover .fill { opacity: 0.88; }
+
+/* ─── Transport ─────────────────────────────────────────────────────────── */
+.transport { display: flex; gap: 8px; align-items: center; justify-content: center; }
 
 .icon {
   width: 42px; height: 42px; border-radius: 50%; border: 1px solid var(--line);
@@ -141,24 +232,20 @@ main {
 
 .icon:hover { background: #252938; }
 
-.icon:active { transform: scale(0.94); }
+.icon:active { transform: scale(0.93); }
 
 .icon.primary {
-  width: 54px; height: 54px; border: 0; color: #102000;
+  width: 56px; height: 56px; border: 0; color: #102000;
   background: var(--accent);
-  box-shadow: 0 8px 22px rgba(182,255,60,0.28);
+  box-shadow: 0 8px 24px rgba(182,255,60,0.3);
 }
 
 .icon.primary:hover { background: #c4ff52; }
 
-.icon.active {
-  background: var(--accent-soft);
-  border-color: var(--accent);
-  color: var(--accent);
-}
+.icon.active { background: var(--accent-soft); border-color: var(--accent); color: var(--accent); }
 
-/* Source picker */
-.sources { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; }
+/* ─── Source picker ─────────────────────────────────────────────────────── */
+.sources { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 12px; }
 
 .source {
   background: var(--panel-2); border: 1px solid var(--line); border-radius: 10px;
@@ -177,11 +264,9 @@ main {
   background: linear-gradient(180deg, rgba(182,255,60,0.06), transparent 80%) var(--panel-2);
 }
 
-.source .name { font-weight: 600; }
+.source .name  { font-weight: 600; font-size: 14px; display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
 
-.source .state {
-  font-size: 11px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 1px;
-}
+.source .state { font-size: 11px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 1px; }
 
 .source .state.warn { color: var(--warn); }
 
@@ -191,14 +276,33 @@ main {
 
 .source.active::after {
   content: ""; position: absolute; top: 12px; right: 12px;
-  width: 8px; height: 8px; border-radius: 50%;
-  background: var(--accent); box-shadow: 0 0 12px var(--accent);
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 10px var(--accent);
 }
 
-/* Forms */
-.row {
-  display: flex; gap: 8px; align-items: center;
+/* ─── Animated waveform bars ────────────────────────────────────────────── */
+.waveform { display: inline-flex; gap: 2px; align-items: flex-end; height: 14px; vertical-align: middle; }
+
+.waveform i {
+  display: block; width: 3px; border-radius: 2px; background: var(--accent);
+  height: 4px; animation: wave-bar 1.1s ease-in-out infinite; font-style: normal;
 }
+
+.waveform i:nth-child(2) { animation-delay: .2s; }
+.waveform i:nth-child(3) { animation-delay: .4s; }
+.waveform i:nth-child(4) { animation-delay: .6s; }
+
+@keyframes wave-bar { 0%, 100% { height: 4px; } 50% { height: 14px; } }
+
+/* ─── Source badge (shuffle etc.) ───────────────────────────────────────── */
+.src-badge {
+  display: inline-block; font-size: 10px; padding: 1px 6px; border-radius: 4px;
+  font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase; line-height: 1.8;
+  background: var(--accent-soft); color: var(--accent);
+}
+
+/* ─── Forms ─────────────────────────────────────────────────────────────── */
+.row { display: flex; gap: 8px; align-items: center; }
 
 .external-audio-row select { flex: 1; min-width: 0; }
 
@@ -216,7 +320,7 @@ input[type="text"]:focus, input[type="number"]:focus, select:focus {
 
 button.primary {
   background: var(--accent); color: #102000; border: 0; padding: 10px 18px; border-radius: 8px;
-  cursor: pointer; font-weight: 600;
+  cursor: pointer; font-weight: 600; white-space: nowrap;
 }
 
 button.primary:hover { background: #c4ff52; }
@@ -229,7 +333,8 @@ button.ghost {
 
 button.ghost:hover { color: var(--text); background: var(--panel-2); }
 
-.slider { display: grid; grid-template-columns: 80px 1fr 56px; align-items: center; gap: 14px; padding: 10px 0; }
+/* ─── Volume slider ─────────────────────────────────────────────────────── */
+.slider { display: grid; grid-template-columns: 64px 1fr 52px; align-items: center; gap: 14px; padding: 8px 0; }
 
 .slider span { color: var(--text-dim); font-size: 13px; }
 
@@ -252,23 +357,18 @@ input[type="range"]::-moz-range-thumb {
 
 output { text-align: right; color: var(--text-dim); font-variant-numeric: tabular-nums; font-size: 13px; }
 
-.stat-grid {
-  display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 14px; margin-top: 18px;
-}
+/* ─── Diagnostics stat grid ─────────────────────────────────────────────── */
+.stat-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(110px, 1fr)); gap: 12px; }
 
-.stat {
-  background: var(--panel-2); border: 1px solid var(--line); border-radius: 8px;
-  padding: 10px 12px;
-}
+.stat { background: var(--panel-2); border: 1px solid var(--line); border-radius: 8px; padding: 10px 12px; }
 
 .stat .label { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 1px; }
 
-.stat .value { font-size: 17px; font-weight: 600; font-variant-numeric: tabular-nums; margin-top: 2px; }
+.stat .value { font-size: 18px; font-weight: 600; font-variant-numeric: tabular-nums; margin-top: 2px; }
 
 .stat .value.warn { color: var(--warn); }
 
-/* Settings drawer */
+/* ─── Settings drawer ───────────────────────────────────────────────────── */
 .drawer {
   position: fixed; top: 0; right: 0; bottom: 0; width: min(420px, 100%);
   background: var(--panel); border-left: 1px solid var(--line);
@@ -306,16 +406,11 @@ output { text-align: right; color: var(--text-dim); font-variant-numeric: tabula
 
 .field select,
 .field input[type="text"],
-.field input[type="number"] {
-  background: var(--panel-2); border: 1px solid var(--line); color: var(--text);
-  border-radius: 8px; padding: 8px 10px;
-}
+.field input[type="number"] { background: var(--panel-2); border: 1px solid var(--line); color: var(--text); border-radius: 8px; padding: 8px 10px; }
 
 .field.bands { gap: 8px; }
 
-.field.bands .band {
-  display: grid; grid-template-columns: 72px 1fr 64px; align-items: center; gap: 10px;
-}
+.field.bands .band { display: grid; grid-template-columns: 72px 1fr 64px; align-items: center; gap: 10px; }
 
 .field.bands .band-label { color: var(--text-dim); font-size: 12px; }
 
@@ -323,79 +418,89 @@ output { text-align: right; color: var(--text-dim); font-variant-numeric: tabula
 
 .field.bands output { color: var(--text-dim); font-size: 12px; text-align: right; }
 
-.scrim {
-  position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 9;
-  animation: fade .25s ease;
-}
+/* ─── Scrim ─────────────────────────────────────────────────────────────── */
+.scrim { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 9; animation: fade .25s ease; }
 
-@keyframes fade { from { opacity: 0; }
+@keyframes fade { from { opacity: 0; } to { opacity: 1; } }
 
- to { opacity: 1; } }
-
+/* ─── Toast ─────────────────────────────────────────────────────────────── */
 .toast {
   position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%);
   background: var(--panel); border: 1px solid var(--line); border-radius: 8px;
   padding: 12px 18px; box-shadow: var(--shadow-2); font-size: 14px;
-  animation: rise .2s ease;
-  z-index: 20;
+  animation: rise .2s ease; z-index: 20;
 }
 
 .toast.err { border-color: var(--danger); color: var(--danger); }
 
-@keyframes rise { from { transform: translate(-50%, 20px); opacity: 0; }
+@keyframes rise { from { transform: translate(-50%, 20px); opacity: 0; } to { transform: translate(-50%, 0); opacity: 1; } }
 
- to { transform: translate(-50%, 0); opacity: 1; } }
-
-/* Credits + donations footer */
-.credits {
-  max-width: 960px; margin: 0 auto; padding: 28px 32px 40px;
-  text-align: center; color: var(--text-dim);
-  border-top: 1px solid var(--line); margin-top: 12px;
+/* ─── Footer ────────────────────────────────────────────────────────────── */
+footer {
+  border-top: 1px solid var(--line);
+  padding: 14px 28px;
+  flex-shrink: 0;
 }
 
-.credit-line { font-size: 13px; margin: 0 0 14px; }
-
-.credit-line strong { color: var(--text); font-weight: 600; }
-
-.credit-line a {
-  color: var(--accent); text-decoration: none; border-bottom: 1px dotted transparent;
-  transition: border-color .15s;
+.footer-inner {
+  max-width: 860px; margin: 0 auto;
+  display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 10px;
 }
 
-.credit-line a:hover { border-bottom-color: var(--accent); }
+.footer-credit { font-size: 12px; color: var(--muted); margin: 0; }
 
-.donate-line { font-size: 12px; margin: 0 0 12px; color: var(--muted); }
+.footer-credit strong { color: var(--text-dim); }
 
-.donate-links {
-  display: flex; flex-wrap: wrap; justify-content: center; gap: 10px;
-}
+.footer-credit a { color: var(--text-dim); text-decoration: none; transition: color .15s; }
 
-.donate-btn {
-  display: inline-flex; align-items: center; gap: 8px;
-  padding: 8px 14px; border-radius: 8px; font-size: 13px; font-weight: 600;
+.footer-credit a:hover { color: var(--text); }
+
+.footer-links { display: flex; gap: 6px; }
+
+.footer-link {
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 5px 10px; border-radius: 6px; font-size: 12px; font-weight: 500;
   text-decoration: none; border: 1px solid var(--line);
-  background: var(--panel-2); color: var(--text);
-  transition: border-color .15s, transform .1s, background .15s;
+  color: var(--text-dim); transition: border-color .15s, color .15s;
 }
 
-.donate-btn:hover { border-color: var(--accent); transform: translateY(-1px); }
+.footer-link:hover { border-color: var(--accent); color: var(--text); }
 
-.donate-btn.sponsors { color: #ff8ec1; }
+.footer-link.sponsors { color: #ff8ec1; }
 
-.donate-btn.kofi     { color: #ff7575; }
+.footer-link.kofi     { color: #ff9999; }
 
-.donate-btn.repo     { color: var(--accent); }
+.footer-link.repo     { color: var(--accent); }
 
-@media (max-width: 640px) {
-  header { padding: 16px 20px; }
+/* ─── Responsive ────────────────────────────────────────────────────────── */
+@media (max-width: 680px) {
+  header {
+    grid-template-columns: 1fr auto;
+    grid-template-rows: auto auto;
+    height: auto;
+    padding: 12px 18px 0;
+  }
 
-  main { padding: 20px; }
+  .brand     { grid-column: 1; grid-row: 1; }
+  .header-end { grid-column: 2; grid-row: 1; }
 
-  .now-playing { grid-template-columns: 1fr; text-align: center; }
+  .tabs {
+    grid-column: 1 / -1; grid-row: 2;
+    border-top: 1px solid var(--line);
+    margin: 12px -18px 0;
+    padding: 0 18px;
+  }
 
-  .art { margin: 0 auto; }
+  .tab { padding: 10px 16px; font-size: 13px; }
 
-  .transport { justify-content: center; }
+  main { padding: 18px 16px 14px; }
 
-  .credits { padding: 24px 20px 32px; }
+  .player-card { grid-template-columns: 100px 1fr; column-gap: 16px; }
+
+  .art { width: 100px; height: 100px; }
+  .art::after { inset: 30px; }
+
+  .title { font-size: 19px; }
+
+  .footer-inner { flex-direction: column; align-items: flex-start; gap: 8px; }
 }


### PR DESCRIPTION
## Summary

- Add sticky header with centered **Player / Sources / Output** nav tabs, status pill, and settings icon button
- Restructure main body into tab panels: Player (now-playing card), Sources (source tiles + cast forms + external audio), Output (volume + live audio diagnostics)
- Redesign player card: 140 px album artwork (real image when `artwork_url` is present, CSS vinyl ring fallback), source name pill, larger title, full-width seekable progress bar, centered transport controls
- Add smooth `requestAnimationFrame` progress interpolation between 1 s server updates
- Add **seek** transport route (`POST /api/source/<name>/seek`) — drains ring buffer after seek so stale PCM is cleared
- Add animated waveform bars on the actively playing source tile
- Add volume slider accent fill, shuffle badge on source tiles
- Add keyboard shortcuts: `Space` = play/pause, `←`/`→` = prev/next
- Redesign footer as a compact bar (credits left, action links right)
- Responsive layout at ≤680 px: tabs drop below brand row, artwork shrinks, footer stacks

## Test plan

- [ ] Open dashboard — header renders with three tabs, footer visible at bottom
- [ ] Switch between Player / Sources / Output tabs
- [ ] Verify now-playing card shows album art when a track with `artwork_url` is playing
- [ ] Verify progress bar fills smoothly between poll updates
- [ ] Click progress bar on a seekable source (e.g. Local Files) — playback jumps to that position
- [ ] Verify progress bar is non-interactive on non-seekable sources
- [ ] Press `Space`, `←`, `→` while focus is outside any input — transport responds
- [ ] Check Sources tab: source tiles, YT cast form, Jellyfin cast form all present
- [ ] Check Output tab: volume slider with fill gradient, diagnostics stat grid
- [ ] Resize to mobile width — tabs wrap below brand row, layout holds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `seek` action to the audio source control API, allowing users to seek to a specific playback position by specifying milliseconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->