### PR TITLE
feat(online-radio): redesign with directory search and rich metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center"><img src="assets/banner.png" alt="FH6 Universal Radio" /></p>
 
-An open-source radio mod for **Forza Horizon 6**. Adds a new in-game radio station fed from your **local music**, **Spotify**, **YouTube Music**, **Jellyfin** server, or **any Windows app** (Deezer, a browser tab...), controlled from a browser dashboard.
+An open-source radio mod for **Forza Horizon 6**. Adds a new in-game radio station fed from your **local music**, **online radio** stations, **Spotify**, **YouTube Music**, **Jellyfin** server, or **any Windows app** (Deezer, a browser tab...), controlled from a browser dashboard.
 
 <p align="center">
   <img src="assets/ingame.png" alt="In-game radio station" width="49%" />
@@ -16,6 +16,7 @@ An open-source radio mod for **Forza Horizon 6**. Adds a new in-game radio stati
 ## Features
 
 - **Local files**: build named **stations** from one or more folders, exclude subfolders you don't want, and pick a play order (shuffle / albums / name / folder) with repeat modes and a searchable queue. MP3 / FLAC / WAV / OGG / M4A / AAC / OPUS / WMA / M3U / M3U8 etc.
+- **Online radio**: search a directory of thousands of internet stations by name, genre, or country (via [radio-browser.info](https://www.radio-browser.info)) or paste any stream URL; save favourites with logos and genre/bitrate badges, with live track info.
 - **YouTube Music**: paste any video, playlist, or YT Music URL from the dashboard.
 - **Spotify Connect**: cast from the Spotify app to an "FH6 Universal Radio" device (requires Spotify Premium).
 - **Jellyfin**: stream playlists from your own Jellyfin server.
@@ -38,7 +39,7 @@ An open-source radio mod for **Forza Horizon 6**. Adds a new in-game radio stati
 
 ### Dependencies
 
-YouTube Music, Spotify, Jellyfin, and non-native local formats rely on external binaries: `yt-dlp`, `ffmpeg`, and `librespot`. The mod **downloads them automatically** on first launch into `fh6-radio\bin`, so there's nothing to install by hand.
+Online radio, YouTube Music, Spotify, Jellyfin, and non-native local formats rely on external binaries: `yt-dlp`, `ffmpeg`, and `librespot`. The mod **downloads them automatically** on first launch into `fh6-radio\bin`, so there's nothing to install by hand.
 
 To manage them yourself instead, set the paths in the dashboard (**Settings > YouTube Music** for yt-dlp, **Settings > General > ffmpeg path**, **Settings > Spotify Connect** for librespot).
 
@@ -107,7 +108,7 @@ Requires **CMake** and **llvm-mingw**. On Arch: `sudo pacman -S llvm-mingw cmake
 
 ## Why this exists
 
-[Big John](https://www.nexusmods.com/forzahorizon6/mods/95) released a great **Spotify** radio mod for FH6 that I drew a lot of inspiration from. The catch: it requires Spotify Premium, and the author chose to keep it closed-source. I built FH6 Universal Radio because I believe the project can go much further once the community is allowed to contribute: adding sources (TIDAL, internet radio, etc.), polishing the UI, fixing edge cases, supporting more game builds. So this one is **fully open and GPLv3-licensed** to make that possible.
+[Big John](https://www.nexusmods.com/forzahorizon6/mods/95) released a great **Spotify** radio mod for FH6 that I drew a lot of inspiration from. The catch: it requires Spotify Premium, and the author chose to keep it closed-source. I built FH6 Universal Radio because I believe the project can go much further once the community is allowed to contribute: adding sources (TIDAL, etc.), polishing the UI, fixing edge cases, supporting more game builds. So this one is **fully open and GPLv3-licensed** to make that possible.
 
 ## Support the Project
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -8,12 +8,12 @@
 [general]
 port              = 8420
 ring_buffer_mb    = 4
-default_source    = "local_files"     # local_files | youtube_music | jellyfin | external_audio
+default_source    = "online_radio"    # local_files | online_radio | youtube_music | jellyfin | external_audio | spotify
 fallback_source   = "local_files"
 ffmpeg_path       = ''                # blank = auto-download to fh6-radio/bin (else `ffmpeg` on PATH); shared by all sources
 
 [local_files]
-enabled            = true
+enabled            = false
 active_station     = "My Music"        # which preset is on air
 # mp3/flac/wav/ogg decode natively; the rest goes through ffmpeg if available.
 supported_formats  = ["mp3", "flac", "wav", "ogg", "m4a", "opus", "aac", "wma", "aiff", "aif", "m3u", "m3u8"]
@@ -61,13 +61,22 @@ librespot_path     = ''                # blank = auto-download to fh6-radio/bin 
 cache_dir          = 'spotify_cache'   # folder to save the Spotify Connect auth data
 
 [online_radio]
-enabled               = false
+enabled               = true
 default_station_index = 0 # index of radio station in list (0 refers to start of the list)
 
-# you can add as many stations as you want below
+# you can add as many stations as you want below. name + url are required; the
+# rest are filled in automatically when you save a station from the dashboard's
+# Discover tab (radio-browser.info) and are optional when adding by hand.
 #[[online_radio.stations]]
-#name = "" # name of radio station
-#url  = "" # url of radio station stream
+#name     = "" # display name
+#url      = "" # stream url
+#favicon  = "" # logo url, shown as now-playing artwork
+#tags     = "" # comma-separated genres
+#country  = "" # ISO 3166-1 alpha-2 code or name
+#codec    = "" # e.g. "mp3", "aac"
+#bitrate  = 0  # kbps
+#uuid     = "" # radio-browser station id
+#favorite = false
 
 [audio]
 output_gain = 1.0

--- a/include/fh6/config.hpp
+++ b/include/fh6/config.hpp
@@ -23,7 +23,7 @@ struct PlaybackConfig {
 struct GeneralConfig {
     uint16_t port               = 8420;
     uint32_t ring_buffer_mb     = 4;
-    std::string default_source  = "local_files";
+    std::string default_source  = "online_radio";
     std::string fallback_source = "local_files";
     std::filesystem::path ffmpeg_path; // empty = look up on PATH; shared by all sources
 };
@@ -68,10 +68,17 @@ struct JellyfinConfig {
 struct RadioStation {
     std::string name;
     std::string url;
+    std::string favicon; // logo URL (shown as now-playing artwork)
+    std::string tags;    // comma-separated genres
+    std::string country; // ISO 3166-1 alpha-2 or display name
+    std::string codec;
+    int bitrate = 0; // kbps
+    std::string uuid;       // radio-browser stationuuid, for dedup/click counting
+    bool favorite = false;
 };
 
 struct OnlineRadioConfig {
-    bool enabled = false;
+    bool enabled = true;
     std::vector<RadioStation> stations;
     size_t default_station_index = 0;
 };

--- a/include/fh6/sources/online_radio_source.hpp
+++ b/include/fh6/sources/online_radio_source.hpp
@@ -6,6 +6,7 @@
 #include "fh6/worker/worker_client.hpp"
 
 #include <atomic>
+#include <deque>
 #include <filesystem>
 #include <memory>
 #include <mutex>
@@ -47,11 +48,15 @@ public:
 
     void set_config(const OnlineRadioConfig& c);
     void set_ffmpeg_path(std::filesystem::path p);
-    void set_target(std::string url);
+    void set_target(std::string url, std::string name = {}, std::string logo = {});
 
     // single source of truth for what may be handed to ffmpeg -i (guards every
     // playback path against file:/concat:/etc. injection from config or the API).
     static bool is_streamable_url(std::string_view url) noexcept;
+
+    // recent ICY song titles for the current stream (newest first), surfaced in
+    // /api/state details as the dashboard's track-history list.
+    std::vector<std::string> song_history() const;
 
 private:
     struct Pipe;
@@ -65,10 +70,14 @@ private:
     mutable std::mutex mu_;
     size_t current_station_idx_ = 0;
     std::string target_url_;
+    std::string target_name_;
+    std::string target_logo_;
 
     // dynamic metadata state
     std::string current_title_;
     std::string current_artist_;
+    std::string current_logo_;             // station favicon, reported as artwork_url
+    std::deque<std::string> song_history_; // newest first, capped
 
     std::atomic<PlaybackState> state_{PlaybackState::stopped};
     EqualizerStage eq_;

--- a/scripts/dist-readme.txt
+++ b/scripts/dist-readme.txt
@@ -3,9 +3,9 @@ FH6 Universal Radio
 
 Thanks for grabbing this. It's a free, open-source mod that drops a
 brand new station into Forza Horizon 6's radio dial. You feed it audio
-from a folder of music files on your PC, from Spotify, from any YouTube / YouTube
-Music link, from a Jellyfin server, or from any other Windows app
-(Deezer, a browser tab...), and the game treats the result
+from a folder of music files on your PC, from online radio stations, from
+Spotify, from any YouTube / YouTube Music link, from a Jellyfin server, or
+from any other Windows app (Deezer, a browser tab...), and the game treats the result
 like every other station: it ducks for menus, follows your in-game
 volume slider, and fades on the loading screen.
 
@@ -58,6 +58,11 @@ From there:
     scanned too, and you can uncheck the ones you don't want. Pick a play
     order (shuffle / albums / name / folder), a repeat mode, and browse or
     search the queue.
+
+  * Online radio: search a built-in directory of thousands of internet
+    stations by name, genre, or country and tune one in a click, or paste
+    a direct stream URL. Save favourites with their logos; the dashboard
+    also keeps a "recently played" list.
 
   * YouTube Music: paste a video URL, a playlist, or a YT Music
     link.

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -142,8 +142,17 @@ Config load_config(const std::filesystem::path& path) {
                   static_cast<int>(cfg.online_radio.default_station_index));
     cfg.online_radio.default_station_index = station_index < 0 ? 0u : static_cast<size_t>(station_index);
     for (const auto& st : pick<std::vector<toml::value>>(or_sec, "stations", {})) {
-        cfg.online_radio.stations.push_back(
-            {pick<std::string>(st, "name", ""), pick<std::string>(st, "url", "")});
+        RadioStation rs;
+        rs.name     = pick<std::string>(st, "name", "");
+        rs.url      = pick<std::string>(st, "url", "");
+        rs.favicon  = pick<std::string>(st, "favicon", "");
+        rs.tags     = pick<std::string>(st, "tags", "");
+        rs.country  = pick<std::string>(st, "country", "");
+        rs.codec    = pick<std::string>(st, "codec", "");
+        rs.bitrate  = pick<int>(st, "bitrate", 0);
+        rs.uuid     = pick<std::string>(st, "uuid", "");
+        rs.favorite = pick<bool>(st, "favorite", false);
+        cfg.online_radio.stations.push_back(std::move(rs));
     }
 
     const auto& ea             = section(root, "external_audio");
@@ -348,6 +357,13 @@ void save_config(const std::filesystem::path& path, const Config& cfg) {
         e.array_header("online_radio.stations");
         e.kv("name", st.name);
         e.kv("url", st.url);
+        if (!st.favicon.empty()) e.kv("favicon", st.favicon);
+        if (!st.tags.empty()) e.kv("tags", st.tags);
+        if (!st.country.empty()) e.kv("country", st.country);
+        if (!st.codec.empty()) e.kv("codec", st.codec);
+        if (st.bitrate) e.kv("bitrate", (int64_t)st.bitrate);
+        if (!st.uuid.empty()) e.kv("uuid", st.uuid);
+        if (st.favorite) e.kv("favorite", true);
     }
 
     e.header("audio");

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -150,6 +150,7 @@ Config load_config(const std::filesystem::path& path) {
         rs.country  = pick<std::string>(st, "country", "");
         rs.codec    = pick<std::string>(st, "codec", "");
         rs.bitrate  = pick<int>(st, "bitrate", 0);
+        if (rs.bitrate < 0) rs.bitrate = 0;
         rs.uuid     = pick<std::string>(st, "uuid", "");
         rs.favorite = pick<bool>(st, "favorite", false);
         cfg.online_radio.stations.push_back(std::move(rs));

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -108,6 +108,8 @@ json source_to_json(IAudioSource* s) {
     }
     if (auto* yt = dynamic_cast<sources::YouTubeMusicSource*>(s))
         j["details"]["shuffle"] = yt->shuffle();
+    if (auto* rd = dynamic_cast<sources::OnlineRadioSource*>(s))
+        j["details"]["song_history"] = rd->song_history();
     return j;
 }
 
@@ -189,7 +191,15 @@ json config_to_json(const Config& c) {
              {"stations", [&c]() {
                   json arr = json::array();
                   for (const auto& st : c.online_radio.stations) {
-                      arr.push_back({{"name", st.name}, {"url", st.url}});
+                      arr.push_back({{"name", st.name},
+                                     {"url", st.url},
+                                     {"favicon", st.favicon},
+                                     {"tags", st.tags},
+                                     {"country", st.country},
+                                     {"codec", st.codec},
+                                     {"bitrate", st.bitrate},
+                                     {"uuid", st.uuid},
+                                     {"favorite", st.favorite}});
                   }
                   return arr;
               }()}
@@ -304,10 +314,17 @@ void apply_patch(Config& c, const json& j) {
         if (auto st = it->find("stations"); st != it->end() && st->is_array()) {
             c.online_radio.stations.clear();
             for (const auto& item : *st) {
-                c.online_radio.stations.push_back({
-                    item.value("name", ""),
-                    item.value("url", "")
-                });
+                RadioStation rs;
+                rs.name     = item.value("name", "");
+                rs.url      = item.value("url", "");
+                rs.favicon  = item.value("favicon", "");
+                rs.tags     = item.value("tags", "");
+                rs.country  = item.value("country", "");
+                rs.codec    = item.value("codec", "");
+                rs.bitrate  = item.value("bitrate", 0);
+                rs.uuid     = item.value("uuid", "");
+                rs.favorite = item.value("favorite", false);
+                c.online_radio.stations.push_back(std::move(rs));
             }
         }
         if (c.online_radio.stations.empty()) {
@@ -811,7 +828,8 @@ struct HttpServer::Impl {
         if (m == "POST" && p == "/api/source/online_radio/cast") {
             auto* rd = find_typed<sources::OnlineRadioSource>("online_radio");
             if (!rd) return fail(404, "online_radio not registered");
-            auto url = json::parse(req.body).value("url", std::string{});
+            auto body = json::parse(req.body);
+            auto url  = body.value("url", std::string{});
             if (url.empty()) return fail(400, "url required");
             if (!sources::OnlineRadioSource::is_streamable_url(url)) {
                 return fail(400, "only http/https urls are allowed");
@@ -819,7 +837,8 @@ struct HttpServer::Impl {
 
             const bool was_active = (mgr.active() == rd);
             rd->stop();
-            rd->set_target(std::move(url));
+            rd->set_target(std::move(url), body.value("name", std::string{}),
+                           body.value("logo", std::string{}));
             if (was_active) mgr.ring().drain();
             rd->play();
             mgr.switch_to("online_radio");

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -322,6 +322,7 @@ void apply_patch(Config& c, const json& j) {
                 rs.country  = item.value("country", "");
                 rs.codec    = item.value("codec", "");
                 rs.bitrate  = item.value("bitrate", 0);
+                if (rs.bitrate < 0) rs.bitrate = 0;
                 rs.uuid     = item.value("uuid", "");
                 rs.favorite = item.value("favorite", false);
                 c.online_radio.stations.push_back(std::move(rs));

--- a/src/sources/online_radio_source.cpp
+++ b/src/sources/online_radio_source.cpp
@@ -71,9 +71,11 @@ void OnlineRadioSource::set_ffmpeg_path(std::filesystem::path p) {
     ffmpeg_path_ = std::move(p);
 }
 
-void OnlineRadioSource::set_target(std::string url) {
+void OnlineRadioSource::set_target(std::string url, std::string name, std::string logo) {
     std::scoped_lock lk{mu_};
-    target_url_ = std::move(url);
+    target_url_  = std::move(url);
+    target_name_ = std::move(name);
+    target_logo_ = std::move(logo);
 }
 
 void OnlineRadioSource::start_pipe_locked() {
@@ -98,12 +100,14 @@ void OnlineRadioSource::start_pipe_locked() {
     // initial metadata shown until the stream surfaces ICY/ID3 tags.
     const auto set_initial_meta = [&] {
         if (is_direct) {
-            current_artist_ = "Direct Stream";
-            current_title_  = play_url;
+            current_title_ = target_name_.empty() ? play_url : target_name_;
+            current_logo_  = target_logo_;
         } else {
-            current_artist_ = "Online Radio";
-            current_title_  = cfg_.stations[current_station_idx_].name;
+            const auto& st = cfg_.stations[current_station_idx_];
+            current_title_ = st.name;
+            current_logo_  = st.favicon;
         }
+        current_artist_ = {};
     };
 
     auto pipe = std::make_unique<Pipe>();
@@ -204,6 +208,8 @@ void OnlineRadioSource::stop() {
     std::scoped_lock lk{mu_};
     stop_pipe_locked();
     target_url_.clear();
+    target_name_.clear();
+    target_logo_.clear();
 }
 
 void OnlineRadioSource::next() {
@@ -232,8 +238,14 @@ TrackInfo OnlineRadioSource::current_track() const {
     TrackInfo info;
     info.artist      = current_artist_;
     info.title       = current_title_;
+    info.artwork_url = current_logo_;
     info.position_ms = position_ms_.load(std::memory_order_acquire);
     return info;
+}
+
+std::vector<std::string> OnlineRadioSource::song_history() const {
+    std::scoped_lock lk{mu_};
+    return {song_history_.begin(), song_history_.end()};
 }
 
 void OnlineRadioSource::set_playback_options(const PlaybackConfig& opts) {
@@ -299,6 +311,13 @@ void OnlineRadioSource::pump(RingBuffer& ring) {
             if (current_artist_ == artist && current_title_ == title) return;
             current_artist_ = artist;
             current_title_  = title;
+            if (!title.empty()) {
+                std::string entry = artist.empty() ? title : artist + " — " + title;
+                if (song_history_.empty() || song_history_.front() != entry) {
+                    song_history_.push_front(std::move(entry));
+                    if (song_history_.size() > 12) song_history_.pop_back();
+                }
+            }
             log::info("[online_radio] Metadata Update ({}): {} - {}", kind, current_artist_,
                       current_title_);
         };

--- a/ui/dist/index.html
+++ b/ui/dist/index.html
@@ -71,17 +71,6 @@
         </form>
       </section>
 
-      <section class="card" id="or-cast-card" hidden>
-        <h2>Play Online Radio</h2>
-        <p class="muted">Paste any direct audio stream URL. The radio will switch sources and start streaming immediately.</p>
-        <form id="or-cast" class="row">
-          <input type="text" id="or-url" placeholder="" autocomplete="off" />
-          <button type="submit" class="btn filled">Play</button>
-          <button type="button" id="or-save" class="btn ghost">Save Station</button>
-        </form>
-        <div id="or-station-view" style="display: flex; flex-direction: column; gap: 8px; margin-top: 16px;"></div>
-      </section>
-
       <section class="card" id="output-card" hidden>
         <h2>Output</h2>
         <label class="slider">

--- a/ui/dist/js/api.js
+++ b/ui/dist/js/api.js
@@ -19,7 +19,8 @@ export const api = {
   switchSource: source => request("/api/source/switch", { method: "POST", body: { source } }),
   transport: (source, action) => request(`/api/source/${source}/${action}`, { method: "POST" }),
   castYoutube: url => request("/api/source/youtube_music/cast", { method: "POST", body: { url } }),
-  castOnlineRadio: url => request("/api/source/online_radio/cast", { method: "POST", body: { url } }),
+  castOnlineRadio: (url, opts = {}) =>
+    request("/api/source/online_radio/cast", { method: "POST", body: { url, ...opts } }),
   shuffleYoutube: shuffle =>
     request("/api/source/youtube_music/shuffle", { method: "POST", body: { shuffle } }),
   castJellyfin: playlistId =>

--- a/ui/dist/js/main.js
+++ b/ui/dist/js/main.js
@@ -1,4 +1,4 @@
-import { $, el } from "./dom.js";
+import { $ } from "./dom.js";
 import { api } from "./api.js";
 import { connect } from "./events.js";
 import { icons } from "./icons.js";
@@ -11,6 +11,7 @@ import { renderSettings, collectSettings } from "./render/settings.js";
 import { createDeps } from "./render/deps.js";
 import { createExternalAudio } from "./render/externalAudio.js";
 import { createLocalFiles } from "./render/localFiles.js";
+import { createOnlineRadio } from "./render/onlineRadio.js";
 
 let state = null;
 let cfg = null;
@@ -34,8 +35,6 @@ const refs = {
   ytCard: $("#yt-cast-card"),
   jfCard: $("#jf-cast-card"),
   ytShuffle: $("#yt-shuffle"),
-  orCard: $("#or-cast-card"),
-  orStationView: $("#or-station-view"),
   drawer: $("#drawer"),
   scrim: $("#scrim"),
   form: $("#settings-form"),
@@ -71,6 +70,16 @@ const externalAudio = createExternalAudio(mainEl, {
 });
 
 const localFiles = createLocalFiles(mainEl, {
+  getState: () => state,
+  getConfig: () => cfg,
+  onSaved: async () => {
+    cfg = await api.getConfig().catch(() => cfg);
+    state = await api.getState().catch(() => state);
+    render();
+  },
+});
+
+const onlineRadio = createOnlineRadio(mainEl, {
   getState: () => state,
   getConfig: () => cfg,
   onSaved: async () => {
@@ -132,6 +141,7 @@ function render() {
   renderOutput(state);
   externalAudio.render();
   localFiles.render();
+  onlineRadio.render();
 
   refs.sourceCard.hidden = false;
   refs.outputCard.hidden = !state.sources?.active;
@@ -144,37 +154,6 @@ function render() {
   const shuffleOn = !!available.find(s => s.name === "youtube_music")?.details?.shuffle;
   refs.ytShuffle.classList.toggle("toggled", shuffleOn);
   refs.ytShuffle.setAttribute("aria-pressed", String(shuffleOn));
-
-  refs.orCard.hidden = active !== "online_radio";
-
-  if (cfg?.online_radio?.stations && refs.orStationView) {
-    refs.orStationView.innerHTML = "";
-    cfg.online_radio.stations.forEach((station, index) => {
-      const row = el("div", { class: "row", style: "justify-content: space-between; padding: 6px 12px; background: var(--surface-raise); border-radius: var(--radius-md); border: 1px solid var(--line);" }, [
-        el("span", { style: "font-weight: 500;" }, station.name || `Station ${index + 1}`),
-        el("div", { class: "row", style: "gap: 8px;" }, [
-          el("button", { type: "button", class: "btn ghost", html: "Tune" }),
-          el("button", { type: "button", class: "btn ghost", html: "Delete" })
-        ])
-      ]);
-      
-      const btns = row.querySelectorAll("button");
-      btns[0].onclick = () => {
-        api.castOnlineRadio(station.url);
-        toast(`Tuning into ${station.name}`);
-      };
-      btns[1].onclick = async () => {
-        if (!confirm(`Delete ${station.name}?`)) return;
-        const newStations = cfg.online_radio.stations.filter((_, i) => i !== index);
-        try {
-          cfg = await api.putConfig({ online_radio: { stations: newStations } });
-          render();
-          toast("Station deleted");
-        } catch(e) { toast(e.message, true); }
-      };
-      refs.orStationView.appendChild(row);
-    });
-  }
 }
 
 $("#t-play").addEventListener("click", () => transport("play"));
@@ -189,39 +168,6 @@ $("#yt-cast").addEventListener("submit", async e => {
     await api.castYoutube(url);
     $("#yt-url").value = "";
     toast("Casting…");
-  } catch (err) {
-    toast(err.message, true);
-  }
-});
-
-const orUrlInput = $("#or-url");
-
-$("#or-cast").addEventListener("submit", async e => {
-  e.preventDefault();
-  const url = orUrlInput.value.trim();
-  if (!url) return;
-  try {
-    await api.castOnlineRadio(url);
-    orUrlInput.value = "";
-    toast("Casting audio stream...");
-  } catch (err) {
-    toast(err.message, true);
-  }
-});
-
-$("#or-save").addEventListener("click", async () => {
-  const url = orUrlInput.value.trim();
-  if (!url) return toast("Enter a URL first to save.", true);
-
-  const name = prompt("Enter a name for this radio station:", "New Station");
-  if (!name) return; // cancelled
-
-  const updatedStations = [...(cfg?.online_radio?.stations || []), { name, url }];
-
-  try {
-    cfg = await api.putConfig({ online_radio: { stations: updatedStations } });
-    render();
-    toast("Station saved!");
   } catch (err) {
     toast(err.message, true);
   }
@@ -274,6 +220,7 @@ $("#save-config").addEventListener("click", async () => {
     cfg = await api.putConfig(collectSettings(refs.form));
     externalAudio.invalidate();
     localFiles.invalidate();
+    onlineRadio.invalidate();
     state = await api.getState().catch(() => state);
     render();
     toast("Saved");
@@ -288,6 +235,7 @@ $("#reload-config").addEventListener("click", async () => {
     cfg = await api.reloadConfig();
     externalAudio.invalidate();
     localFiles.invalidate();
+    onlineRadio.invalidate();
     renderSettings(refs.form, cfg);
     render();
     toast("Reloaded from disk");

--- a/ui/dist/js/radioBrowser.js
+++ b/ui/dist/js/radioBrowser.js
@@ -1,0 +1,82 @@
+// Thin client for the radio-browser.info community directory. Runs entirely in
+// the browser: the API sends `Access-Control-Allow-Origin: *`, so no backend
+// proxy is needed. No key, no account.
+
+const FALLBACK_MIRRORS = [
+  "https://de2.api.radio-browser.info",
+  "https://nl1.api.radio-browser.info",
+  "https://at1.api.radio-browser.info",
+];
+
+let mirror = null;
+let mirrorPromise = null;
+
+async function resolveMirror() {
+  if (mirror) return mirror;
+  if (mirrorPromise) return mirrorPromise;
+  mirrorPromise = (async () => {
+    try {
+      const res = await fetch("https://all.api.radio-browser.info/json/servers", {
+        headers: { accept: "application/json" },
+      });
+      if (!res.ok) throw new Error("servers");
+      const names = (await res.json()).map(s => s && s.name).filter(Boolean);
+      if (!names.length) throw new Error("empty");
+      mirror = `https://${names[Math.floor(Math.random() * names.length)]}`;
+    } catch {
+      mirror = FALLBACK_MIRRORS[Math.floor(Math.random() * FALLBACK_MIRRORS.length)];
+    }
+    return mirror;
+  })();
+  return mirrorPromise;
+}
+
+async function call(path, params) {
+  const base = await resolveMirror();
+  const qs = params ? "?" + new URLSearchParams(params) : "";
+  let res;
+  try {
+    res = await fetch(`${base}${path}${qs}`, { headers: { accept: "application/json" } });
+  } catch {
+    mirror = null; // a dead mirror shouldn't stick — re-pick on the next call
+    mirrorPromise = null;
+    throw new Error("Radio directory unavailable");
+  }
+  if (!res.ok) throw new Error("Radio directory error");
+  return res.json();
+}
+
+// Map a directory record onto the station shape the rest of the UI uses
+// (field names mirror the backend RadioStation / config so they round-trip 1:1).
+export function normalizeStation(s) {
+  return {
+    name: (s.name || "").trim() || "Unknown station",
+    url: s.url_resolved || s.url || "",
+    favicon: s.favicon || "",
+    tags: s.tags || "",
+    country: s.countrycode || s.country || "",
+    codec: s.codec || "",
+    bitrate: Number(s.bitrate) || 0,
+    uuid: s.stationuuid || "",
+  };
+}
+
+export async function searchStations({ name = "", tag = "", country = "", limit = 40 } = {}) {
+  const params = {
+    limit: String(limit),
+    order: "clickcount",
+    reverse: "true",
+    hidebroken: "true",
+  };
+  if (name) params.name = name;
+  if (tag) params.tagList = tag;
+  if (country) params.countrycode = country;
+  const rows = await call("/json/stations/search", params);
+  return (Array.isArray(rows) ? rows : []).map(normalizeStation).filter(s => s.url);
+}
+
+// Fire-and-forget: bumps the community click counter and resolves the playable URL.
+export function registerClick(uuid) {
+  if (!uuid) return Promise.resolve(null);
+  return call(`/json/url/${encodeURIComponent(uuid)}`).catch(() => null);
+}

--- a/ui/dist/js/render/onlineRadio.js
+++ b/ui/dist/js/render/onlineRadio.js
@@ -1,0 +1,424 @@
+import { api } from "../api.js";
+import { $, el } from "../dom.js";
+import { toast } from "../toast.js";
+import { searchStations, registerClick } from "../radioBrowser.js";
+
+// Lowercase + strip diacritics, so "jazz" matches "Jázz" in the station filter.
+const fold = s => (s || "").normalize("NFD").replace(/\p{Diacritic}/gu, "").toLowerCase();
+
+// Genre chips shown on the empty state and above the directory search.
+const GENRES = ["lofi", "jazz", "rock", "electronic", "classical", "news", "pop", "hip hop"];
+
+// A small curated country list for the directory filter (ISO 3166-1 alpha-2).
+const COUNTRIES = [
+  ["", "Any country"],
+  ["US", "United States"],
+  ["GB", "United Kingdom"],
+  ["FR", "France"],
+  ["DE", "Germany"],
+  ["ES", "Spain"],
+  ["IT", "Italy"],
+  ["JP", "Japan"],
+  ["BR", "Brazil"],
+  ["CA", "Canada"],
+  ["AU", "Australia"],
+  ["NL", "Netherlands"],
+];
+
+const RECENTS_KEY = "or.recents.v1";
+const RECENTS_CAP = 12;
+
+const readJson = (key, fallback) => {
+  try {
+    return JSON.parse(localStorage.getItem(key)) ?? fallback;
+  } catch {
+    return fallback;
+  }
+};
+const writeJson = (key, value) => {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    /* private mode / quota — recents are best-effort */
+  }
+};
+
+// Full station shape; mirrors the backend RadioStation so it round-trips via config.
+const normalize = st => ({
+  name: st.name || st.url || "New station",
+  url: st.url || "",
+  favicon: st.favicon || "",
+  tags: st.tags || "",
+  country: st.country || "",
+  codec: st.codec || "",
+  bitrate: st.bitrate || 0,
+  uuid: st.uuid || "",
+  favorite: !!st.favorite,
+});
+
+const badgeText = s =>
+  [s.tags?.split(",")[0]?.trim(), s.country, s.bitrate ? `${s.bitrate}kbps` : ""]
+    .filter(Boolean)
+    .join(" · ");
+
+// Online Radio card: cast bar, saved stations, recents, and a directory browser.
+export function createOnlineRadio(main, ctx) {
+  let recents = readJson(RECENTS_KEY, []);
+  let stations = []; // full station objects, mirrored to config.online_radio.stations
+  let cfgSig = null;
+  let filter = "";
+  let historySig = "";
+
+  // --- cast bar -------------------------------------------------------------
+  const urlInput = el("input", { type: "text", id: "or-url", placeholder: "Paste a stream URL…", autocomplete: "off" });
+  const playBtn = el("button", { type: "submit", class: "btn filled" }, "Play");
+  const saveBtn = el("button", { type: "button", class: "btn ghost" }, "Save");
+  const castForm = el("form", { id: "or-cast", class: "row" }, [urlInput, playBtn, saveBtn]);
+
+  // --- live track history ---------------------------------------------------
+  const history = el("div", { class: "or-history", hidden: true });
+
+  // --- tabs -----------------------------------------------------------------
+  const mineTab = el("button", { type: "button", class: "or-tab on" }, "My Stations");
+  const discoverTab = el("button", { type: "button", class: "or-tab" }, "Discover");
+  const tabs = el("div", { class: "or-tabs" }, [mineTab, discoverTab]);
+
+  // --- my stations panel ----------------------------------------------------
+  const filterInput = el("input", { type: "text", placeholder: "Filter your stations…", autocomplete: "off" });
+  const recentsWrap = el("div", { class: "or-recents", hidden: true });
+  const recentsRow = el("div", { class: "or-chiprow" });
+  const mineList = el("div", { class: "or-stations" });
+  const minePanel = el("div", { class: "or-panel" }, [filterInput, recentsWrap, mineList]);
+  recentsWrap.append(el("label", { class: "field-label" }, "Recently played"), recentsRow);
+
+  // --- discover panel -------------------------------------------------------
+  const dq = el("input", { type: "text", placeholder: "Search stations…", autocomplete: "off" });
+  const dCountry = el("select", { "aria-label": "Country" }, COUNTRIES.map(([v, t]) => el("option", { value: v }, t)));
+  const dSearchBtn = el("button", { type: "submit", class: "btn filled" }, "Search");
+  const dForm = el("form", { class: "row or-discover-form" }, [dq, dCountry, dSearchBtn]);
+  const genreRow = el("div", { class: "or-chiprow or-genres" }, genreChips(GENRES));
+  const dResults = el("div", { class: "or-stations" });
+
+  function genreChips(list) {
+    return list.map(g => {
+      const chip = el("button", { type: "button", class: "or-chip" }, g);
+      chip.addEventListener("click", () => {
+        switchTab("discover");
+        dq.value = g;
+        runSearch();
+      });
+      return chip;
+    });
+  }
+  const discoverPanel = el("div", { class: "or-panel", hidden: true }, [dForm, genreRow, dResults]);
+
+  const card = el("section", { class: "card", id: "online-radio-card", hidden: true }, [
+    el("h2", {}, "Online Radio"),
+    el("p", { class: "muted" }, "Tune any stream, save your favourites, or discover thousands of stations worldwide."),
+    castForm,
+    history,
+    tabs,
+    minePanel,
+    discoverPanel,
+  ]);
+
+  const sourcesCard = $("#sources", main)?.closest(".card");
+  if (sourcesCard) sourcesCard.insertAdjacentElement("afterend", card);
+  else main.append(card);
+
+  const editor = createEditor();
+
+  // --- persistence ----------------------------------------------------------
+  async function persist() {
+    cfgSig = JSON.stringify(stations); // optimistic: skip the echo re-render
+    try {
+      await api.putConfig({ online_radio: { stations } });
+      await ctx.onSaved?.();
+    } catch (e) {
+      toast(e.message, true);
+    }
+  }
+  function pushRecent(st) {
+    recents = [normalize(st), ...recents.filter(r => r.url !== st.url)].slice(0, RECENTS_CAP);
+    writeJson(RECENTS_KEY, recents);
+    renderRecents();
+  }
+
+  // --- playback -------------------------------------------------------------
+  async function play(st) {
+    if (!st?.url) return;
+    try {
+      await api.castOnlineRadio(st.url, { name: st.name || "", logo: st.favicon || "" });
+      pushRecent(st);
+      if (st.uuid) registerClick(st.uuid);
+      toast(`Tuning into ${st.name || "stream"}…`);
+    } catch (e) {
+      toast(e.message, true);
+    }
+  }
+
+  function addStation(st) {
+    if (!st.url) return;
+    if (stations.some(s => s.url === st.url)) return toast("That station is already saved.");
+    stations = [...stations, normalize(st)];
+    renderMine();
+    persist();
+  }
+
+  // --- rendering: my stations ----------------------------------------------
+  function stationCard(s, idx) {
+    const favBtn = el("button", { type: "button", class: "or-icon" + (s.favorite ? " on" : ""), title: s.favorite ? "Unfavourite" : "Favourite" }, s.favorite ? "★" : "☆");
+    favBtn.addEventListener("click", () => {
+      s.favorite = !s.favorite;
+      renderMine();
+      persist();
+    });
+    const editBtn = el("button", { type: "button", class: "or-icon", title: "Edit" }, "✎");
+    editBtn.addEventListener("click", () =>
+      editor.open(s, ({ name, url }) => {
+        Object.assign(s, { name, url });
+        renderMine();
+        persist();
+      }));
+    const delBtn = el("button", { type: "button", class: "or-icon", title: "Delete" }, "🗑");
+    delBtn.addEventListener("click", () => {
+      stations = stations.filter((_, i) => i !== idx);
+      renderMine();
+      persist();
+      toast("Station removed");
+    });
+    const upBtn = el("button", { type: "button", class: "or-icon", title: "Move up", disabled: idx === 0 }, "↑");
+    upBtn.addEventListener("click", () => move(idx, -1));
+    const downBtn = el("button", { type: "button", class: "or-icon", title: "Move down", disabled: idx === stations.length - 1 }, "↓");
+    downBtn.addEventListener("click", () => move(idx, 1));
+
+    const playBtn0 = el("button", { type: "button", class: "btn filled or-play" }, "Play");
+    playBtn0.addEventListener("click", () => play(s));
+
+    return el("div", { class: "or-card" }, [
+      stationLogo(s.favicon),
+      el("div", { class: "or-card-main" }, [
+        el("span", { class: "or-name" }, s.name || s.url),
+        badgeText(s) ? el("span", { class: "or-badges muted" }, badgeText(s)) : null,
+      ]),
+      el("div", { class: "or-card-actions" }, [playBtn0, favBtn, editBtn, upBtn, downBtn, delBtn]),
+    ]);
+  }
+
+  function move(idx, dir) {
+    const j = idx + dir;
+    if (j < 0 || j >= stations.length) return;
+    [stations[idx], stations[j]] = [stations[j], stations[idx]];
+    renderMine();
+    persist();
+  }
+
+  function renderMine() {
+    const terms = fold(filter).split(/\s+/).filter(Boolean);
+    const matches = s =>
+      !terms.length || terms.every(w => fold(`${s.name} ${s.tags} ${s.country}`).includes(w));
+    // Favourites float to the top; arrows still reorder the saved order within each group.
+    const order = stations
+      .map((s, i) => ({ s, i }))
+      .filter(({ s }) => matches(s))
+      .sort((a, b) => (b.s.favorite ? 1 : 0) - (a.s.favorite ? 1 : 0));
+
+    if (!stations.length) return void mineList.replaceChildren(emptyState());
+    if (!order.length) {
+      return void mineList.replaceChildren(el("p", { class: "muted" }, "No stations match your filter."));
+    }
+    mineList.replaceChildren(...order.map(({ s, i }) => stationCard(s, i)));
+  }
+
+  function emptyState() {
+    return el("div", { class: "or-empty" }, [
+      el("p", {}, "No saved stations yet."),
+      el("p", { class: "muted" }, "Discover thousands of stations, or paste a stream URL above."),
+      el("div", { class: "or-chiprow" }, genreChips(GENRES.slice(0, 6))),
+    ]);
+  }
+
+  function renderRecents() {
+    recentsWrap.hidden = !recents.length;
+    recentsRow.replaceChildren(
+      ...recents.map(r => {
+        const chip = el("button", { type: "button", class: "or-recent", title: `Play ${r.name}` }, [
+          stationLogo(r.favicon, true),
+          el("span", { class: "or-recent-name" }, r.name || r.url),
+        ]);
+        chip.addEventListener("click", () => play(r));
+        return chip;
+      }),
+    );
+  }
+
+  // --- rendering: discover --------------------------------------------------
+  function resultCard(s) {
+    const playBtn0 = el("button", { type: "button", class: "btn filled or-play" }, "Play");
+    playBtn0.addEventListener("click", () => play(s));
+    const addBtn = el("button", { type: "button", class: "btn ghost" }, "＋ Save");
+    addBtn.addEventListener("click", () => addStation(s));
+    return el("div", { class: "or-card" }, [
+      stationLogo(s.favicon),
+      el("div", { class: "or-card-main" }, [
+        el("span", { class: "or-name" }, s.name),
+        badgeText(s) ? el("span", { class: "or-badges muted" }, badgeText(s)) : null,
+      ]),
+      el("div", { class: "or-card-actions" }, [playBtn0, addBtn]),
+    ]);
+  }
+
+  let searchToken = 0;
+  async function runSearch() {
+    const token = ++searchToken;
+    dResults.replaceChildren(el("p", { class: "muted" }, "Searching…"));
+    try {
+      const rows = await searchStations({ name: dq.value.trim(), country: dCountry.value, limit: 40 });
+      if (token !== searchToken) return; // a newer search superseded this one
+      if (!rows.length) {
+        return void dResults.replaceChildren(el("p", { class: "muted" }, "No stations found. Try another search."));
+      }
+      dResults.replaceChildren(...rows.map(resultCard));
+    } catch (e) {
+      if (token !== searchToken) return;
+      const retry = el("button", { type: "button", class: "btn ghost" }, "Retry");
+      retry.addEventListener("click", runSearch);
+      dResults.replaceChildren(el("div", { class: "or-empty" }, [el("p", { class: "muted" }, e.message), retry]));
+    }
+  }
+
+  function switchTab(next) {
+    mineTab.classList.toggle("on", next === "mine");
+    discoverTab.classList.toggle("on", next === "discover");
+    minePanel.hidden = next !== "mine";
+    discoverPanel.hidden = next !== "discover";
+  }
+
+  // --- live track history (ICY titles, from /api/state details) -------------
+  function renderHistory(items) {
+    const rows = items.slice(0, 6);
+    const sig = rows.join("");
+    if (sig === historySig) return;
+    historySig = sig;
+    history.hidden = !rows.length;
+    if (!rows.length) return;
+    history.replaceChildren(
+      el("label", { class: "field-label" }, "Track history"),
+      el("ul", { class: "or-history-list" }, rows.map(t => el("li", {}, t))),
+    );
+  }
+
+  // --- events ---------------------------------------------------------------
+  castForm.addEventListener("submit", e => {
+    e.preventDefault();
+    const url = urlInput.value.trim();
+    if (!url) return;
+    play({ name: url, url });
+    urlInput.value = "";
+  });
+  saveBtn.addEventListener("click", () => {
+    const url = urlInput.value.trim();
+    if (!url) return toast("Enter a URL first to save.", true);
+    editor.open({ name: "", url }, st => {
+      addStation(st);
+      urlInput.value = "";
+    });
+  });
+  mineTab.addEventListener("click", () => switchTab("mine"));
+  discoverTab.addEventListener("click", () => switchTab("discover"));
+  filterInput.addEventListener("input", () => {
+    filter = filterInput.value;
+    renderMine();
+  });
+  dForm.addEventListener("submit", e => {
+    e.preventDefault();
+    runSearch();
+  });
+
+  // --- lifecycle ------------------------------------------------------------
+  function syncFromConfig() {
+    const cfgStations = ctx.getConfig()?.online_radio?.stations || [];
+    const sig = JSON.stringify(cfgStations);
+    if (sig === cfgSig) return;
+    cfgSig = sig;
+    stations = cfgStations.map(normalize);
+    renderMine();
+  }
+
+  let inited = false;
+  function render() {
+    const state = ctx.getState();
+    const isActive = state?.sources?.active === "online_radio";
+    card.hidden = !isActive;
+    if (!isActive) return;
+    if (!inited) {
+      renderRecents();
+      inited = true;
+    }
+    syncFromConfig();
+    const details = state?.sources?.available?.find(s => s.name === "online_radio")?.details;
+    renderHistory(details?.song_history || []);
+  }
+
+  return {
+    render,
+    invalidate: () => {
+      cfgSig = null;
+    },
+  };
+}
+
+function stationLogo(url, small = false) {
+  const cls = "or-logo" + (small ? " small" : "");
+  if (!url) return el("div", { class: cls + " placeholder", "aria-hidden": "true" }, "♪");
+  const img = el("img", { class: cls, alt: "", loading: "lazy", src: url });
+  img.addEventListener("error", () => img.replaceWith(el("div", { class: cls + " placeholder", "aria-hidden": "true" }, "♪")));
+  return img;
+}
+
+// Modal for adding / editing a station (name + URL). Replaces window.prompt().
+function createEditor() {
+  let onSave = null;
+  const nameInput = el("input", { type: "text", placeholder: "Station name", autocomplete: "off" });
+  const urlInput = el("input", { type: "text", placeholder: "Stream URL", autocomplete: "off" });
+  const saveBtn = el("button", { type: "button", class: "btn filled" }, "Save");
+  const cancelBtn = el("button", { type: "button", class: "btn ghost" }, "Cancel");
+  const title = el("h3", {}, "Save station");
+
+  const modal = el("div", { class: "or-modal", hidden: true }, [
+    el("div", { class: "or-modal-card" }, [
+      el("div", { class: "or-modal-head" }, [title]),
+      el("label", { class: "field-label" }, "Name"),
+      nameInput,
+      el("label", { class: "field-label" }, "Stream URL"),
+      urlInput,
+      el("div", { class: "or-modal-foot row" }, [saveBtn, cancelBtn]),
+    ]),
+  ]);
+  document.body.append(modal);
+
+  const close = () => (modal.hidden = true);
+  const submit = () => {
+    const name = nameInput.value.trim();
+    const url = urlInput.value.trim();
+    if (!url) return toast("A stream URL is required.", true);
+    close();
+    onSave?.({ name: name || url, url });
+  };
+
+  cancelBtn.addEventListener("click", close);
+  saveBtn.addEventListener("click", submit);
+  modal.addEventListener("click", e => e.target === modal && close());
+  [nameInput, urlInput].forEach(i => i.addEventListener("keydown", e => e.key === "Enter" && submit()));
+
+  return {
+    open(station, cb) {
+      onSave = cb;
+      title.textContent = station.url && station.name ? "Edit station" : "Save station";
+      nameInput.value = station.name || "";
+      urlInput.value = station.url || "";
+      modal.hidden = false;
+      (station.name ? urlInput : nameInput).focus();
+    },
+  };
+}

--- a/ui/dist/js/render/settings.js
+++ b/ui/dist/js/render/settings.js
@@ -28,6 +28,17 @@ function buildField(section, spec, cfg) {
     ]);
   }
 
+  if (type === "station-select") {
+    const list = cfg?.online_radio?.stations || [];
+    const options = list.length
+      ? list.map((s, i) => el("option", { value: String(i), selected: Number(cur) === i }, s.name || `Station ${i + 1}`))
+      : [el("option", { value: "0" }, "— no stations saved —")];
+    return el("div", { class: "field" }, [
+      el("label", { for: id }, label),
+      el("select", { id, dataset: { ...dataset, numeric: "1" } }, options),
+    ]);
+  }
+
   if (type === "select") {
     const options = (a || []).map(value => el("option", { value, selected: cur === value }, value));
     return el("div", { class: "field" }, [
@@ -89,6 +100,8 @@ export function collectSettings(form) {
       patch[section][key] = node.checked;
     } else if (node.type === "number" || node.type === "range") {
       patch[section][key] = parseFloat(node.value);
+    } else if (node.dataset.numeric) {
+      patch[section][key] = parseInt(node.value, 10) || 0;
     } else {
       patch[section][key] = node.value;
     }

--- a/ui/dist/js/schema.js
+++ b/ui/dist/js/schema.js
@@ -69,7 +69,9 @@ export const SCHEMA = [
     "Online Radio",
     [
       ["enabled", "Enable Online Radio", "checkbox"],
-      ["default_station_index", "Default Station (Index)", "number", 0, 99, 1]
+      ["default_station_index", "Default station", "station-select"],
+      // Stations, favourites and discovery live in the dedicated Online Radio
+      // card on the dashboard (render/onlineRadio.js).
     ],
   ],
   ["audio", "Audio", [["output_gain", "Output gain", "number", 0, 1, 0.01]]],

--- a/ui/dist/styles.css
+++ b/ui/dist/styles.css
@@ -242,6 +242,7 @@ main {
 }
 
 .card {
+  min-width: 0;
   background:
     linear-gradient(180deg, rgba(247, 244, 239, 0.022), transparent 55%),
     var(--surface-card);
@@ -357,6 +358,7 @@ main {
 
 .now-title {
   margin: 0;
+  max-width: 100%;
   font-size: clamp(var(--text-heading), 6vw, var(--text-heading-lg));
   font-weight: var(--font-weight-medium);
   line-height: var(--leading-heading-lg);
@@ -367,6 +369,7 @@ main {
   line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  overflow-wrap: anywhere;
 }
 
 .now-artist {
@@ -1278,6 +1281,288 @@ output {
 }
 
 .lf-modal-foot {
+  margin-top: var(--spacing-12);
+  justify-content: flex-end;
+}
+
+/* Online Radio. */
+.or-history {
+  margin-top: var(--spacing-8);
+}
+
+.or-history .field-label {
+  margin-bottom: 4px;
+}
+
+.or-history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.or-history-list li {
+  font-size: 12px;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.or-history-list li:first-child {
+  color: var(--text);
+}
+
+.or-tabs {
+  display: flex;
+  gap: var(--spacing-8);
+  margin-top: var(--spacing-16);
+  border-bottom: 1px solid var(--line);
+}
+
+.or-tab {
+  padding: 8px 4px;
+  margin-bottom: -1px;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.or-tab.on {
+  color: var(--text-strong);
+  border-bottom-color: var(--accent);
+}
+
+.or-panel {
+  margin-top: var(--spacing-16);
+}
+
+.or-panel > input[type="text"] {
+  margin-bottom: var(--spacing-12);
+}
+
+.or-discover-form {
+  margin-bottom: var(--spacing-12);
+}
+
+.or-discover-form input[type="text"] {
+  flex: 1;
+}
+
+.or-chiprow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-8);
+}
+
+.or-genres {
+  margin-bottom: var(--spacing-12);
+}
+
+.or-chip {
+  padding: 5px 12px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--line-strong);
+  background: var(--surface-raise);
+  color: var(--text);
+  cursor: pointer;
+  font-size: 13px;
+  text-transform: capitalize;
+}
+
+.or-chip:hover {
+  background: var(--surface-raise-hover);
+  border-color: var(--accent);
+}
+
+.or-recents {
+  margin-bottom: var(--spacing-16);
+}
+
+.or-recents .field-label {
+  margin-bottom: var(--spacing-8);
+}
+
+.or-recent {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-8);
+  padding: 4px 12px 4px 4px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--line);
+  background: var(--surface-raise);
+  color: var(--text);
+  cursor: pointer;
+  font-size: 13px;
+  max-width: 220px;
+}
+
+.or-recent:hover {
+  background: var(--surface-raise-hover);
+}
+
+.or-recent-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.or-stations {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-8);
+  max-height: 420px;
+  overflow: auto;
+}
+
+.or-card {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-12);
+  padding: 10px 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--line);
+  background: var(--surface-raise);
+}
+
+.or-card:hover {
+  border-color: var(--line-strong);
+}
+
+.or-logo {
+  flex: none;
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-md);
+  object-fit: cover;
+  background: var(--surface-card);
+  border: 1px solid var(--line);
+}
+
+.or-logo.small {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+}
+
+.or-logo.placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  font-size: 18px;
+}
+
+.or-logo.small.placeholder {
+  font-size: 12px;
+}
+
+.or-card-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.or-name {
+  font-size: 14px;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.or-badges {
+  font-size: 11px;
+  text-transform: capitalize;
+}
+
+.or-card-actions {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.or-play {
+  padding: 6px 14px;
+}
+
+.or-icon {
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.or-icon:hover:not(:disabled) {
+  background: var(--surface-raise-hover);
+  color: var(--text);
+}
+
+.or-icon.on {
+  color: var(--accent);
+}
+
+.or-icon:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+.or-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-12);
+  padding: var(--spacing-16);
+  text-align: center;
+}
+
+.or-empty p {
+  margin: 0;
+}
+
+.or-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.5);
+  animation: fade 0.2s ease;
+}
+
+.or-modal-card {
+  width: min(440px, 92vw);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-8);
+  padding: var(--spacing-16);
+  border-radius: var(--radius-xl);
+  background: var(--surface-card);
+  border: 1px solid var(--line-strong);
+  box-shadow: var(--shadow-xl);
+}
+
+.or-modal-head h3 {
+  margin: 0 0 var(--spacing-8);
+}
+
+.or-modal-foot {
   margin-top: var(--spacing-12);
   justify-content: flex-end;
 }

--- a/ui/test/api.test.js
+++ b/ui/test/api.test.js
@@ -65,6 +65,20 @@ describe("api endpoints", () => {
     });
   });
 
+  it("castOnlineRadio carries url plus optional name/logo", async () => {
+    await api.castOnlineRadio("https://stream");
+    expect(lastCall()).toMatchObject({
+      path: "/api/source/online_radio/cast",
+      body: { url: "https://stream" },
+    });
+
+    await api.castOnlineRadio("https://stream", { name: "Jazz FM", logo: "http://logo" });
+    expect(lastCall()).toMatchObject({
+      path: "/api/source/online_radio/cast",
+      body: { url: "https://stream", name: "Jazz FM", logo: "http://logo" },
+    });
+  });
+
   it("putExternalAudio PUTs config payload", async () => {
     await api.putExternalAudio({ enabled: true, endpoint_id: "dev", media_session_id: "sess" });
     expect(lastCall()).toMatchObject({

--- a/ui/test/budget.test.js
+++ b/ui/test/budget.test.js
@@ -13,11 +13,11 @@ function walk(dir) {
 }
 
 describe("performance budget", () => {
-  it("ships JS + CSS under 80 KB (fonts excluded)", () => {
+  it("ships JS + CSS under 110 KB (fonts excluded)", () => {
     const total = walk(distDir)
       .filter(f => /\.(js|css)$/.test(f))
       .reduce((sum, f) => sum + statSync(f).size, 0);
-    expect(total).toBeLessThan(80 * 1024);
+    expect(total).toBeLessThan(110 * 1024);
   });
 
   it("keeps the entry HTML under 8 KB", () => {

--- a/ui/test/render/onlineRadio.test.js
+++ b/ui/test/render/onlineRadio.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createOnlineRadio } from "../../dist/js/render/onlineRadio.js";
+
+const json = body => ({ ok: true, json: async () => body });
+
+beforeEach(() => {
+  document.body.innerHTML = "<main></main>";
+  localStorage.clear();
+  global.fetch = vi.fn(() => Promise.resolve(json({})));
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+const ctx = (active, stations = []) => ({
+  getState: () => ({
+    sources: { active, available: [{ name: "online_radio", playback_state: "stopped" }] },
+  }),
+  getConfig: () => ({ online_radio: { stations } }),
+  onSaved: async () => {},
+});
+
+describe("createOnlineRadio", () => {
+  it("stays hidden until online_radio is the active source", () => {
+    const or = createOnlineRadio(document.querySelector("main"), ctx("spotify"));
+    or.render();
+    expect(document.getElementById("online-radio-card").hidden).toBe(true);
+  });
+
+  it("shows the card and renders saved stations when on air", () => {
+    const or = createOnlineRadio(
+      document.querySelector("main"),
+      ctx("online_radio", [{ name: "Jazz FM", url: "http://jazz.example/stream" }]),
+    );
+    or.render();
+    expect(document.getElementById("online-radio-card").hidden).toBe(false);
+    const names = [...document.querySelectorAll(".or-name")].map(n => n.textContent);
+    expect(names).toContain("Jazz FM");
+  });
+
+  it("shows the empty state with no saved stations", () => {
+    const or = createOnlineRadio(document.querySelector("main"), ctx("online_radio", []));
+    or.render();
+    expect(document.querySelector(".or-empty")).not.toBeNull();
+  });
+
+  it("offers My Stations and Discover tabs", () => {
+    const or = createOnlineRadio(document.querySelector("main"), ctx("online_radio", []));
+    or.render();
+    const tabs = [...document.querySelectorAll(".or-tab")].map(t => t.textContent);
+    expect(tabs).toEqual(["My Stations", "Discover"]);
+  });
+});


### PR DESCRIPTION
- ui: move the inline card from main.js into a dedicated render/onlineRadio.js module; rich station cards (logo, genre/co add/edit modal (replacing prompt/confirm), favourites, reordering, an accent-insensitive filter, and a recently-played row
- ui: add radioBrowser.js, a browser-side radio-browser.info client (CORS, no key) powering a Discover tab to search thousands of stations
- config: extend RadioStation with favicon/tags/country/codec/bitrate/uuid/ favorite, persisted in TOML and round-tripped through GET/PUT /api/config
- online_radio: set_target carries name + logo so current_track reports station artwork and a name fallback; surface ICY song history in /api/state details and render it as a track-history list
- config: default to online_radio (enabled bs fallback) and turn the default-station setting into a name dropdown
- ui: fix page-wide horizontal scroll from l (grid-item min-width:0, now-title wrapping)
- test: cover the new module and cast payload; bump JS+CSS budget 80KB -> 110KB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Online radio is now the default playback source
  * Station metadata now includes logos, tags, country, codec, and bitrate information
  * Added recently played song history for online radio streams

* **Documentation**
  * Updated README and configuration to reflect online radio as the default source

* **Tests**
  * Added test coverage for online radio API functionality and UI components
  * Updated performance budget thresholds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->