### PR TITLE
feat: enhance source switching logic in run_bridge function

### DIFF
--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -167,10 +167,14 @@ void run_bridge(HMODULE self) noexcept {
 
     if (!mgr.switch_to(cfg.general.default_source) && !mgr.switch_to(cfg.general.fallback_source)) {
         auto snap = mgr.sources_snapshot();
-        if (snap.size() == 1) {
-            mgr.switch_to(snap[0]->name());
+        if (snap.empty()) {
+            log::warn("[bridge] no sources registered");
+        } else if (snap.size() == 1) {
+            if (!mgr.switch_to(snap[0]->name()))
+                log::error("[bridge] failed to switch to sole registered source '{}'", snap[0]->name());
         } else {
-            log::warn("[bridge] neither default nor fallback source was registered");
+            log::warn("[bridge] configured default/fallback sources not found among {} registered sources",
+                      snap.size());
         }
     }
 
@@ -192,7 +196,10 @@ void run_bridge(HMODULE self) noexcept {
         if (!mgr.active()) {
             if (!mgr.switch_to(c.general.default_source) && !mgr.switch_to(c.general.fallback_source)) {
                 auto snap = mgr.sources_snapshot();
-                if (snap.size() == 1) mgr.switch_to(snap[0]->name());
+                if (snap.size() == 1) {
+                    if (!mgr.switch_to(snap[0]->name()))
+                        log::error("[bridge] failed to switch to sole registered source '{}'", snap[0]->name());
+                }
             }
         }
 

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -166,7 +166,12 @@ void run_bridge(HMODULE self) noexcept {
     sync_sources(with_resolved_bins(cfg, deps));
 
     if (!mgr.switch_to(cfg.general.default_source) && !mgr.switch_to(cfg.general.fallback_source)) {
-        log::warn("[bridge] neither default nor fallback source was registered");
+        auto snap = mgr.sources_snapshot();
+        if (snap.size() == 1) {
+            mgr.switch_to(snap[0]->name());
+        } else {
+            log::warn("[bridge] neither default nor fallback source was registered");
+        }
     }
 
     fmod_bridge::DSPBridge bridge{mgr, fns};
@@ -185,7 +190,10 @@ void run_bridge(HMODULE self) noexcept {
         const Config c = with_resolved_bins(raw, deps);
         sync_sources(c);
         if (!mgr.active()) {
-            if (!mgr.switch_to(c.general.default_source)) mgr.switch_to(c.general.fallback_source);
+            if (!mgr.switch_to(c.general.default_source) && !mgr.switch_to(c.general.fallback_source)) {
+                auto snap = mgr.sources_snapshot();
+                if (snap.size() == 1) mgr.switch_to(snap[0]->name());
+            }
         }
 
         // Push the gain to both: the control loop's ramper otherwise snaps


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source selection when configured default and fallback fail: warns if no sources are available, automatically switches to the only registered source when exactly one exists, and otherwise logs the number of available sources.
  * Applied the same improved handling during configuration changes when the audio manager is inactive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->