### PR TITLE
Feature: Add .m3u/.m3u8 playlist parsing to local_file_source

### DIFF
--- a/src/sources/local_file_source.cpp
+++ b/src/sources/local_file_source.cpp
@@ -21,6 +21,7 @@
 #endif
 
 #include <algorithm>
+#include <fstream>
 #include <random>
 
 namespace fh6::sources {
@@ -44,6 +45,24 @@ bool extension_matches(const std::filesystem::path& p, const std::vector<std::st
     if (!e.empty() && e.front() == '.') e.erase(0, 1);
     std::ranges::transform(e, e.begin(), [](unsigned char c) { return (char)std::tolower(c); });
     return std::ranges::find(exts, e) != exts.end();
+}
+
+std::vector<std::filesystem::path> parse_m3u_playlist(const std::filesystem::path& file) {
+    std::vector<std::filesystem::path> out;
+    std::ifstream in(file);
+    if (!in) return out;
+    const auto dir = file.parent_path();
+    std::string line;
+    while (std::getline(in, line)) {
+        while (!line.empty() && (line.back() == '\r' || line.back() == '\n'))
+            line.pop_back();
+        if (line.empty() || line[0] == '#') continue;
+        std::filesystem::path p = std::filesystem::path{line};
+        if (p.is_relative()) p = dir / p;
+        std::error_code ec;
+        if (std::filesystem::exists(p, ec)) out.push_back(std::move(p));
+    }
+    return out;
 }
 
 struct ProbedMetadata {
@@ -248,7 +267,14 @@ void LocalFileSource::rebuild_playlist() {
     playlist_.clear();
     std::error_code ec;
     auto add = [&](const std::filesystem::path& p) {
-        if (extension_matches(p, cfg_.supported_formats)) playlist_.push_back(p);
+        const auto ext = p.extension().string();
+        if (ieq_str(ext, ".m3u") || ieq_str(ext, ".m3u8")) {
+            for (auto& entry : parse_m3u_playlist(p))
+                if (extension_matches(entry, cfg_.supported_formats))
+                    playlist_.push_back(std::move(entry));
+        } else if (extension_matches(p, cfg_.supported_formats)) {
+            playlist_.push_back(p);
+        }
     };
     if (cfg_.recursive) {
         for (const auto& e : std::filesystem::recursive_directory_iterator(

--- a/src/sources/local_file_source.cpp
+++ b/src/sources/local_file_source.cpp
@@ -47,6 +47,8 @@ bool extension_matches(const std::filesystem::path& p, const std::vector<std::st
     return std::ranges::find(exts, e) != exts.end();
 }
 
+/// Parse an .m3u / .m3u8 playlist: one entry per line, # comments,
+/// extended info (#EXTINF) is ignored.
 std::vector<std::filesystem::path> parse_m3u_playlist(const std::filesystem::path& file) {
     std::vector<std::filesystem::path> out;
     std::ifstream in(file);


### PR DESCRIPTION
As per the tittle, this add support for m3u/m3u8 playlists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Playlist support: Local file source now recognizes M3U/M3U8 playlists and automatically expands them into playable tracks during library updates. The parser ignores comments/empty lines, resolves relative paths, verifies file existence, and only includes entries matching supported media formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->