### PR TITLE
Refactor local file playback to multi-station architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ An open-source radio mod for **Forza Horizon 6**. Adds a new in-game radio stati
 
 ## Features
 
-- **Local files**: point it at any folder. MP3 / FLAC / WAV / OGG / M4A / AAC / OPUS / WMA / M3U / M3U8 etc.
+- **Local files**: build named **stations** from one or more folders, exclude subfolders you don't want, and pick a play order (shuffle / albums / name / folder) with repeat modes and a searchable queue. MP3 / FLAC / WAV / OGG / M4A / AAC / OPUS / WMA / M3U / M3U8 etc.
 - **YouTube Music**: paste any video, playlist, or YT Music URL from the dashboard.
 - **Spotify Connect**: cast from the Spotify app to an "FH6 Universal Radio" device (requires Spotify Premium).
 - **Jellyfin**: stream playlists from your own Jellyfin server.
@@ -99,7 +99,7 @@ Requires **CMake** and **llvm-mingw**. On Arch: `sudo pacman -S llvm-mingw cmake
 |---|---|
 | Dashboard says **bridge offline** | Media overlay not installed. Re-run `install.ps1` with `dist\media\` present. |
 | New radio station doesn't show in-game | **Audio > Streamer Mode** is off. Turn it on, restart the game. |
-| Local files don't play | No `music_dir` set, or the folder only has unsupported formats. Set one from the dashboard. |
+| Local files don't play | The active station has no folders, or its folders only hold unsupported formats. Add a folder in the dashboard's Local Files card. |
 | YouTube Music produces no audio | Check `%TEMP%\fh6-stderr.log` (helper-process stderr lands there). Usually expired cookies, or geo/format restrictions. |
 | Spotify device doesn't appear or won't play | Wait for `librespot` to finish downloading, confirm your phone/PC is on the same network, and that the account is Spotify Premium. Helper stderr lands in `%TEMP%\fh6-spotify-stderr.log`. |
 | External Audio plays in the background, not through the radio | You're capturing the same device the app plays on. Route the app's output to a **virtual audio cable** and select that cable as the **Capture device** (see [External audio](#external-audio)). |

--- a/config.example.toml
+++ b/config.example.toml
@@ -3,7 +3,7 @@
 # if you prefer hand edits. Windows paths should use TOML literal strings
 # (single quotes) so backslashes pass through verbatim:
 #
-#   music_dir = 'C:\Users\you\Music'
+#   roots = ['C:\Users\you\Music']
 
 [general]
 port              = 8420

--- a/config.example.toml
+++ b/config.example.toml
@@ -14,11 +14,20 @@ ffmpeg_path       = ''                # blank = auto-download to fh6-radio/bin (
 
 [local_files]
 enabled            = true
-music_dir          = ''                # blank => set from the dashboard
-recursive          = true
-shuffle            = true
+active_station     = "My Music"        # which preset is on air
 # mp3/flac/wav/ogg decode natively; the rest goes through ffmpeg if available.
 supported_formats  = ["mp3", "flac", "wav", "ogg", "m4a", "opus", "aac", "wma", "aiff", "aif", "m3u", "m3u8"]
+
+# Stations are presets you manage from the dashboard's Local Files card. Each one
+# can point at several folders, exclude subfolders, and set its own play order.
+[[local_files.station]]
+name      = "My Music"
+roots     = []                         # e.g. ['C:\Users\you\Music', 'D:\FLAC']
+excluded  = []                         # subfolders to skip, e.g. ['C:\Users\you\Music\Audiobooks']
+recursive = true
+order     = "shuffle"                  # "shuffle" | "album" | "name" | "folder"
+grouping  = "folder"                   # album grouping when order = "album": "folder" | "tags"
+repeat    = "all"                      # "all" | "one" | "off"
 
 [youtube_music]
 enabled            = false

--- a/include/fh6/config.hpp
+++ b/include/fh6/config.hpp
@@ -28,11 +28,21 @@ struct GeneralConfig {
     std::filesystem::path ffmpeg_path;  // empty = look up on PATH; shared by all sources
 };
 
+// A named preset of folders + playback rules.
+struct LocalStation {
+    std::string name;
+    std::vector<std::filesystem::path> roots;     // one or more scan roots
+    std::vector<std::filesystem::path> excluded;  // absolute folders; folder + descendants skipped
+    bool recursive       = true;
+    std::string order     = "shuffle";  // "shuffle" | "album" | "name" | "folder"
+    std::string grouping  = "folder";   // for order=="album": "folder" | "tags"
+    std::string repeat    = "all";      // "all" | "one" | "off"
+};
+
 struct LocalFilesConfig {
     bool enabled = true;
-    std::filesystem::path music_dir;
-    bool recursive = true;
-    bool shuffle   = true;
+    std::vector<LocalStation> stations;
+    std::string active_station;         // station name; empty/unknown => first station
     std::vector<std::string> supported_formats{"mp3",  "flac", "wav", "ogg",  "m4a",
                                                 "opus", "aac",  "wma", "aiff", "aif",
                                                 "m3u",  "m3u8"};

--- a/include/fh6/http/http_server.hpp
+++ b/include/fh6/http/http_server.hpp
@@ -26,8 +26,15 @@ namespace fh6::http {
 //   POST /api/source/<name>/{play,pause,stop,next,previous}
 //
 //   POST /api/source/youtube_music/cast   body {"url":"..."}
-//   POST /api/source/local_files/rescan   body {"music_dir":"...","recursive":bool}
-//   GET  /api/source/local_files/playlist
+//
+//   POST /api/fs/browse                   body {"path":"..."}; "" => drive list
+//   GET  /api/source/local_files/stations stations + active_station + track_count
+//   PUT  /api/source/local_files/stations body {"stations":[...],"active_station":"..."}
+//   POST /api/source/local_files/activate body {"name":"..."} (switch source + play)
+//   GET  /api/source/local_files/queue    {"cursor":N,"tracks":[{index,title,folder}]}
+//   POST /api/source/local_files/play     body {"index":N}
+//   POST /api/source/local_files/reshuffle
+//   POST /api/source/local_files/rescan   re-scan the active station
 //
 //   GET  /api/config                      full config.toml as JSON
 //   PUT  /api/config                      deep-patch config; writes file + notifies

--- a/include/fh6/sources/local_file_source.hpp
+++ b/include/fh6/sources/local_file_source.hpp
@@ -5,16 +5,33 @@
 #include "fh6/playback_dsp.hpp"
 
 #include <atomic>
+#include <cstdint>
 #include <filesystem>
 #include <memory>
 #include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
 #include <vector>
 
 namespace fh6::sources {
 
+// One immediate subfolder (or drive, when listing the filesystem root) used by
+// the dashboard folder browser and the exclusion tree.
+struct FsEntry {
+    std::string name;
+    std::string path;
+    bool has_children = false;
+};
+
+// List immediate subdirectories of `dir`. An empty `dir` lists drive roots.
+std::vector<FsEntry> enumerate_dir(const std::filesystem::path& dir);
+
 class LocalFileSource final : public IAudioSource {
 public:
-    LocalFileSource(LocalFilesConfig cfg, std::filesystem::path ffmpeg_path);
+    // index_path: where the tag-grouping metadata cache is persisted.
+    LocalFileSource(LocalFilesConfig cfg, std::filesystem::path ffmpeg_path,
+                    std::filesystem::path index_path);
     ~LocalFileSource() override;
 
     std::string_view name() const noexcept override { return "local_files"; }
@@ -33,11 +50,27 @@ public:
 
     void pump(RingBuffer& ring) override;
 
-    void set_directory(std::filesystem::path dir, bool recursive);
-    void set_shuffle(bool shuffle);
+    // Replace the whole config; rescans only when scan-affecting fields of the
+    // active station changed. repeat is applied live without a rescan.
+    void set_config(LocalFilesConfig cfg);
+    // Switch the on-air preset by name (rescans + restarts playback).
+    void set_active_station(std::string name);
+    void reshuffle();
+    bool jump_to(std::size_t index);
     void set_ffmpeg_path(std::filesystem::path p);
     void set_playback_options(const PlaybackConfig& opts) override;
-    std::vector<std::string> playlist_snapshot() const;
+
+    struct QueueEntry {
+        std::size_t index = 0;
+        std::string title;   // metadata title when indexed, else file stem
+        std::string artist;  // metadata artist when indexed
+        std::string folder;  // parent folder name
+    };
+    struct QueueSnapshot {
+        std::size_t cursor = 0;
+        std::vector<QueueEntry> entries;
+    };
+    QueueSnapshot queue_snapshot() const;
 
     TrackInfo current_track() const override;
     std::optional<ArtworkImage> artwork() const override;
@@ -48,13 +81,58 @@ public:
     AuthState auth_state() const noexcept override;
     std::string auth_instructions() const override;
     std::size_t track_count() const noexcept;
+    std::size_t station_count() const noexcept;
+    // Bumps each time a background metadata-index pass finishes, so the UI can
+    // refresh the queue once real titles/artists become available.
+    std::uint64_t index_version() const noexcept {
+        return index_version_.load(std::memory_order_acquire);
+    }
+
+    // Active-station descriptors for /api/sources details.
+    std::string active_station_name() const;
+    std::string active_order() const;
+    std::string active_grouping() const;
+    std::string active_repeat() const;
 
     SourceCapabilities capabilities() const noexcept override { return {true, true, false}; }
 
 private:
     struct Decoder; // pimpl, keeps miniaudio out of the header
 
+    struct TrackMeta {
+        std::int64_t mtime = 0;
+        std::string album, album_artist, title, artist;
+        int track_no = 0, disc_no = 0;
+        std::uint64_t duration_ms = 0;
+    };
+
     void rebuild_playlist();
+    const LocalStation* active_station_locked() const noexcept;
+    bool is_shuffle_locked() const noexcept;
+    std::string repeat_mode_locked() const;
+
+    void apply_order_locked(const LocalStation& st);
+    void order_album_by_folder_locked();
+    void shuffle_in_place_locked(std::vector<std::filesystem::path>& v) const;
+
+    // Forward navigation that ignores repeat (explicit skip/next), and the
+    // repeat-aware variant used when a track ends naturally.
+    bool advance_forward_locked();
+    bool eof_advance_locked();
+
+    // Tag-grouping background index. Probed off the audio path; the playlist is
+    // re-sorted in place once metadata lands.
+    void stop_tag_thread();
+    // Always populates the metadata index in the background; reorders the
+    // playlist by tags too when `resort` is set (album order, tag grouping).
+    void start_index_locked(std::uint64_t gen, bool resort);
+    void index_worker(std::vector<std::filesystem::path> paths, std::wstring ff,
+                      std::uint64_t gen, bool resort);
+    void load_index_if_needed();
+    void save_index();
+    std::vector<std::filesystem::path>
+    order_album_by_tags(const std::vector<std::filesystem::path>& in);
+
     // Open one decoder for playlist_[index] (miniaudio first, ffmpeg fallback).
     // Returns nullptr if the file is unplayable / out of range.
     std::unique_ptr<Decoder> open_decoder_locked(std::size_t index);
@@ -68,8 +146,10 @@ private:
 
     LocalFilesConfig cfg_;
     std::filesystem::path ffmpeg_path_;
+    std::filesystem::path index_path_;
     std::vector<std::filesystem::path> playlist_;
     std::size_t cursor_ = 0;
+    std::filesystem::path last_played_;  // bag-shuffle: avoid an immediate repeat on wrap
 
     std::unique_ptr<Decoder> dec_;
     std::unique_ptr<Decoder> prefetch_dec_;
@@ -77,6 +157,16 @@ private:
     mutable std::mutex mu_;
     std::atomic<PlaybackState> state_{PlaybackState::stopped};
     std::atomic<uint64_t> position_ms_{0};
+
+    // Tag index state. index_mu_ is never held while mu_ is held by the worker
+    // (the worker takes mu_ only for the final swap), avoiding lock-order issues.
+    mutable std::mutex index_mu_;
+    std::unordered_map<std::string, TrackMeta> index_;
+    bool index_loaded_ = false;
+    std::thread tag_thread_;
+    std::atomic<bool> tag_cancel_{false};
+    std::atomic<std::uint64_t> rebuild_gen_{0};
+    std::atomic<std::uint64_t> index_version_{0};
 
     EqualizerStage eq_;
     std::atomic<bool> volume_norm_{true};

--- a/scripts/dist-readme.txt
+++ b/scripts/dist-readme.txt
@@ -53,9 +53,11 @@ Prompt to find it.
 
 From there:
 
-  * Local files: give it a folder full of MP3, FLAC, WAV, OGG, M4A,
-    AAC, OPUS, M3U, M3U8 or WMA tracks. Subfolders are scanned too. Shuffle,
-    skip, and volume controls are all in the UI.
+  * Local files: build "stations" from one or more folders of MP3, FLAC,
+    WAV, OGG, M4A, AAC, OPUS, M3U, M3U8 or WMA tracks. Subfolders are
+    scanned too, and you can uncheck the ones you don't want. Pick a play
+    order (shuffle / albums / name / folder), a repeat mode, and browse or
+    search the queue.
 
   * YouTube Music: paste a video URL, a playlist, or a YT Music
     link.

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -128,8 +128,8 @@ void run_bridge(HMODULE self) noexcept {
     // the dashboard tile live, without a game restart.
     auto sync_sources = [&mgr, &data_dir](const Config& c) {
         if (c.local_files.enabled && !mgr.find("local_files")) {
-            auto src = std::make_unique<sources::LocalFileSource>(c.local_files,
-                                                                  c.general.ffmpeg_path);
+            auto src = std::make_unique<sources::LocalFileSource>(
+                c.local_files, c.general.ffmpeg_path, data_dir / "local_index.json");
             if (src->initialize()) mgr.register_source(std::move(src));
         } else if (!c.local_files.enabled && mgr.find("local_files")) {
             mgr.unregister_source("local_files");
@@ -209,9 +209,8 @@ void run_bridge(HMODULE self) noexcept {
         bridge.set_force_stereo_audio(c.playback.force_stereo_audio);
         if (ctrl_ptr) ctrl_ptr->set_configured_gain(c.audio.output_gain);
         if (auto* local = dynamic_cast<sources::LocalFileSource*>(mgr.find("local_files"))) {
-            local->set_shuffle(c.local_files.shuffle);
             local->set_ffmpeg_path(c.general.ffmpeg_path);
-            local->set_directory(c.local_files.music_dir, c.local_files.recursive);
+            local->set_config(c.local_files);
             if (mgr.active() == local && local->track_count() > 0 &&
                 local->playback_state() != PlaybackState::playing) {
                 local->play();

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -59,17 +59,55 @@ Config load_config(const std::filesystem::path& path) {
         pick<std::string>(g, "fallback_source", cfg.general.fallback_source);
     cfg.general.ffmpeg_path = pick_path(g, "ffmpeg_path");
 
-    const auto& lf            = section(root, "local_files");
-    cfg.local_files.enabled   = pick<bool>(lf, "enabled", cfg.local_files.enabled);
-    cfg.local_files.music_dir = pick_path(lf, "music_dir");
-    cfg.local_files.recursive = pick<bool>(lf, "recursive", cfg.local_files.recursive);
-    cfg.local_files.shuffle   = pick<bool>(lf, "shuffle", cfg.local_files.shuffle);
+    const auto& lf          = section(root, "local_files");
+    cfg.local_files.enabled = pick<bool>(lf, "enabled", cfg.local_files.enabled);
+    cfg.local_files.active_station = pick<std::string>(lf, "active_station", "");
     try {
         if (lf.contains("supported_formats")) {
             auto v = toml::find<std::vector<std::string>>(lf, "supported_formats");
             if (!v.empty()) cfg.local_files.supported_formats = std::move(v);
         }
     } catch (...) {}
+
+    auto read_paths = [](const toml::value& tbl, const char* key) {
+        std::vector<std::filesystem::path> out;
+        try {
+            if (tbl.contains(key))
+                for (auto& s : toml::find<std::vector<std::string>>(tbl, key))
+                    if (!s.empty()) out.emplace_back(s);
+        } catch (...) {}
+        return out;
+    };
+    try {
+        if (lf.contains("station")) {
+            for (const auto& st : toml::find<std::vector<toml::value>>(lf, "station")) {
+                LocalStation s;
+                s.name      = pick<std::string>(st, "name", "");
+                s.roots     = read_paths(st, "roots");
+                s.excluded  = read_paths(st, "excluded");
+                s.recursive = pick<bool>(st, "recursive", s.recursive);
+                s.order     = pick<std::string>(st, "order", s.order);
+                s.grouping  = pick<std::string>(st, "grouping", s.grouping);
+                s.repeat    = pick<std::string>(st, "repeat", s.repeat);
+                if (s.name.empty()) s.name = "Station " + std::to_string(cfg.local_files.stations.size() + 1);
+                cfg.local_files.stations.push_back(std::move(s));
+            }
+        }
+    } catch (...) {}
+
+    // Migrate the legacy flat layout (music_dir / recursive / shuffle) into a
+    // single "My Music" station so existing installs keep working untouched.
+    if (cfg.local_files.stations.empty()) {
+        auto music_dir = pick_path(lf, "music_dir");
+        LocalStation s;
+        s.name      = "My Music";
+        s.recursive = pick<bool>(lf, "recursive", true);
+        s.order     = pick<bool>(lf, "shuffle", true) ? "shuffle" : "name";
+        if (!music_dir.empty()) s.roots.push_back(std::move(music_dir));
+        cfg.local_files.stations.push_back(std::move(s));
+    }
+    if (cfg.local_files.active_station.empty())
+        cfg.local_files.active_station = cfg.local_files.stations.front().name;
 
     const auto& ym                     = section(root, "youtube_music");
     cfg.youtube_music.enabled          = pick<bool>(ym, "enabled", cfg.youtube_music.enabled);
@@ -150,16 +188,19 @@ struct Emitter {
         out += name;
         out += "]\n";
     }
-    void kv(std::string_view key, std::string_view str) {
-        // Literal (single-quoted) strings don't process escapes, which is
-        // what we want for Windows paths. Use them when the value contains
-        // \ or " and no '; otherwise basic double-quoted with backslash
-        // escaping.
-        const bool has_bs  = str.find('\\') != std::string_view::npos;
-        const bool has_dq  = str.find('"') != std::string_view::npos;
-        const bool has_sq  = str.find('\'') != std::string_view::npos;
-        out               += key;
-        out               += " = ";
+    void array_header(const char* name) {
+        if (!out.empty()) out += '\n';
+        out += "[[";
+        out += name;
+        out += "]]\n";
+    }
+    // Literal (single-quoted) strings don't process escapes, which is what we
+    // want for Windows paths. Use them when the value contains \ or " and no ';
+    // otherwise basic double-quoted with backslash escaping.
+    void quoted(std::string_view str) {
+        const bool has_bs = str.find('\\') != std::string_view::npos;
+        const bool has_dq = str.find('"') != std::string_view::npos;
+        const bool has_sq = str.find('\'') != std::string_view::npos;
         if ((has_bs || has_dq) && !has_sq) {
             out += '\'';
             out += str;
@@ -172,7 +213,21 @@ struct Emitter {
             }
             out += '"';
         }
+    }
+    void kv(std::string_view key, std::string_view str) {
+        out += key;
+        out += " = ";
+        quoted(str);
         out += '\n';
+    }
+    void kv_paths(std::string_view key, const std::vector<std::filesystem::path>& v) {
+        out += key;
+        out += " = [";
+        for (std::size_t i = 0; i < v.size(); ++i) {
+            if (i) out += ", ";
+            quoted(v[i].string());
+        }
+        out += "]\n";
     }
     void kv(std::string_view key, bool v) {
         out += key;
@@ -234,10 +289,18 @@ void save_config(const std::filesystem::path& path, const Config& cfg) {
 
     e.header("local_files");
     e.kv("enabled", cfg.local_files.enabled);
-    e.kv_path("music_dir", cfg.local_files.music_dir);
-    e.kv("recursive", cfg.local_files.recursive);
-    e.kv("shuffle", cfg.local_files.shuffle);
+    e.kv("active_station", cfg.local_files.active_station);
     e.kv_strs("supported_formats", cfg.local_files.supported_formats);
+    for (const auto& st : cfg.local_files.stations) {
+        e.array_header("local_files.station");
+        e.kv("name", st.name);
+        e.kv_paths("roots", st.roots);
+        e.kv_paths("excluded", st.excluded);
+        e.kv("recursive", st.recursive);
+        e.kv("order", st.order);
+        e.kv("grouping", st.grouping);
+        e.kv("repeat", st.repeat);
+    }
 
     e.header("youtube_music");
     e.kv("enabled", cfg.youtube_music.enabled);

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -96,11 +96,42 @@ json source_to_json(IAudioSource* s) {
          }},
         {"details", json::object()},
     };
-    if (auto* lf = dynamic_cast<sources::LocalFileSource*>(s))
-        j["details"]["track_count"] = lf->track_count();
+    if (auto* lf = dynamic_cast<sources::LocalFileSource*>(s)) {
+        j["details"]["track_count"]    = lf->track_count();
+        j["details"]["station_count"]  = lf->station_count();
+        j["details"]["active_station"] = lf->active_station_name();
+        j["details"]["order"]          = lf->active_order();
+        j["details"]["grouping"]       = lf->active_grouping();
+        j["details"]["repeat"]         = lf->active_repeat();
+        j["details"]["index_version"]  = lf->index_version();
+    }
     if (auto* yt = dynamic_cast<sources::YouTubeMusicSource*>(s))
         j["details"]["shuffle"] = yt->shuffle();
     return j;
+}
+
+json paths_to_json(const std::vector<std::filesystem::path>& v) {
+    json a = json::array();
+    for (const auto& p : v) a.push_back(path_s(p));
+    return a;
+}
+
+json station_to_json(const LocalStation& s) {
+    return json{
+        {"name", s.name},
+        {"roots", paths_to_json(s.roots)},
+        {"excluded", paths_to_json(s.excluded)},
+        {"recursive", s.recursive},
+        {"order", s.order},
+        {"grouping", s.grouping},
+        {"repeat", s.repeat},
+    };
+}
+
+json stations_to_json(const std::vector<LocalStation>& v) {
+    json a = json::array();
+    for (const auto& s : v) a.push_back(station_to_json(s));
+    return a;
 }
 
 json config_to_json(const Config& c) {
@@ -116,9 +147,8 @@ json config_to_json(const Config& c) {
         {"local_files",
          json{
              {"enabled", c.local_files.enabled},
-             {"music_dir", path_s(c.local_files.music_dir)},
-             {"recursive", c.local_files.recursive},
-             {"shuffle", c.local_files.shuffle},
+             {"active_station", c.local_files.active_station},
+             {"stations", stations_to_json(c.local_files.stations)},
              {"supported_formats", c.local_files.supported_formats},
          }},
         {"youtube_music",
@@ -180,6 +210,29 @@ std::filesystem::path pull_path(const json& tbl, const char* k,
     return s.empty() ? std::filesystem::path{} : std::filesystem::path{s};
 }
 
+std::vector<std::filesystem::path> paths_from_json(const json& a) {
+    std::vector<std::filesystem::path> out;
+    if (a.is_array())
+        for (const auto& e : a)
+            if (e.is_string()) {
+                auto s = e.get<std::string>();
+                if (!s.empty()) out.emplace_back(s);
+            }
+    return out;
+}
+
+LocalStation station_from_json(const json& j) {
+    LocalStation s;
+    s.name      = pull<std::string>(j, "name", "");
+    s.recursive = pull<bool>(j, "recursive", true);
+    s.order     = pull<std::string>(j, "order", s.order);
+    s.grouping  = pull<std::string>(j, "grouping", s.grouping);
+    s.repeat    = pull<std::string>(j, "repeat", s.repeat);
+    if (auto it = j.find("roots"); it != j.end())    s.roots    = paths_from_json(*it);
+    if (auto it = j.find("excluded"); it != j.end()) s.excluded = paths_from_json(*it);
+    return s;
+}
+
 // Deep-merge a partial JSON patch into Config. Absent keys keep their value.
 void apply_patch(Config& c, const json& j) {
     if (auto it = j.find("general"); it != j.end()) {
@@ -190,10 +243,14 @@ void apply_patch(Config& c, const json& j) {
         c.general.ffmpeg_path     = pull_path(*it, "ffmpeg_path", c.general.ffmpeg_path);
     }
     if (auto it = j.find("local_files"); it != j.end()) {
-        c.local_files.enabled   = pull(*it, "enabled", c.local_files.enabled);
-        c.local_files.music_dir = pull_path(*it, "music_dir", c.local_files.music_dir);
-        c.local_files.recursive = pull(*it, "recursive", c.local_files.recursive);
-        c.local_files.shuffle   = pull(*it, "shuffle", c.local_files.shuffle);
+        c.local_files.enabled = pull(*it, "enabled", c.local_files.enabled);
+        c.local_files.active_station =
+            pull(*it, "active_station", c.local_files.active_station);
+        if (auto sts = it->find("stations"); sts != it->end() && sts->is_array()) {
+            std::vector<LocalStation> parsed;
+            for (const auto& st : *sts) parsed.push_back(station_from_json(st));
+            if (!parsed.empty()) c.local_files.stations = std::move(parsed);
+        }
         if (auto fmts = it->find("supported_formats"); fmts != it->end() && fmts->is_array())
             c.local_files.supported_formats = fmts->get<std::vector<std::string>>();
     }
@@ -541,10 +598,80 @@ struct HttpServer::Impl {
             deps.retry();
             return ok();
         }
-        if (m == "GET" && p == "/api/source/local_files/playlist") {
+        if (m == "GET" && p == "/api/source/local_files/queue") {
             auto* lf = find_typed<sources::LocalFileSource>("local_files");
-            return lf ? ok(json{{"tracks", lf->playlist_snapshot()}})
-                      : fail(404, "local_files not registered");
+            if (!lf) return fail(404, "local_files not registered");
+            auto snap   = lf->queue_snapshot();
+            json tracks = json::array();
+            for (const auto& e : snap.entries)
+                tracks.push_back(
+                    json{{"index", e.index}, {"title", e.title}, {"folder", e.folder}});
+            return ok(json{{"cursor", snap.cursor}, {"tracks", tracks}});
+        }
+        if (m == "POST" && p == "/api/fs/browse") {
+            auto j = req.body.empty() ? json::object() : json::parse(req.body);
+            std::filesystem::path dir = j.value("path", std::string{});
+            json entries              = json::array();
+            for (const auto& e : sources::enumerate_dir(dir))
+                entries.push_back(
+                    json{{"name", e.name}, {"path", e.path}, {"has_children", e.has_children}});
+            std::string parent;
+            if (!dir.empty()) {
+                auto pp = dir.parent_path();
+                if (pp != dir) parent = path_s(pp);  // at a drive root, fall back to the drive list
+            }
+            return ok(json{{"parent", parent}, {"path", path_s(dir)}, {"entries", entries}});
+        }
+        if (m == "GET" && p == "/api/source/local_files/stations") {
+            auto* lf  = find_typed<sources::LocalFileSource>("local_files");
+            auto snap = store.snapshot();
+            return ok(json{
+                {"stations", stations_to_json(snap.local_files.stations)},
+                {"active_station", snap.local_files.active_station},
+                {"track_count", lf ? lf->track_count() : 0},
+            });
+        }
+        if (m == "PUT" && p == "/api/source/local_files/stations") {
+            auto j = json::parse(req.body);
+            store.patch([&](Config& c) {
+                if (auto sts = j.find("stations"); sts != j.end() && sts->is_array()) {
+                    std::vector<LocalStation> parsed;
+                    for (const auto& st : *sts) parsed.push_back(station_from_json(st));
+                    if (!parsed.empty()) c.local_files.stations = std::move(parsed);
+                }
+                if (auto a = j.find("active_station"); a != j.end() && a->is_string())
+                    c.local_files.active_station = a->get<std::string>();
+            });
+            auto* lf = find_typed<sources::LocalFileSource>("local_files");
+            return ok(json{{"track_count", lf ? lf->track_count() : 0}});
+        }
+        if (m == "POST" && p == "/api/source/local_files/activate") {
+            auto* lf = find_typed<sources::LocalFileSource>("local_files");
+            if (!lf) return fail(404, "local_files not registered");
+            auto name             = json::parse(req.body).value("name", std::string{});
+            const bool was_active = (mgr.active() == lf);
+            // patch -> apply_config -> set_config rebuilds for the new station.
+            store.patch([&](Config& c) { c.local_files.active_station = name; });
+            if (was_active) mgr.ring().drain();
+            lf->play();
+            mgr.switch_to("local_files");
+            return ok(json{{"track_count", lf->track_count()}});
+        }
+        if (m == "POST" && p == "/api/source/local_files/play") {
+            auto* lf = find_typed<sources::LocalFileSource>("local_files");
+            if (!lf) return fail(404, "local_files not registered");
+            auto idx              = json::parse(req.body).value("index", std::size_t{0});
+            const bool was_active = (mgr.active() == lf);
+            if (!lf->jump_to(idx)) return fail(400, "index out of range");
+            if (was_active) mgr.ring().drain();
+            mgr.switch_to("local_files");
+            return ok();
+        }
+        if (m == "POST" && p == "/api/source/local_files/reshuffle") {
+            auto* lf = find_typed<sources::LocalFileSource>("local_files");
+            if (!lf) return fail(404, "local_files not registered");
+            lf->reshuffle();
+            return ok();
         }
 
         if (m == "PUT" && p == "/api/config") {
@@ -643,20 +770,9 @@ struct HttpServer::Impl {
         if (m == "POST" && p == "/api/source/local_files/rescan") {
             auto* lf = find_typed<sources::LocalFileSource>("local_files");
             if (!lf) return fail(404, "local_files not registered");
-            auto j = req.body.empty() ? json::object() : json::parse(req.body);
-            if (auto it = j.find("music_dir"); it != j.end()) {
-                std::filesystem::path dir = it->get<std::string>();
-                bool recursive            = j.value("recursive", true);
-                lf->set_directory(dir, recursive);
-                store.patch([&](Config& c) {
-                    c.local_files.music_dir = dir;
-                    c.local_files.recursive = recursive;
-                });
-            } else {
-                auto snap = store.snapshot();
-                lf->set_directory(snap.local_files.music_dir, snap.local_files.recursive);
-            }
-            return ok(json{{"track_count", lf->playlist_snapshot().size()}});
+            // Re-apply the stored config; set_config rescans the active station.
+            lf->set_config(store.snapshot().local_files);
+            return ok(json{{"track_count", lf->track_count()}});
         }
         if (m == "POST" && p == "/api/options") {
             auto j = json::parse(req.body);

--- a/src/sources/local_file_source.cpp
+++ b/src/sources/local_file_source.cpp
@@ -20,9 +20,14 @@
 #pragma warning(pop)
 #endif
 
+#include <nlohmann/json.hpp>
+
 #include <algorithm>
+#include <chrono>
 #include <fstream>
 #include <random>
+#include <set>
+#include <unordered_map>
 
 namespace fh6::sources {
 
@@ -69,8 +74,21 @@ std::vector<std::filesystem::path> parse_m3u_playlist(const std::filesystem::pat
 
 struct ProbedMetadata {
     std::uint64_t duration_ms = 0;
-    std::string title, artist, album;
+    std::string title, artist, album, album_artist;
+    int track_no = 0, disc_no = 0;
 };
+
+// Leading integer of values like "5", "5/12", "05" -> 5; 0 when absent.
+int parse_leading_int(std::string_view v) noexcept {
+    int n = 0;
+    bool any = false;
+    for (char c : v) {
+        if (c < '0' || c > '9') break;
+        any = true;
+        n   = n * 10 + (c - '0');
+    }
+    return any ? n : 0;
+}
 
 // Cover format from magic bytes; "" for anything we wouldn't give an <img>.
 std::string sniff_image_mime(const std::string& d) noexcept {
@@ -204,11 +222,36 @@ ProbedMetadata probe_metadata(const std::wstring& ff_bin, const std::filesystem:
         while (!val.empty() && val.front() == ' ') val.remove_prefix(1);
         if (val.empty()) continue;
 
-        if (out.title.empty()       && ieq_str(key, "title"))  out.title.assign(val);
-        else if (out.artist.empty() && ieq_str(key, "artist")) out.artist.assign(val);
-        else if (out.album.empty()  && ieq_str(key, "album"))  out.album.assign(val);
+        if (out.title.empty()              && ieq_str(key, "title"))        out.title.assign(val);
+        else if (out.artist.empty()        && ieq_str(key, "artist"))       out.artist.assign(val);
+        else if (out.album.empty()         && ieq_str(key, "album"))        out.album.assign(val);
+        else if (out.album_artist.empty()  && (ieq_str(key, "album_artist") ||
+                                               ieq_str(key, "ALBUM ARTIST") ||
+                                               ieq_str(key, "albumartist"))) out.album_artist.assign(val);
+        else if (out.track_no == 0         && ieq_str(key, "track"))        out.track_no = parse_leading_int(val);
+        else if (out.disc_no == 0          && (ieq_str(key, "disc") ||
+                                               ieq_str(key, "discnumber")))  out.disc_no = parse_leading_int(val);
     }
     return out;
+}
+
+// Case-insensitive, separator-aware prefix test using normalized generic
+// strings, so "C:/Music/Live" is detected as inside "C:/music".
+std::string norm_path_key(const std::filesystem::path& p) {
+    auto s = p.lexically_normal().generic_string();
+    std::ranges::transform(s, s.begin(), [](unsigned char c) { return (char)std::tolower(c); });
+    if (!s.empty() && s.back() == '/') s.pop_back();
+    return s;
+}
+bool path_within(const std::string& child, const std::string& parent) noexcept {
+    if (parent.empty() || child.size() < parent.size()) return false;
+    if (child.compare(0, parent.size(), parent) != 0) return false;
+    return child.size() == parent.size() || child[parent.size()] == '/';
+}
+
+std::mt19937& thread_rng() {
+    static thread_local std::mt19937 g{std::random_device{}()};
+    return g;
 }
 
 } // namespace
@@ -242,57 +285,305 @@ struct LocalFileSource::Decoder {
     }
 };
 
-LocalFileSource::LocalFileSource(LocalFilesConfig cfg, std::filesystem::path ffmpeg_path)
+LocalFileSource::LocalFileSource(LocalFilesConfig cfg, std::filesystem::path ffmpeg_path,
+                                 std::filesystem::path index_path)
     : cfg_{std::move(cfg)},
-      ffmpeg_path_{std::move(ffmpeg_path)} {}
+      ffmpeg_path_{std::move(ffmpeg_path)},
+      index_path_{std::move(index_path)} {}
 
-LocalFileSource::~LocalFileSource() { close_current(); }
+LocalFileSource::~LocalFileSource() {
+    stop_tag_thread();
+    close_current();
+}
 
 void LocalFileSource::shutdown() noexcept { close_current(); }
 
 bool LocalFileSource::initialize() {
     if (!cfg_.enabled) return false;
-    // No directory yet is fine. auth_state stays needs_auth until the user
-    // sets one from the dashboard, which calls set_directory() to rescan.
-    if (cfg_.music_dir.empty() || !std::filesystem::exists(cfg_.music_dir)) {
-        log::warn("[local] registered with no music_dir yet -- set one from the dashboard");
-        return true;
-    }
+    // No roots yet is fine. auth_state stays needs_auth until the user adds a
+    // folder from the dashboard, which calls set_config() to rescan.
     rebuild_playlist();
-    log::info("[local] discovered {} tracks in {}", playlist_.size(), cfg_.music_dir.string());
+    log::info("[local] station '{}': {} tracks", active_station_name(), track_count());
     return true;
 }
 
+const LocalStation* LocalFileSource::active_station_locked() const noexcept {
+    if (cfg_.stations.empty()) return nullptr;
+    for (const auto& s : cfg_.stations)
+        if (s.name == cfg_.active_station) return &s;
+    return &cfg_.stations.front();
+}
+
+bool LocalFileSource::is_shuffle_locked() const noexcept {
+    const LocalStation* st = active_station_locked();
+    return st && st->order == "shuffle";
+}
+
+std::string LocalFileSource::repeat_mode_locked() const {
+    const LocalStation* st = active_station_locked();
+    return st ? st->repeat : std::string{"all"};
+}
+
+void LocalFileSource::shuffle_in_place_locked(std::vector<std::filesystem::path>& v) const {
+    std::shuffle(v.begin(), v.end(), thread_rng());
+}
+
+void LocalFileSource::order_album_by_folder_locked() {
+    std::unordered_map<std::string, std::vector<std::filesystem::path>> groups;
+    std::vector<std::string> order;
+    for (auto& p : playlist_) {
+        auto key            = p.parent_path().string();
+        auto [it, inserted] = groups.try_emplace(key);
+        if (inserted) order.push_back(key);
+        it->second.push_back(std::move(p));
+    }
+    for (auto& [_, v] : groups) std::ranges::sort(v);  // track order within the album
+    std::shuffle(order.begin(), order.end(), thread_rng());  // album order
+    playlist_.clear();
+    for (auto& key : order)
+        for (auto& p : groups[key]) playlist_.push_back(std::move(p));
+}
+
+void LocalFileSource::apply_order_locked(const LocalStation& st) {
+    if (st.order == "name") {
+        std::ranges::sort(playlist_);
+    } else if (st.order == "folder") {
+        std::ranges::sort(playlist_, [](const auto& a, const auto& b) {
+            const auto pa = a.parent_path(), pb = b.parent_path();
+            return pa != pb ? pa < pb : a.filename() < b.filename();
+        });
+    } else if (st.order == "album") {
+        order_album_by_folder_locked();  // immediate; tag re-sort refines it later
+    } else {
+        shuffle_in_place_locked(playlist_);  // "shuffle"
+    }
+}
+
 void LocalFileSource::rebuild_playlist() {
+    stop_tag_thread();   // join any in-flight tag re-sort before mutating state
     std::scoped_lock lk{mu_};
     discard_prefetch_locked();   // playlist contents/order are about to change
+    const std::uint64_t gen = ++rebuild_gen_;
     playlist_.clear();
-    std::error_code ec;
-    auto add = [&](const std::filesystem::path& p) {
+    cursor_ = 0;
+
+    const LocalStation* st = active_station_locked();
+    if (!st || st->roots.empty()) return;
+
+    std::vector<std::string> excluded;
+    excluded.reserve(st->excluded.size());
+    for (const auto& e : st->excluded) excluded.push_back(norm_path_key(e));
+    auto is_excluded = [&](const std::filesystem::path& dir) {
+        const auto key = norm_path_key(dir);
+        for (const auto& ex : excluded)
+            if (path_within(key, ex)) return true;
+        return false;
+    };
+
+    std::set<std::filesystem::path> seen;
+    auto add_file = [&](const std::filesystem::path& p) {
         const auto ext = p.extension().string();
         if (ieq_str(ext, ".m3u") || ieq_str(ext, ".m3u8")) {
             for (auto& entry : parse_m3u_playlist(p))
-                if (extension_matches(entry, cfg_.supported_formats))
+                if (extension_matches(entry, cfg_.supported_formats) && seen.insert(entry).second)
                     playlist_.push_back(std::move(entry));
-        } else if (extension_matches(p, cfg_.supported_formats)) {
+        } else if (extension_matches(p, cfg_.supported_formats) && seen.insert(p).second) {
             playlist_.push_back(p);
         }
     };
-    if (cfg_.recursive) {
-        for (const auto& e : std::filesystem::recursive_directory_iterator(
-                 cfg_.music_dir, std::filesystem::directory_options::skip_permission_denied, ec))
-            if (e.is_regular_file(ec)) add(e.path());
-    } else {
-        for (const auto& e : std::filesystem::directory_iterator(cfg_.music_dir, ec))
-            if (e.is_regular_file(ec)) add(e.path());
+
+    for (const auto& root : st->roots) {
+        std::error_code ec;
+        if (root.empty() || !std::filesystem::exists(root, ec)) continue;
+        if (st->recursive) {
+            std::filesystem::recursive_directory_iterator it(
+                root, std::filesystem::directory_options::skip_permission_denied, ec), end;
+            for (; it != end && !ec; it.increment(ec)) {
+                std::error_code fe;
+                if (it->is_directory(fe)) {
+                    if (is_excluded(it->path())) it.disable_recursion_pending();
+                } else if (it->is_regular_file(fe)) {
+                    add_file(it->path());
+                }
+            }
+        } else {
+            for (const auto& e : std::filesystem::directory_iterator(root, ec))
+                if (e.is_regular_file(ec)) add_file(e.path());
+        }
     }
-    if (cfg_.shuffle) {
-        static thread_local std::mt19937 rng{std::random_device{}()};
-        std::shuffle(playlist_.begin(), playlist_.end(), rng);
-    } else {
-        std::ranges::sort(playlist_);
+
+    apply_order_locked(*st);
+    // Populate the metadata index in the background for every station so the
+    // queue shows real titles and search matches them; reorder by tags only
+    // when the station asks for album/tag grouping.
+    start_index_locked(gen, st->order == "album" && st->grouping == "tags");
+}
+
+// ---- tag-grouping background index -----------------------------------------
+
+void LocalFileSource::stop_tag_thread() {
+    tag_cancel_.store(true, std::memory_order_release);
+    if (tag_thread_.joinable()) tag_thread_.join();
+    tag_cancel_.store(false, std::memory_order_release);
+}
+
+void LocalFileSource::start_index_locked(std::uint64_t gen, bool resort) {
+    if (playlist_.empty()) return;
+    auto paths      = playlist_;
+    std::wstring ff = ffmpeg_path_.empty() ? L"ffmpeg" : ffmpeg_path_.wstring();
+    tag_thread_     = std::thread(&LocalFileSource::index_worker, this, std::move(paths),
+                                  std::move(ff), gen, resort);
+}
+
+void LocalFileSource::load_index_if_needed() {
+    std::scoped_lock il{index_mu_};
+    if (index_loaded_) return;
+    index_loaded_ = true;
+    if (index_path_.empty()) return;
+    std::ifstream in(index_path_, std::ios::binary);
+    if (!in) return;
+    try {
+        nlohmann::json j;
+        in >> j;
+        for (auto& [k, v] : j.items()) {
+            TrackMeta m;
+            m.mtime        = v.value("mtime", std::int64_t{0});
+            m.album        = v.value("album", std::string{});
+            m.album_artist = v.value("album_artist", std::string{});
+            m.title        = v.value("title", std::string{});
+            m.artist       = v.value("artist", std::string{});
+            m.track_no     = v.value("track_no", 0);
+            m.disc_no      = v.value("disc_no", 0);
+            m.duration_ms  = v.value("duration_ms", std::uint64_t{0});
+            index_[k]      = std::move(m);
+        }
+    } catch (...) {}
+}
+
+void LocalFileSource::save_index() {
+    if (index_path_.empty()) return;
+    nlohmann::json j = nlohmann::json::object();
+    {
+        std::scoped_lock il{index_mu_};
+        for (auto& [k, m] : index_)
+            j[k] = nlohmann::json{{"mtime", m.mtime},
+                                  {"album", m.album},
+                                  {"album_artist", m.album_artist},
+                                  {"title", m.title},
+                                  {"artist", m.artist},
+                                  {"track_no", m.track_no},
+                                  {"disc_no", m.disc_no},
+                                  {"duration_ms", m.duration_ms}};
     }
-    cursor_ = 0;
+    std::error_code ec;
+    auto tmp = index_path_;
+    tmp += ".tmp";
+    {
+        std::ofstream os(tmp, std::ios::binary | std::ios::trunc);
+        if (!os) return;
+        os << j.dump();
+    }
+    std::filesystem::rename(tmp, index_path_, ec);
+}
+
+std::vector<std::filesystem::path>
+LocalFileSource::order_album_by_tags(const std::vector<std::filesystem::path>& in) {
+    struct Item {
+        std::filesystem::path path;
+        int disc = 0, track = 0;
+        std::string fname;
+    };
+    std::unordered_map<std::string, std::vector<Item>> groups;
+    std::vector<std::string> order;
+    {
+        std::scoped_lock il{index_mu_};
+        for (const auto& p : in) {
+            std::string gkey;
+            int disc_no = 0, track_no = 0;
+            auto it = index_.find(p.string());
+            if (it != index_.end() &&
+                !(it->second.album.empty() && it->second.album_artist.empty())) {
+                const auto& m = it->second;
+                gkey          = (m.album_artist.empty() ? m.artist : m.album_artist) + '\x01' + m.album;
+                disc_no       = m.disc_no;
+                track_no      = m.track_no;
+            } else {
+                gkey = std::string{'\x02'} + p.parent_path().string();  // fallback: by folder
+            }
+            auto [g, ins] = groups.try_emplace(gkey);
+            if (ins) order.push_back(gkey);
+            g->second.push_back(Item{p, disc_no, track_no, p.filename().string()});
+        }
+    }
+    for (auto& [_, v] : groups)
+        std::ranges::sort(v, [](const Item& a, const Item& b) {
+            if (a.disc != b.disc) return a.disc < b.disc;
+            if (a.track != b.track) return a.track < b.track;
+            return a.fname < b.fname;
+        });
+    std::shuffle(order.begin(), order.end(), thread_rng());
+    std::vector<std::filesystem::path> out;
+    out.reserve(in.size());
+    for (auto& k : order)
+        for (auto& item : groups[k]) out.push_back(std::move(item.path));
+    return out;
+}
+
+void LocalFileSource::index_worker(std::vector<std::filesystem::path> paths, std::wstring ff,
+                                   std::uint64_t gen, bool resort) {
+    load_index_if_needed();
+    bool probed_any = false;
+    for (const auto& p : paths) {
+        if (tag_cancel_.load(std::memory_order_acquire)) return;
+        std::error_code ec;
+        auto wt               = std::filesystem::last_write_time(p, ec);
+        const std::int64_t mt = ec ? 0 : (std::int64_t)wt.time_since_epoch().count();
+        const auto key        = p.string();
+        {
+            std::scoped_lock il{index_mu_};
+            auto it = index_.find(key);
+            if (it != index_.end() && it->second.mtime == mt) continue;
+        }
+        ProbedMetadata m = probe_metadata(ff, p);
+        TrackMeta tm;
+        tm.mtime        = mt;
+        tm.album        = std::move(m.album);
+        tm.album_artist = std::move(m.album_artist);
+        tm.title        = std::move(m.title);
+        tm.artist       = std::move(m.artist);
+        tm.track_no     = m.track_no;
+        tm.disc_no      = m.disc_no;
+        tm.duration_ms  = m.duration_ms;
+        {
+            std::scoped_lock il{index_mu_};
+            index_[key] = std::move(tm);
+        }
+        probed_any = true;
+    }
+    if (tag_cancel_.load(std::memory_order_acquire)) return;
+    if (probed_any) save_index();
+    // Let the dashboard know richer titles are available, even when we don't
+    // reorder (e.g. shuffle / name stations).
+    index_version_.fetch_add(1, std::memory_order_acq_rel);
+    if (!resort) return;
+
+    auto ordered = order_album_by_tags(paths);
+
+    std::scoped_lock lk{mu_};
+    if (tag_cancel_.load(std::memory_order_acquire) ||
+        rebuild_gen_.load(std::memory_order_acquire) != gen)
+        return;  // a newer rebuild superseded this pass
+    std::filesystem::path cur =
+        (dec_ && cursor_ < playlist_.size()) ? playlist_[cursor_] : std::filesystem::path{};
+    playlist_ = std::move(ordered);
+    discard_prefetch_locked();
+    if (!cur.empty()) {
+        auto it = std::ranges::find(playlist_, cur);
+        cursor_ = (it != playlist_.end()) ? (std::size_t)(it - playlist_.begin()) : 0;
+    } else {
+        cursor_ = 0;
+    }
+    log::info("[local] album tag index complete; re-sorted {} tracks", playlist_.size());
 }
 
 void LocalFileSource::close_current() {
@@ -396,6 +687,36 @@ std::size_t LocalFileSource::next_cursor_locked() const noexcept {
     return (cursor_ + 1) % playlist_.size();
 }
 
+// Explicit skip/next: always moves forward regardless of repeat. Reshuffles the
+// bag on wrap (shuffle order) so each pass is a fresh permutation that never
+// repeats the just-finished track first.
+bool LocalFileSource::advance_forward_locked() {
+    if (playlist_.empty()) return false;
+    const bool wrap = (cursor_ + 1 >= playlist_.size());
+    if (wrap && is_shuffle_locked() && playlist_.size() > 1) {
+        last_played_ = playlist_[cursor_];
+        shuffle_in_place_locked(playlist_);
+        if (playlist_.front() == last_played_)
+            std::swap(playlist_.front(), playlist_[playlist_.size() / 2]);
+        discard_prefetch_locked();
+        cursor_ = 0;
+        return open_track(0);
+    }
+    const std::size_t n = (cursor_ + 1) % playlist_.size();
+    if (promote_prefetch_locked(n)) return true;
+    return open_track(n);
+}
+
+// Natural end-of-track: honors repeat (one = replay, off = stop at the end,
+// all = wrap, reshuffling the bag when in shuffle order).
+bool LocalFileSource::eof_advance_locked() {
+    if (playlist_.empty()) return false;
+    const std::string rep = repeat_mode_locked();
+    if (rep == "one") return open_track(cursor_);
+    if (rep == "off" && cursor_ + 1 >= playlist_.size()) return false;
+    return advance_forward_locked();
+}
+
 bool LocalFileSource::promote_prefetch_locked(std::size_t expected_cursor) {
     if (!prefetch_dec_ || prefetch_dec_->for_cursor != expected_cursor) {
         discard_prefetch_locked();
@@ -429,9 +750,7 @@ void LocalFileSource::pause() { state_.store(PlaybackState::paused, std::memory_
 
 bool LocalFileSource::skip_next() {
     std::scoped_lock lk{mu_};
-    if (playlist_.empty()) return false;
-    const std::size_t next = next_cursor_locked();
-    if (!promote_prefetch_locked(next) && !open_track(next)) return false;
+    if (!advance_forward_locked()) return false;
     state_.store(PlaybackState::playing, std::memory_order_release);
     return true;
 }
@@ -458,10 +777,7 @@ void LocalFileSource::stop() {
 
 void LocalFileSource::next() {
     std::scoped_lock lk{mu_};
-    if (playlist_.empty()) return;
-    const std::size_t next = next_cursor_locked();
-    if (!promote_prefetch_locked(next)) open_track(next);
-    state_.store(PlaybackState::playing, std::memory_order_release);
+    if (advance_forward_locked()) state_.store(PlaybackState::playing, std::memory_order_release);
 }
 
 void LocalFileSource::previous() {
@@ -482,8 +798,7 @@ void LocalFileSource::pump(RingBuffer& ring) {
                          ? dec_->loudness_coef
                          : 1.0f;
     auto advance_at_eof = [&] {
-        const std::size_t next = next_cursor_locked();
-        if (!promote_prefetch_locked(next)) open_track(next);
+        if (!eof_advance_locked()) state_.store(PlaybackState::stopped, std::memory_order_release);
     };
 
     auto apply_dsp = [&](int16_t* samples, std::size_t frames) {
@@ -606,36 +921,73 @@ std::optional<ArtworkImage> LocalFileSource::artwork() const {
     return std::nullopt;
 }
 
-void LocalFileSource::set_directory(std::filesystem::path dir, bool recursive) {
+void LocalFileSource::set_config(LocalFilesConfig cfg) {
+    bool rescan;
     {
         std::scoped_lock lk{mu_};
-        if (cfg_.music_dir == dir && cfg_.recursive == recursive) return;
-        cfg_.music_dir = std::move(dir);
-        cfg_.recursive = recursive;
+        const LocalStation* o        = active_station_locked();
+        const LocalStation old       = o ? *o : LocalStation{};
+        const std::string old_active = cfg_.active_station;
+        const auto old_formats       = cfg_.supported_formats;
+        cfg_                         = std::move(cfg);
+        const LocalStation* n        = active_station_locked();
+        const LocalStation neu       = n ? *n : LocalStation{};
+        rescan = old_active != cfg_.active_station || old.roots != neu.roots ||
+                 old.excluded != neu.excluded || old.recursive != neu.recursive ||
+                 old.order != neu.order || old.grouping != neu.grouping ||
+                 old_formats != cfg_.supported_formats;
+    }
+    if (rescan) rebuild_playlist();
+}
+
+void LocalFileSource::set_active_station(std::string name) {
+    {
+        std::scoped_lock lk{mu_};
+        if (cfg_.active_station == name) return;
+        cfg_.active_station = std::move(name);
     }
     rebuild_playlist();
-    log::info("[local] rescanned: {} tracks under {}", playlist_.size(), cfg_.music_dir.string());
+}
+
+void LocalFileSource::reshuffle() {
+    std::scoped_lock lk{mu_};
+    if (playlist_.size() < 2) return;
+    std::filesystem::path cur =
+        (dec_ && cursor_ < playlist_.size()) ? playlist_[cursor_] : std::filesystem::path{};
+    shuffle_in_place_locked(playlist_);
+    discard_prefetch_locked();
+    if (!cur.empty()) {
+        auto it = std::ranges::find(playlist_, cur);
+        cursor_ = (it != playlist_.end()) ? (std::size_t)(it - playlist_.begin()) : 0;
+    } else {
+        cursor_ = 0;
+    }
+}
+
+bool LocalFileSource::jump_to(std::size_t index) {
+    std::scoped_lock lk{mu_};
+    if (index >= playlist_.size()) return false;
+    discard_prefetch_locked();
+    if (!open_track(index)) return false;
+    state_.store(PlaybackState::playing, std::memory_order_release);
+    return true;
 }
 
 AuthState LocalFileSource::auth_state() const noexcept {
     std::scoped_lock lk{mu_};
-    if (cfg_.music_dir.empty()) return AuthState::needs_auth;
-    if (!std::filesystem::exists(cfg_.music_dir)) return AuthState::error;
+    const LocalStation* st = active_station_locked();
+    if (!st || st->roots.empty()) return AuthState::needs_auth;
     return playlist_.empty() ? AuthState::needs_auth : AuthState::none_required;
 }
 
 std::string LocalFileSource::auth_instructions() const {
     std::scoped_lock lk{mu_};
-    if (cfg_.music_dir.empty()) {
-        return "Pick a folder containing your music in the Settings drawer "
-               "(Local files -> Music directory), then click Save.";
-    }
-    if (!std::filesystem::exists(cfg_.music_dir))
-        return "Music folder doesn't exist: " + cfg_.music_dir.string();
-    if (playlist_.empty()) {
-        return "No audio files matching the configured extensions were found in " +
-               cfg_.music_dir.string();
-    }
+    const LocalStation* st = active_station_locked();
+    if (!st || st->roots.empty())
+        return "Add a music folder to this station in the Local Files card, then Save.";
+    if (playlist_.empty())
+        return "No audio files matching the configured formats were found in this station's "
+               "folders.";
     return {};
 }
 
@@ -644,12 +996,33 @@ std::size_t LocalFileSource::track_count() const noexcept {
     return playlist_.size();
 }
 
-void LocalFileSource::set_shuffle(bool shuffle) {
-    {
-        std::scoped_lock lk{mu_};
-        cfg_.shuffle = shuffle;
-    }
-    rebuild_playlist();
+std::size_t LocalFileSource::station_count() const noexcept {
+    std::scoped_lock lk{mu_};
+    return cfg_.stations.size();
+}
+
+std::string LocalFileSource::active_station_name() const {
+    std::scoped_lock lk{mu_};
+    const LocalStation* st = active_station_locked();
+    return st ? st->name : std::string{};
+}
+
+std::string LocalFileSource::active_order() const {
+    std::scoped_lock lk{mu_};
+    const LocalStation* st = active_station_locked();
+    return st ? st->order : std::string{};
+}
+
+std::string LocalFileSource::active_grouping() const {
+    std::scoped_lock lk{mu_};
+    const LocalStation* st = active_station_locked();
+    return st ? st->grouping : std::string{};
+}
+
+std::string LocalFileSource::active_repeat() const {
+    std::scoped_lock lk{mu_};
+    const LocalStation* st = active_station_locked();
+    return st ? st->repeat : std::string{};
 }
 
 void LocalFileSource::set_ffmpeg_path(std::filesystem::path p) {
@@ -668,11 +1041,62 @@ void LocalFileSource::set_playback_options(const PlaybackConfig& opts) {
     }
 }
 
-std::vector<std::string> LocalFileSource::playlist_snapshot() const {
+LocalFileSource::QueueSnapshot LocalFileSource::queue_snapshot() const {
     std::scoped_lock lk{mu_};
-    std::vector<std::string> out;
-    out.reserve(playlist_.size());
-    for (const auto& p : playlist_) out.push_back(p.string());
+    std::scoped_lock il{index_mu_};
+    QueueSnapshot snap;
+    snap.cursor = cursor_;
+    snap.entries.reserve(playlist_.size());
+    for (std::size_t i = 0; i < playlist_.size(); ++i) {
+        const auto& p = playlist_[i];
+        QueueEntry e{i, p.stem().string(), {}, p.parent_path().filename().string()};
+        if (auto it = index_.find(p.string()); it != index_.end()) {
+            if (!it->second.title.empty()) e.title = it->second.title;
+            e.artist = it->second.artist;
+        }
+        snap.entries.push_back(std::move(e));
+    }
+    return snap;
+}
+
+std::vector<FsEntry> enumerate_dir(const std::filesystem::path& dir) {
+    auto u8 = [](const std::filesystem::path& p) {
+        auto s = p.u8string();
+        return std::string{s.begin(), s.end()};
+    };
+    std::vector<FsEntry> out;
+    if (dir.empty()) {
+        const DWORD mask = GetLogicalDrives();
+        for (int i = 0; i < 26; ++i) {
+            if (!(mask & (1u << i))) continue;
+            std::string root = std::string(1, char('A' + i)) + ":\\";
+            out.push_back(FsEntry{root, root, true});
+        }
+        return out;
+    }
+    std::error_code ec;
+    for (const auto& e : std::filesystem::directory_iterator(
+             dir, std::filesystem::directory_options::skip_permission_denied, ec)) {
+        std::error_code de;
+        if (!e.is_directory(de)) continue;
+        FsEntry fe;
+        fe.name = u8(e.path().filename());
+        fe.path = u8(e.path());
+        // Cheap "has children": stop at the first subdirectory found.
+        std::error_code ce;
+        std::filesystem::directory_iterator sub(
+            e.path(), std::filesystem::directory_options::skip_permission_denied, ce),
+            subEnd;
+        for (; sub != subEnd && !ce; sub.increment(ce)) {
+            std::error_code se;
+            if (sub->is_directory(se)) {
+                fe.has_children = true;
+                break;
+            }
+        }
+        out.push_back(std::move(fe));
+    }
+    std::ranges::sort(out, [](const FsEntry& a, const FsEntry& b) { return a.name < b.name; });
     return out;
 }
 

--- a/src/sources/local_file_source.cpp
+++ b/src/sources/local_file_source.cpp
@@ -361,41 +361,59 @@ void LocalFileSource::apply_order_locked(const LocalStation& st) {
 
 void LocalFileSource::rebuild_playlist() {
     stop_tag_thread();   // join any in-flight tag re-sort before mutating state
-    std::scoped_lock lk{mu_};
-    discard_prefetch_locked();   // playlist contents/order are about to change
-    const std::uint64_t gen = ++rebuild_gen_;
-    playlist_.clear();
-    cursor_ = 0;
 
-    const LocalStation* st = active_station_locked();
-    if (!st || st->roots.empty()) return;
+    // Snapshot what we need, then scan off-lock: the directory walk and .m3u
+    // parsing are heavy IO and pump() also takes mu_, so scanning under the lock
+    // would stall the audio thread on large libraries. Mirrors index_worker's
+    // snapshot -> work -> reacquire -> gen-check handover.
+    LocalStation              st;
+    std::vector<std::string>  formats;
+    std::filesystem::path     cur;
+    std::uint64_t             gen;
+    {
+        std::scoped_lock lk{mu_};
+        discard_prefetch_locked();   // playlist contents/order are about to change
+        gen = ++rebuild_gen_;
+        const LocalStation* a = active_station_locked();
+        if (!a || a->roots.empty()) {
+            playlist_.clear();
+            cursor_ = 0;
+            dec_.reset();            // no station -> nothing to play
+            return;
+        }
+        st      = *a;
+        formats = cfg_.supported_formats;
+        cur     = (dec_ && cursor_ < playlist_.size()) ? playlist_[cursor_]
+                                                       : std::filesystem::path{};
+    }
+
+    std::vector<std::filesystem::path> built;
+    std::set<std::filesystem::path>    seen;
 
     std::vector<std::string> excluded;
-    excluded.reserve(st->excluded.size());
-    for (const auto& e : st->excluded) excluded.push_back(norm_path_key(e));
+    excluded.reserve(st.excluded.size());
+    for (const auto& e : st.excluded) excluded.push_back(norm_path_key(e));
     auto is_excluded = [&](const std::filesystem::path& dir) {
         const auto key = norm_path_key(dir);
         for (const auto& ex : excluded)
             if (path_within(key, ex)) return true;
         return false;
     };
-
-    std::set<std::filesystem::path> seen;
     auto add_file = [&](const std::filesystem::path& p) {
         const auto ext = p.extension().string();
         if (ieq_str(ext, ".m3u") || ieq_str(ext, ".m3u8")) {
             for (auto& entry : parse_m3u_playlist(p))
-                if (extension_matches(entry, cfg_.supported_formats) && seen.insert(entry).second)
-                    playlist_.push_back(std::move(entry));
-        } else if (extension_matches(p, cfg_.supported_formats) && seen.insert(p).second) {
-            playlist_.push_back(p);
+                if (extension_matches(entry, formats) && seen.insert(entry).second)
+                    built.push_back(std::move(entry));
+        } else if (extension_matches(p, formats) && seen.insert(p).second) {
+            built.push_back(p);
         }
     };
 
-    for (const auto& root : st->roots) {
+    for (const auto& root : st.roots) {
         std::error_code ec;
         if (root.empty() || !std::filesystem::exists(root, ec)) continue;
-        if (st->recursive) {
+        if (st.recursive) {
             std::filesystem::recursive_directory_iterator it(
                 root, std::filesystem::directory_options::skip_permission_denied, ec), end;
             for (; it != end && !ec; it.increment(ec)) {
@@ -412,11 +430,24 @@ void LocalFileSource::rebuild_playlist() {
         }
     }
 
-    apply_order_locked(*st);
+    std::scoped_lock lk{mu_};
+    if (rebuild_gen_.load(std::memory_order_acquire) != gen) return;  // superseded mid-scan
+    discard_prefetch_locked();       // pump() may have prefetched against the old queue
+    playlist_ = std::move(built);
+    apply_order_locked(st);
+    // Keep the current track playing if the rebuilt queue still has it (an order
+    // change within the same station); otherwise it's a different station, so
+    // drop the decoder and let play() cut over to the new queue.
+    cursor_ = 0;
+    if (!cur.empty()) {
+        auto it = std::ranges::find(playlist_, cur);
+        if (it != playlist_.end()) cursor_ = (std::size_t)(it - playlist_.begin());
+        else dec_.reset();
+    }
     // Populate the metadata index in the background for every station so the
     // queue shows real titles and search matches them; reorder by tags only
     // when the station asks for album/tag grouping.
-    start_index_locked(gen, st->order == "album" && st->grouping == "tags");
+    start_index_locked(gen, st.order == "album" && st.grouping == "tags");
 }
 
 // ---- tag-grouping background index -----------------------------------------
@@ -484,6 +515,18 @@ void LocalFileSource::save_index() {
         os << j.dump();
     }
     std::filesystem::rename(tmp, index_path_, ec);
+    if (ec) {
+        // Windows rename() won't clobber an existing target; fall back to
+        // replace, and on any failure drop the temp so it doesn't accumulate.
+        std::error_code rep;
+        std::filesystem::remove(index_path_, rep);
+        std::filesystem::rename(tmp, index_path_, rep);
+        if (rep) {
+            log::warn("[local] could not write metadata index {}: {}",
+                      index_path_.string(), rep.message());
+            std::filesystem::remove(tmp, rep);
+        }
+    }
 }
 
 std::vector<std::filesystem::path>

--- a/ui/dist/js/api.js
+++ b/ui/dist/js/api.js
@@ -27,4 +27,19 @@ export const api = {
   getExternalAudio: () => request("/api/external_audio/devices"),
   putExternalAudio: config => request("/api/external_audio/config", { method: "PUT", body: config }),
   getDeps: () => request("/api/deps"),
+
+  // Local Files
+  browseFs: path => request("/api/fs/browse", { method: "POST", body: { path: path || "" } }),
+  getLocalStations: () => request("/api/source/local_files/stations"),
+  putLocalStations: (stations, activeStation) =>
+    request("/api/source/local_files/stations", {
+      method: "PUT",
+      body: { stations, active_station: activeStation },
+    }),
+  activateLocalStation: name =>
+    request("/api/source/local_files/activate", { method: "POST", body: { name } }),
+  getLocalQueue: () => request("/api/source/local_files/queue"),
+  playLocalIndex: index =>
+    request("/api/source/local_files/play", { method: "POST", body: { index } }),
+  reshuffleLocal: () => request("/api/source/local_files/reshuffle", { method: "POST" }),
 };

--- a/ui/dist/js/main.js
+++ b/ui/dist/js/main.js
@@ -10,6 +10,7 @@ import { createOutput } from "./render/output.js";
 import { renderSettings, collectSettings } from "./render/settings.js";
 import { createDeps } from "./render/deps.js";
 import { createExternalAudio } from "./render/externalAudio.js";
+import { createLocalFiles } from "./render/localFiles.js";
 
 let state = null;
 let cfg = null;
@@ -67,6 +68,16 @@ const externalAudio = createExternalAudio(mainEl, {
   },
 });
 
+const localFiles = createLocalFiles(mainEl, {
+  getState: () => state,
+  getConfig: () => cfg,
+  onSaved: async () => {
+    cfg = await api.getConfig().catch(() => cfg);
+    state = await api.getState().catch(() => state);
+    render();
+  },
+});
+
 async function switchSource(name) {
   try {
     await api.switchSource(name);
@@ -118,6 +129,7 @@ function render() {
   renderSources(refs.sources, state, cfg, switchSource);
   renderOutput(state);
   externalAudio.render();
+  localFiles.render();
 
   refs.sourceCard.hidden = false;
   refs.outputCard.hidden = !state.sources?.active;
@@ -193,6 +205,7 @@ $("#save-config").addEventListener("click", async () => {
   try {
     cfg = await api.putConfig(collectSettings(refs.form));
     externalAudio.invalidate();
+    localFiles.invalidate();
     state = await api.getState().catch(() => state);
     render();
     toast("Saved");
@@ -206,6 +219,7 @@ $("#reload-config").addEventListener("click", async () => {
   try {
     cfg = await api.reloadConfig();
     externalAudio.invalidate();
+    localFiles.invalidate();
     renderSettings(refs.form, cfg);
     render();
     toast("Reloaded from disk");

--- a/ui/dist/js/main.js
+++ b/ui/dist/js/main.js
@@ -135,8 +135,10 @@ function render() {
   refs.outputCard.hidden = !state.sources?.active;
 
   const available = state.sources?.available || [];
-  refs.ytCard.hidden = !available.some(s => s.name === "youtube_music");
-  refs.jfCard.hidden = !available.some(s => s.name === "jellyfin");
+  const active = state.sources?.active;
+  // Source-specific cards only show while that source is on air.
+  refs.ytCard.hidden = active !== "youtube_music";
+  refs.jfCard.hidden = active !== "jellyfin";
   const shuffleOn = !!available.find(s => s.name === "youtube_music")?.details?.shuffle;
   refs.ytShuffle.classList.toggle("toggled", shuffleOn);
   refs.ytShuffle.setAttribute("aria-pressed", String(shuffleOn));

--- a/ui/dist/js/render/externalAudio.js
+++ b/ui/dist/js/render/externalAudio.js
@@ -83,9 +83,10 @@ export function createExternalAudio(main, ctx) {
 
   function render() {
     const state = ctx.getState();
-    const enabled = !!ctx.getConfig()?.external_audio?.enabled;
-    card.hidden = !enabled;
-    if (!enabled) return;
+    // Only show the External Audio card while it's the source on air.
+    const onAir = state?.sources?.active === "external_audio";
+    card.hidden = !onAir;
+    if (!onAir) return;
 
     load();
 

--- a/ui/dist/js/render/localFiles.js
+++ b/ui/dist/js/render/localFiles.js
@@ -1,0 +1,465 @@
+import { api } from "../api.js";
+import { $, el } from "../dom.js";
+import { icons } from "../icons.js";
+import { toast } from "../toast.js";
+
+const ORDERS = [
+  ["shuffle", "Shuffle"],
+  ["album", "Albums"],
+  ["name", "Name (A–Z)"],
+  ["folder", "Folder"],
+];
+const GROUPINGS = [
+  ["folder", "By folder"],
+  ["tags", "By tags"],
+];
+const REPEATS = [
+  ["all", "Repeat all"],
+  ["one", "Repeat one"],
+  ["off", "No repeat"],
+];
+
+// Lowercase + strip diacritics, so "ete" matches "Été" in queue search.
+const fold = s => (s || "").normalize("NFD").replace(/\p{Diacritic}/gu, "").toLowerCase();
+
+// Path helpers: case-insensitive, separator-agnostic.
+const norm = p => (p || "").replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
+const within = (child, parent) => {
+  const c = norm(child);
+  const a = norm(parent);
+  return c === a || c.startsWith(a + "/");
+};
+
+function newStation(name) {
+  return { name, roots: [], excluded: [], recursive: true, order: "shuffle", grouping: "folder", repeat: "all" };
+}
+
+// Lazy folder browser modal. open(onPick) resolves the chosen folder path.
+function createBrowser() {
+  let dir = "";
+  let onPick = null;
+
+  const list = el("div", { class: "lf-browse-list" });
+  const crumb = el("div", { class: "lf-browse-crumb muted" });
+  const useBtn = el("button", { type: "button", class: "btn filled" }, "Use this folder");
+  const upBtn = el("button", { type: "button", class: "btn ghost" }, "Up");
+  const closeBtn = el("button", { type: "button", class: "btn ghost" }, "Cancel");
+
+  const modal = el("div", { class: "lf-modal", hidden: true }, [
+    el("div", { class: "lf-modal-card" }, [
+      el("div", { class: "lf-modal-head" }, [el("h3", {}, "Choose a folder"), crumb]),
+      list,
+      el("div", { class: "lf-modal-foot row" }, [upBtn, useBtn, closeBtn]),
+    ]),
+  ]);
+  document.body.append(modal);
+
+  async function go(path) {
+    dir = path || "";
+    let r;
+    try {
+      r = await api.browseFs(dir);
+    } catch (e) {
+      toast(e.message, true);
+      return;
+    }
+    dir = r.path || "";
+    crumb.textContent = dir || "This PC";
+    upBtn.disabled = false;
+    useBtn.disabled = !dir;
+    list.replaceChildren(
+      ...(r.entries || []).map(entry => {
+        const row = el("button", { type: "button", class: "lf-browse-row" }, [
+          el("span", { class: "lf-browse-name" }, entry.name || entry.path),
+          entry.has_children ? el("span", { class: "lf-chevron" }, "›") : null,
+        ]);
+        row.dataset.parent = r.parent || "";
+        row.addEventListener("click", () => go(entry.path));
+        return row;
+      }),
+    );
+    list.dataset.parent = r.parent || "";
+    if (!(r.entries || []).length)
+      {list.append(el("p", { class: "muted" }, dir ? "No subfolders here." : "No drives found."));}
+  }
+
+  upBtn.addEventListener("click", () => go(list.dataset.parent || ""));
+  closeBtn.addEventListener("click", () => (modal.hidden = true));
+  modal.addEventListener("click", e => {
+    if (e.target === modal) modal.hidden = true;
+  });
+  useBtn.addEventListener("click", () => {
+    if (!dir) return;
+    modal.hidden = true;
+    onPick?.(dir);
+  });
+
+  return {
+    open(cb) {
+      onPick = cb;
+      modal.hidden = false;
+      go("");
+    },
+  };
+}
+
+// Local Files card: stations (presets), folder selection, ordering and queue.
+export function createLocalFiles(main, ctx) {
+  let stations = [];
+  let activeStation = "";
+  let selected = 0;
+  let queue = { cursor: 0, tracks: [] };
+  let search = "";
+  let loaded = false;
+  const expanded = new Set(); // expanded tree folder paths (normalized)
+
+  const browser = createBrowser();
+
+  const stationSelect = el("select", { id: "lf-station", "aria-label": "Station preset" });
+  const onAirBtn = el("button", { type: "button", class: "btn filled" }, "Set on air");
+  const newBtn = el("button", { type: "button", class: "btn ghost" }, "New");
+  const renameBtn = el("button", { type: "button", class: "btn ghost" }, "Rename");
+  const deleteBtn = el("button", { type: "button", class: "btn ghost" }, "Delete");
+
+  const rootsBox = el("div", { class: "lf-roots" });
+  const addFolderBtn = el("button", { type: "button", class: "btn ghost" }, "Add folder");
+  const treeBox = el("div", { class: "lf-tree" });
+  const orderSelect = el("select", { "aria-label": "Play order" },
+    ORDERS.map(([v, t]) => el("option", { value: v }, t)));
+  const groupingSelect = el("select", { "aria-label": "Album grouping" },
+    GROUPINGS.map(([v, t]) => el("option", { value: v }, t)));
+  const repeatSelect = el("select", { "aria-label": "Repeat mode" },
+    REPEATS.map(([v, t]) => el("option", { value: v }, t)));
+  const saveBtn = el("button", { type: "button", class: "btn filled" }, "Save");
+
+  const searchInput = el("input", { type: "text", placeholder: "Search the queue…", autocomplete: "off" });
+  const reshuffleBtn = el("button", { type: "button", class: "icon-btn", "aria-label": "Reshuffle", html: icons.shuffle });
+  const trackList = el("ul", { class: "lf-tracklist" });
+  const queueCount = el("span", { class: "muted" });
+
+  const card = el("section", { class: "card", id: "local-files-card", hidden: true }, [
+    el("h2", {}, "Local Files"),
+    el("div", { class: "lf-stationbar row" }, [stationSelect, onAirBtn]),
+    el("div", { class: "row lf-stationtools" }, [newBtn, renameBtn, deleteBtn]),
+    el("div", { class: "lf-editor" }, [
+      el("label", { class: "field-label" }, "Folders"),
+      rootsBox,
+      el("div", { class: "row" }, [addFolderBtn]),
+      el("label", { class: "field-label" }, "Exclude subfolders (uncheck to skip)"),
+      treeBox,
+      el("div", { class: "lf-modes row" }, [
+        el("label", { class: "lf-mode" }, ["Order", orderSelect]),
+        el("label", { class: "lf-mode", id: "lf-grouping-field" }, ["Grouping", groupingSelect]),
+        el("label", { class: "lf-mode" }, ["Repeat", repeatSelect]),
+      ]),
+      el("div", { class: "row lf-editor-foot" }, [saveBtn]),
+    ]),
+    el("div", { class: "lf-queue" }, [
+      el("div", { class: "lf-queue-head row" }, [
+        el("label", { class: "field-label" }, "Queue"),
+        queueCount,
+        reshuffleBtn,
+      ]),
+      searchInput,
+      trackList,
+    ]),
+  ]);
+
+  const sourcesCard = $("#sources", main)?.closest(".card");
+  if (sourcesCard) sourcesCard.insertAdjacentElement("afterend", card);
+  else main.append(card);
+
+  const cur = () => stations[selected];
+
+  async function load(force = false) {
+    if (loaded && !force) return;
+    try {
+      const r = await api.getLocalStations();
+      stations = Array.isArray(r.stations) && r.stations.length ? r.stations : [newStation("My Music")];
+      stations.forEach(s => {
+        s.roots ??= [];
+        s.excluded ??= [];
+      });
+      activeStation = r.active_station || stations[0].name;
+      selected = Math.max(0, stations.findIndex(s => s.name === activeStation));
+      loaded = true;
+    } catch {
+      return;
+    }
+    renderEditor();
+    loadQueue();
+  }
+
+  async function loadQueue() {
+    try {
+      queue = await api.getLocalQueue();
+    } catch {
+      queue = { cursor: 0, tracks: [] };
+    }
+    renderQueue();
+  }
+
+  function renderStations() {
+    stationSelect.replaceChildren(
+      ...stations.map((s, i) =>
+        el("option", { value: String(i), selected: i === selected },
+          s.name + (s.name === activeStation ? "  • on air" : "")),
+      ),
+    );
+    deleteBtn.disabled = stations.length <= 1;
+    onAirBtn.disabled = cur()?.name === activeStation;
+    onAirBtn.textContent = cur()?.name === activeStation ? "On air" : "Set on air";
+  }
+
+  function renderRoots() {
+    const s = cur();
+    rootsBox.replaceChildren(
+      ...(s.roots.length
+        ? s.roots.map((root, i) => {
+            const remove = el("button", { type: "button", class: "lf-x", "aria-label": "Remove folder" }, "✕");
+            remove.addEventListener("click", () => {
+              s.roots.splice(i, 1);
+              s.excluded = s.excluded.filter(ex => s.roots.some(r => within(ex, r)));
+              renderRoots();
+              renderTree();
+            });
+            return el("div", { class: "lf-root" }, [el("span", { class: "lf-root-path" }, root), remove]);
+          })
+        : [el("p", { class: "muted" }, "No folders yet — add one to build this station.")]),
+    );
+  }
+
+  function excludedState(s, path) {
+    const n = norm(path);
+    for (const ex of s.excluded) {
+      const e = norm(ex);
+      if (e === n) return "self";
+      if (n.startsWith(e + "/")) return "ancestor";
+    }
+    return "none";
+  }
+  const hasExcludedDescendant = (s, path) =>
+    s.excluded.some(ex => norm(ex) !== norm(path) && norm(ex).startsWith(norm(path) + "/"));
+
+  function treeRow(s, entry, depth) {
+    const state = excludedState(s, entry.path);
+    const box = el("input", { type: "checkbox" });
+    box.checked = state === "none";
+    box.disabled = state === "ancestor";
+    box.indeterminate = state === "none" && hasExcludedDescendant(s, entry.path);
+    box.addEventListener("change", () => {
+      if (box.checked) {
+        s.excluded = s.excluded.filter(ex => norm(ex) !== norm(entry.path));
+      } else {
+        s.excluded = s.excluded.filter(ex => !within(ex, entry.path));
+        s.excluded.push(entry.path);
+      }
+      renderTree();
+    });
+
+    const children = el("div", { class: "lf-tree-children" });
+    const isOpen = expanded.has(norm(entry.path));
+    const caret = el("button", {
+      type: "button",
+      class: "lf-caret" + (entry.has_children ? "" : " empty"),
+      "aria-label": "Expand",
+    }, entry.has_children ? (isOpen ? "▾" : "▸") : "·");
+    if (entry.has_children) {
+      caret.addEventListener("click", () => {
+        if (expanded.has(norm(entry.path))) expanded.delete(norm(entry.path));
+        else expanded.add(norm(entry.path));
+        renderTree();
+      });
+    }
+
+    const row = el("div", { class: "lf-tree-row", style: `padding-left:${depth * 16}px` }, [
+      caret,
+      el("label", { class: "lf-tree-label" + (state === "ancestor" ? " muted" : "") }, [
+        box,
+        el("span", {}, entry.name || entry.path),
+      ]),
+    ]);
+
+    const wrap = el("div", {}, [row, children]);
+    if (entry.has_children && isOpen) {
+      api
+        .browseFs(entry.path)
+        .then(r => {
+          children.replaceChildren(...(r.entries || []).map(c => treeRow(s, c, depth + 1)));
+        })
+        .catch(() => {});
+    }
+    return wrap;
+  }
+
+  function renderTree() {
+    const s = cur();
+    if (!s.roots.length) {
+      treeBox.replaceChildren(el("p", { class: "muted" }, "Add a folder above to pick which subfolders to include."));
+      return;
+    }
+    treeBox.replaceChildren(
+      ...s.roots.map(root => treeRow(s, { name: root, path: root, has_children: true }, 0)),
+    );
+  }
+
+  function renderModes() {
+    const s = cur();
+    orderSelect.value = s.order;
+    groupingSelect.value = s.grouping;
+    repeatSelect.value = s.repeat;
+    $("#lf-grouping-field").hidden = s.order !== "album";
+  }
+
+  function renderEditor() {
+    if (!cur()) return;
+    renderStations();
+    renderRoots();
+    renderTree();
+    renderModes();
+  }
+
+  function renderQueue() {
+    // Accent-insensitive, multi-word search: every word must appear somewhere
+    // in title + artist + folder, in any order or position.
+    const terms = fold(search).split(/\s+/).filter(Boolean);
+    const rows = (queue.tracks || []).filter(t => {
+      if (!terms.length) return true;
+      const hay = fold(`${t.title} ${t.artist || ""} ${t.folder || ""}`);
+      return terms.every(w => hay.includes(w));
+    });
+    queueCount.textContent = `${queue.tracks?.length || 0} tracks`;
+    trackList.replaceChildren(
+      ...rows.map(t => {
+        const li = el("li", { class: "lf-track" + (t.index === queue.cursor ? " current" : "") }, [
+          el("span", { class: "lf-track-title" }, t.artist ? `${t.title} — ${t.artist}` : t.title),
+          t.folder ? el("span", { class: "lf-track-folder muted" }, t.folder) : null,
+        ]);
+        li.addEventListener("click", async () => {
+          try {
+            await api.playLocalIndex(t.index);
+            queue.cursor = t.index;
+            renderQueue();
+          } catch (e) {
+            toast(e.message, true);
+          }
+        });
+        return li;
+      }),
+    );
+    if (!rows.length)
+      {trackList.append(
+        el("li", { class: "muted" }, terms.length ? "No matches." : "Queue is empty."),
+      );}
+  }
+
+  // --- events ---------------------------------------------------------------
+  stationSelect.addEventListener("change", () => {
+    selected = parseInt(stationSelect.value, 10) || 0;
+    renderEditor();
+  });
+  newBtn.addEventListener("click", () => {
+    let name = "New Station";
+    let n = 2;
+    while (stations.some(s => s.name === name)) name = `New Station ${n++}`;
+    stations.push(newStation(name));
+    selected = stations.length - 1;
+    renderEditor();
+  });
+  renameBtn.addEventListener("click", () => {
+    const s = cur();
+    const name = window.prompt("Station name", s.name)?.trim();
+    if (!name || name === s.name) return;
+    if (stations.some(x => x !== s && x.name === name)) return toast("A station with that name exists", true);
+    if (s.name === activeStation) activeStation = name;
+    s.name = name;
+    renderEditor();
+  });
+  deleteBtn.addEventListener("click", () => {
+    if (stations.length <= 1) return;
+    const wasActive = cur().name === activeStation;
+    stations.splice(selected, 1);
+    selected = Math.min(selected, stations.length - 1);
+    if (wasActive) activeStation = stations[0].name;
+    renderEditor();
+  });
+  addFolderBtn.addEventListener("click", () => {
+    browser.open(path => {
+      const s = cur();
+      if (!s.roots.some(r => norm(r) === norm(path))) s.roots.push(path);
+      renderRoots();
+      renderTree();
+    });
+  });
+  orderSelect.addEventListener("change", () => {
+    cur().order = orderSelect.value;
+    renderModes();
+  });
+  groupingSelect.addEventListener("change", () => (cur().grouping = groupingSelect.value));
+  repeatSelect.addEventListener("change", () => (cur().repeat = repeatSelect.value));
+
+  saveBtn.addEventListener("click", async () => {
+    try {
+      const r = await api.putLocalStations(stations, activeStation);
+      toast(`Saved · ${r.track_count} tracks`);
+      await ctx.onSaved?.();
+      loadQueue();
+    } catch (e) {
+      toast(e.message, true);
+    }
+  });
+  onAirBtn.addEventListener("click", async () => {
+    const name = cur().name;
+    try {
+      await api.putLocalStations(stations, name); // persist edits + set active
+      await api.activateLocalStation(name); // switch source + play
+      activeStation = name;
+      renderStations();
+      toast(`On air: ${name}`);
+      await ctx.onSaved?.();
+      loadQueue();
+    } catch (e) {
+      toast(e.message, true);
+    }
+  });
+  searchInput.addEventListener("input", () => {
+    search = searchInput.value;
+    renderQueue();
+  });
+  reshuffleBtn.addEventListener("click", async () => {
+    try {
+      await api.reshuffleLocal();
+      loadQueue();
+    } catch (e) {
+      toast(e.message, true);
+    }
+  });
+
+  // --- lifecycle ------------------------------------------------------------
+  let lastTrackCount = -1;
+  let lastIndexVersion = -1;
+  function render() {
+    const enabled = !!ctx.getConfig()?.local_files?.enabled;
+    card.hidden = !enabled;
+    if (!enabled) return;
+    load();
+    // Refresh the queue (titles, artists, current-track highlight) when the
+    // track count changes (rescan) or the metadata index advances.
+    const state = ctx.getState();
+    const lf = state?.sources?.available?.find(s => s.name === "local_files");
+    const tc = lf?.details?.track_count ?? -1;
+    const iv = lf?.details?.index_version ?? -1;
+    if (loaded && (tc !== lastTrackCount || iv !== lastIndexVersion)) {
+      lastTrackCount = tc;
+      lastIndexVersion = iv;
+      loadQueue();
+    }
+  }
+
+  return {
+    render,
+    invalidate: () => {
+      loaded = false;
+    },
+  };
+}

--- a/ui/dist/js/render/localFiles.js
+++ b/ui/dist/js/render/localFiles.js
@@ -439,13 +439,13 @@ export function createLocalFiles(main, ctx) {
   let lastTrackCount = -1;
   let lastIndexVersion = -1;
   function render() {
-    const enabled = !!ctx.getConfig()?.local_files?.enabled;
-    card.hidden = !enabled;
-    if (!enabled) return;
+    const state = ctx.getState();
+    const isActive = state?.sources?.active === "local_files";
+    card.hidden = !isActive;
+    if (!isActive) return;
     load();
     // Refresh the queue (titles, artists, current-track highlight) when the
     // track count changes (rescan) or the metadata index advances.
-    const state = ctx.getState();
     const lf = state?.sources?.available?.find(s => s.name === "local_files");
     const tc = lf?.details?.track_count ?? -1;
     const iv = lf?.details?.index_version ?? -1;

--- a/ui/dist/js/schema.js
+++ b/ui/dist/js/schema.js
@@ -26,9 +26,8 @@ export const SCHEMA = [
     "Local files",
     [
       ["enabled", "Enabled", "checkbox"],
-      ["music_dir", "Music directory", "text"],
-      ["recursive", "Scan subfolders", "checkbox"],
-      ["shuffle", "Shuffle", "checkbox"],
+      // Folders, stations, ordering and the queue live in the dedicated
+      // Local Files card on the dashboard (render/localFiles.js).
     ],
   ],
   [

--- a/ui/dist/styles.css
+++ b/ui/dist/styles.css
@@ -1004,3 +1004,253 @@ output {
     transition: none !important;
   }
 }
+
+/* Local Files card. */
+.lf-stationbar {
+  gap: var(--spacing-8);
+  align-items: center;
+}
+
+.lf-stationbar select {
+  flex: 1;
+}
+
+.lf-stationtools {
+  margin-top: var(--spacing-8);
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.lf-editor {
+  margin-top: var(--spacing-16);
+  padding-top: var(--spacing-16);
+  border-top: 1px solid var(--line);
+}
+
+.lf-roots {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.lf-root {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-8);
+  padding: 8px 10px;
+  border-radius: var(--radius-md);
+  background: var(--surface-raise);
+  border: 1px solid var(--line);
+}
+
+.lf-root-path {
+  flex: 1;
+  font-size: 13px;
+  word-break: break-all;
+}
+
+.lf-x {
+  flex: none;
+  width: 24px;
+  height: 24px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--line-strong);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  line-height: 1;
+}
+
+.lf-x:hover {
+  color: var(--alert);
+  border-color: var(--alert);
+}
+
+.lf-tree {
+  max-height: 260px;
+  overflow: auto;
+  padding: var(--spacing-8);
+  border-radius: var(--radius-md);
+  background: var(--surface-overlay);
+  border: 1px solid var(--line);
+}
+
+.lf-tree-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 0;
+}
+
+.lf-caret {
+  flex: none;
+  width: 20px;
+  height: 20px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.lf-caret.empty {
+  cursor: default;
+  opacity: 0.3;
+}
+
+.lf-tree-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.lf-tree-label.muted {
+  opacity: 0.5;
+}
+
+.lf-modes {
+  margin-top: var(--spacing-16);
+  gap: var(--spacing-16);
+  flex-wrap: wrap;
+}
+
+.lf-mode {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.lf-editor-foot {
+  margin-top: var(--spacing-16);
+  justify-content: flex-end;
+}
+
+.lf-queue {
+  margin-top: var(--spacing-16);
+  padding-top: var(--spacing-16);
+  border-top: 1px solid var(--line);
+}
+
+.lf-queue-head {
+  align-items: center;
+  gap: var(--spacing-8);
+  margin-bottom: var(--spacing-8);
+}
+
+.lf-queue-head .field-label {
+  margin: 0;
+  flex: 1;
+}
+
+.lf-queue-head .icon-btn {
+  flex: none;
+}
+
+.lf-tracklist {
+  list-style: none;
+  margin: var(--spacing-8) 0 0;
+  padding: 0;
+  max-height: 320px;
+  overflow: auto;
+}
+
+.lf-track {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 10px;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+}
+
+.lf-track:hover {
+  background: var(--surface-raise);
+}
+
+.lf-track.current {
+  background: linear-gradient(180deg, rgba(245, 217, 7, 0.08), transparent 80%) var(--surface-card);
+  border-left: 2px solid var(--accent);
+}
+
+.lf-track-title {
+  font-size: 14px;
+}
+
+.lf-track-folder {
+  font-size: 11px;
+}
+
+/* Folder browser modal. */
+.lf-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.5);
+  animation: fade 0.2s ease;
+}
+
+.lf-modal-card {
+  width: min(520px, 92vw);
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  padding: var(--spacing-16);
+  border-radius: var(--radius-xl);
+  background: var(--surface-card);
+  border: 1px solid var(--line-strong);
+  box-shadow: var(--shadow-xl);
+}
+
+.lf-modal-head {
+  margin-bottom: var(--spacing-12);
+}
+
+.lf-modal-head h3 {
+  margin: 0 0 4px;
+}
+
+.lf-browse-crumb {
+  font-size: 12px;
+  word-break: break-all;
+}
+
+.lf-browse-list {
+  flex: 1;
+  overflow: auto;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--line);
+}
+
+.lf-browse-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 10px 12px;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--line);
+  color: var(--text);
+  cursor: pointer;
+  text-align: left;
+}
+
+.lf-browse-row:hover {
+  background: var(--surface-raise);
+}
+
+.lf-chevron {
+  color: var(--text-muted);
+}
+
+.lf-modal-foot {
+  margin-top: var(--spacing-12);
+  justify-content: flex-end;
+}

--- a/ui/dist/styles.css
+++ b/ui/dist/styles.css
@@ -631,6 +631,33 @@ select:focus {
   box-shadow: 0 0 0 3px rgba(245, 217, 7, 0.14);
 }
 
+select {
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: 38px;
+  background-color: var(--color-pitch-black);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%23a3a3a3' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  background-size: 16px;
+  cursor: pointer;
+}
+
+select:hover {
+  border-color: var(--line-strong);
+}
+
+select option,
+select optgroup {
+  background-color: var(--color-void-black);
+  color: var(--text);
+}
+
+select option:checked {
+  background-color: var(--surface-raise-hover);
+  color: var(--text-strong);
+}
+
 input[type="range"] {
   appearance: none;
   height: 4px;

--- a/ui/test/api.test.js
+++ b/ui/test/api.test.js
@@ -74,6 +74,46 @@ describe("api endpoints", () => {
     });
   });
 
+  it("local files endpoints carry the right method and body", async () => {
+    await api.browseFs("C:\\Music");
+    expect(lastCall()).toMatchObject({
+      path: "/api/fs/browse",
+      method: "POST",
+      body: { path: "C:\\Music" },
+    });
+
+    await api.getLocalStations();
+    expect(lastCall()).toMatchObject({ path: "/api/source/local_files/stations", method: "GET" });
+
+    const stations = [{ name: "Rock", roots: ["D:\\Rock"], excluded: [] }];
+    await api.putLocalStations(stations, "Rock");
+    expect(lastCall()).toMatchObject({
+      path: "/api/source/local_files/stations",
+      method: "PUT",
+      body: { stations, active_station: "Rock" },
+    });
+
+    await api.activateLocalStation("Rock");
+    expect(lastCall()).toMatchObject({
+      path: "/api/source/local_files/activate",
+      method: "POST",
+      body: { name: "Rock" },
+    });
+
+    await api.getLocalQueue();
+    expect(lastCall()).toMatchObject({ path: "/api/source/local_files/queue", method: "GET" });
+
+    await api.playLocalIndex(7);
+    expect(lastCall()).toMatchObject({
+      path: "/api/source/local_files/play",
+      method: "POST",
+      body: { index: 7 },
+    });
+
+    await api.reshuffleLocal();
+    expect(lastCall()).toMatchObject({ path: "/api/source/local_files/reshuffle", method: "POST" });
+  });
+
   it("throws the server error message on non-ok responses", async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: false,

--- a/ui/test/budget.test.js
+++ b/ui/test/budget.test.js
@@ -13,11 +13,11 @@ function walk(dir) {
 }
 
 describe("performance budget", () => {
-  it("ships JS + CSS under 60 KB (fonts excluded)", () => {
+  it("ships JS + CSS under 80 KB (fonts excluded)", () => {
     const total = walk(distDir)
       .filter(f => /\.(js|css)$/.test(f))
       .reduce((sum, f) => sum + statSync(f).size, 0);
-    expect(total).toBeLessThan(60 * 1024);
+    expect(total).toBeLessThan(80 * 1024);
   });
 
   it("keeps the entry HTML under 8 KB", () => {

--- a/ui/test/render/localFiles.test.js
+++ b/ui/test/render/localFiles.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createLocalFiles } from "../../dist/js/render/localFiles.js";
+
+const json = body => ({ ok: true, json: async () => body });
+
+const STATIONS = {
+  stations: [
+    {
+      name: "My Music",
+      roots: [],
+      excluded: [],
+      order: "shuffle",
+      grouping: "folder",
+      repeat: "all",
+    },
+  ],
+  active_station: "My Music",
+  track_count: 0,
+};
+
+beforeEach(() => {
+  document.body.innerHTML = "<main></main>";
+  global.fetch = vi.fn(url => {
+    if (url.includes("/stations")) return Promise.resolve(json(STATIONS));
+    if (url.includes("/queue")) return Promise.resolve(json({ cursor: 0, tracks: [] }));
+    return Promise.resolve(json({}));
+  });
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+const ctx = (enabled, state = { sources: { available: [] } }) => ({
+  getState: () => state,
+  getConfig: () => ({ local_files: { enabled } }),
+  onSaved: async () => {},
+});
+
+describe("createLocalFiles", () => {
+  it("inserts the card hidden until local_files is enabled", () => {
+    const lf = createLocalFiles(document.querySelector("main"), ctx(false));
+    lf.render();
+    expect(document.getElementById("local-files-card").hidden).toBe(true);
+  });
+
+  it("shows the card and loads stations when enabled", async () => {
+    const lf = createLocalFiles(document.querySelector("main"), ctx(true));
+    lf.render();
+    expect(document.getElementById("local-files-card").hidden).toBe(false);
+    await new Promise(r => setTimeout(r, 0));
+    const opts = document.getElementById("lf-station").querySelectorAll("option");
+    expect(opts.length).toBe(1);
+    expect(opts[0].textContent).toContain("My Music");
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/source/local_files/stations",
+      expect.anything(),
+    );
+  });
+});

--- a/ui/test/render/localFiles.test.js
+++ b/ui/test/render/localFiles.test.js
@@ -29,21 +29,21 @@ beforeEach(() => {
 
 afterEach(() => vi.restoreAllMocks());
 
-const ctx = (enabled, state = { sources: { available: [] } }) => ({
-  getState: () => state,
-  getConfig: () => ({ local_files: { enabled } }),
+const ctx = active => ({
+  getState: () => ({ sources: { active, available: [{ name: "local_files", details: {} }] } }),
+  getConfig: () => ({ local_files: { enabled: true } }),
   onSaved: async () => {},
 });
 
 describe("createLocalFiles", () => {
-  it("inserts the card hidden until local_files is enabled", () => {
-    const lf = createLocalFiles(document.querySelector("main"), ctx(false));
+  it("stays hidden until local_files is the active source", () => {
+    const lf = createLocalFiles(document.querySelector("main"), ctx("spotify"));
     lf.render();
     expect(document.getElementById("local-files-card").hidden).toBe(true);
   });
 
-  it("shows the card and loads stations when enabled", async () => {
-    const lf = createLocalFiles(document.querySelector("main"), ctx(true));
+  it("shows the card and loads stations when local_files is on air", async () => {
+    const lf = createLocalFiles(document.querySelector("main"), ctx("local_files"));
     lf.render();
     expect(document.getElementById("local-files-card").hidden).toBe(false);
     await new Promise(r => setTimeout(r, 0));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-station local files: named stations from multiple folders, station switching, and filesystem browsing
  * Station-level playback controls: order modes (shuffle/albums/name/folder), repeat modes, exclusions, and queue search/browsing
  * Start playback at specific queue index and reshuffle from UI

* **Improvements**
  * More reliable metadata/grouping and background indexing for smoother local playback

* **Documentation**
  * Updated local files setup and troubleshooting

* **Tests**
  * Added API and UI tests for local files features
<!-- end of auto-generated comment: release notes by coderabbit.ai -->