### PR TITLE
feat(koel): add Koel/Subsonic API audio source

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ add_library(version SHARED
     src/sources/local_file_source.cpp
     src/sources/youtube_music_source.cpp
     src/sources/jellyfin_source.cpp
+    src/sources/koel_source.cpp
     src/sources/external_audio_source.cpp
     src/sources/external_media_session.cpp
     src/sources/spotify_source.cpp

--- a/config.example.toml
+++ b/config.example.toml
@@ -8,7 +8,7 @@
 [general]
 port              = 8420
 ring_buffer_mb    = 4
-default_source    = "online_radio"    # local_files | online_radio | youtube_music | jellyfin | external_audio | spotify
+default_source    = "online_radio"    # local_files | online_radio | youtube_music | jellyfin | koel | external_audio | spotify
 fallback_source   = "local_files"
 ffmpeg_path       = ''                # blank = auto-download to fh6-radio/bin (else `ffmpeg` on PATH); shared by all sources
 
@@ -45,6 +45,15 @@ default_playlist   = ''                # jellyfin playlist ID goes here
 use_favorites      = false             # set to true to play your favorites instead of a playlist
 shuffle            = true              # true or false
 
+[koel]
+enabled            = false
+server_url         = ''                # e.g. 'https://koel.example.com'
+username           = 'email@example.com' # Subsonic username (your Koel email address)
+password           = ''                # Subsonic password or Koel API key (found in Profile & Preferences > Subsonic)
+source_type        = 'favorites'       # chosen from the main menu
+source_id          = ''                # chosen from the main menu
+shuffle            = true
+random_count       = 25
 
 [external_audio]
 # Off by default. Enable from the dashboard Settings drawer before using External Audio.

--- a/config.example.toml
+++ b/config.example.toml
@@ -48,8 +48,8 @@ shuffle            = true              # true or false
 [koel]
 enabled            = false
 server_url         = ''                # e.g. 'https://koel.example.com'
-username           = 'email@example.com' # Subsonic username (your Koel email address)
-password           = ''                # Subsonic password or Koel API key (found in Profile & Preferences > Subsonic)
+username           = 'email@example.com' # your Koel email address
+password           = ''                # Koel Subsonic API key (found in Profile & Preferences > Subsonic)
 source_type        = 'favorites'       # chosen from the main menu
 source_id          = ''                # chosen from the main menu
 shuffle            = true

--- a/config.example.toml
+++ b/config.example.toml
@@ -48,8 +48,8 @@ shuffle            = true              # true or false
 [koel]
 enabled            = false
 server_url         = ''                # e.g. 'https://koel.example.com'
-username           = 'email@example.com' # your Koel email address
-password           = ''                # Koel Subsonic API key (found in Profile & Preferences > Subsonic)
+username           = 'email@example.com' # your Koel email or Subsonic username
+password           = ''                # Koel Subsonic API key (Profile & Preferences > Subsonic) or Subsonic API key
 source_type        = 'favorites'       # chosen from the main menu
 source_id          = ''                # chosen from the main menu
 shuffle            = true

--- a/include/fh6/config.hpp
+++ b/include/fh6/config.hpp
@@ -100,6 +100,17 @@ struct ExternalAudioConfig {
     std::string media_session_id;
 };
 
+struct KoelConfig {
+    bool enabled = false;
+    std::string server_url;    // e.g. 'http://192.168.1.100:8080'
+    std::string username;      // Subsonic username (default: "subsonic")
+    std::string password;      // Subsonic password or API key
+    std::string source_type;   // "favorites" | "playlist" | "album" | "artist" | "random"
+    std::string source_id;     // ID for playlist/album/artist
+    bool shuffle   = true;
+    int random_count = 25;
+};
+
 struct SpotifyConfig {
     bool enabled = false;
     std::filesystem::path librespot_path; // empty = look up on PATH
@@ -112,6 +123,7 @@ struct Config {
     YouTubeMusicConfig youtube_music;
     AudioConfig audio;
     JellyfinConfig jellyfin;
+    KoelConfig koel;
     ExternalAudioConfig external_audio;
     SpotifyConfig spotify;
     OnlineRadioConfig online_radio;

--- a/include/fh6/sources/koel_source.hpp
+++ b/include/fh6/sources/koel_source.hpp
@@ -1,0 +1,111 @@
+#pragma once
+
+#include "fh6/audio_source.hpp"
+#include "fh6/config.hpp"
+#include "fh6/playback_dsp.hpp"
+#include "fh6/ring_buffer.hpp"
+#include "fh6/worker/worker_client.hpp"
+
+#include <atomic>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace fh6::sources {
+
+struct KoelTrack {
+    std::string id;
+    std::string parent;    // album ID (for cover art)
+    std::string title;
+    std::string artist;
+    std::string album;
+    std::string image_url; // Full URL or path to cover art
+    std::uint64_t duration_ms = 0;
+};
+
+// Resolves a Koel playlist/album/favorites over Subsonic API HTTP, then streams
+// each item through ffmpeg. The PCM pipe is drained by pump() in non-blocking
+// mode (PeekNamedPipe-gated) so a stalled HTTP stream can never freeze the
+// AudioSourceManager pump loop.
+class KoelSource final : public IAudioSource {
+public:
+    KoelSource(KoelConfig cfg, std::filesystem::path ffmpeg_path,
+               worker::WorkerClient* worker = nullptr);
+    ~KoelSource() override;
+
+    std::string_view name() const noexcept override { return "koel"; }
+    std::string_view display_name() const noexcept override { return "Koel"; }
+
+    bool initialize() override;
+    void shutdown() noexcept override;
+
+    void play() override;
+    void pause() override;
+    void stop() override;
+    void next() override;
+    void previous() override;
+    void pump(RingBuffer& ring) override;
+
+    // Settings drawer hot-update; re-fetches when auth/url/source fields
+    // change, re-shuffles in place when only `shuffle` flips.
+    void set_config(KoelConfig cfg);
+    void set_ffmpeg_path(std::filesystem::path p);
+
+    void set_playback_options(const PlaybackConfig& opts) override;
+
+    // POST /api/source/koel/cast: swap to a different source type/id.
+    // Returns empty string on success, error message on failure.
+    std::string cast(std::string source_type, std::string source_id);
+
+    std::string source_type() const;
+    std::string auth_error() const;
+    std::size_t track_count() const;
+
+    TrackInfo current_track() const override;
+    PlaybackState playback_state() const noexcept override {
+        return state_.load(std::memory_order_acquire);
+    }
+    AuthState auth_state() const noexcept override;
+    SourceCapabilities capabilities() const noexcept override { return {false, true, true}; }
+
+    std::string auth_instructions() const override {
+        return "Enter your Koel server URL, your Koel email as username, and your Subsonic API "
+               "key as password. Then select a source (favorites, playlist, album, or artist). "
+               "The API key can be found in Koel settings under 'Profile & Preferences' > 'Subsonic'.";
+    }
+
+private:
+    struct Pipe;
+
+    // mu_ held.
+    std::unique_ptr<Pipe> spawn_pipe_locked(std::size_t for_idx);
+    void start_pipe_locked();
+    void stop_pipe_locked();
+    void discard_prefetch_locked() noexcept;
+    bool promote_prefetch_locked(std::size_t expected_idx);
+    void maybe_spawn_prefetch_locked();
+    std::size_t next_queue_idx_locked() const noexcept;
+    void advance_locked(std::ptrdiff_t step);
+
+    KoelConfig cfg_;
+    std::filesystem::path ffmpeg_path_;
+    worker::WorkerClient* worker_;
+
+    mutable std::mutex mu_;
+    std::vector<KoelTrack> queue_;
+    std::size_t current_idx_ = 0;
+    std::unique_ptr<Pipe> pipe_;
+    std::unique_ptr<Pipe> prefetch_;
+    std::atomic<PlaybackState> state_{PlaybackState::stopped};
+
+    EqualizerStage eq_;
+    std::atomic<bool> volume_norm_{false};
+    std::atomic<bool> prebuffer_next_{true};
+    std::atomic<AuthState> auth_state_{AuthState::needs_auth};
+    std::string auth_error_;
+};
+
+} // namespace fh6::sources

--- a/include/fh6/sources/koel_source.hpp
+++ b/include/fh6/sources/koel_source.hpp
@@ -106,6 +106,9 @@ private:
     std::atomic<bool> prebuffer_next_{true};
     std::atomic<AuthState> auth_state_{AuthState::needs_auth};
     std::string auth_error_;
+    // Cache artwork URL per track so auth params don't change on every poll.
+    mutable std::size_t cached_artwork_idx_ = SIZE_MAX;
+    mutable std::string cached_artwork_url_;
 };
 
 } // namespace fh6::sources

--- a/include/fh6/sources/koel_source.hpp
+++ b/include/fh6/sources/koel_source.hpp
@@ -73,7 +73,7 @@ public:
 
     std::string auth_instructions() const override {
         return "Enter your Koel server URL, your Koel email as username, and your Subsonic API "
-               "key as password. Then select a source (favorites, playlist, album, or artist). "
+               "key as password. Then select a source (favorites, playlist, album, artist, or random). "
                "The API key can be found in Koel settings under 'Profile & Preferences' > 'Subsonic'.";
     }
 

--- a/include/fh6/sources/koel_source.hpp
+++ b/include/fh6/sources/koel_source.hpp
@@ -37,7 +37,7 @@ public:
     ~KoelSource() override;
 
     std::string_view name() const noexcept override { return "koel"; }
-    std::string_view display_name() const noexcept override { return "Koel"; }
+    std::string_view display_name() const noexcept override { return "Koel / Subsonic"; }
 
     bool initialize() override;
     void shutdown() noexcept override;
@@ -72,9 +72,8 @@ public:
     SourceCapabilities capabilities() const noexcept override { return {false, true, true}; }
 
     std::string auth_instructions() const override {
-        return "Enter your Koel server URL, your Koel email as username, and your Subsonic API "
-               "key as password. Then select a source (favorites, playlist, album, artist, or random). "
-               "The API key can be found in Koel settings under 'Profile & Preferences' > 'Subsonic'.";
+        return "Enter your Koel or Subsonic-compatible server URL, your email or username, and your Subsonic API "
+               "key as password. For Koel, the API key can be found in settings under 'Profile & Preferences' > 'Subsonic'.";
     }
 
 private:

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -14,6 +14,7 @@
 #include "fh6/sources/external_audio_source.hpp"
 #include "fh6/sources/youtube_music_source.hpp"
 #include "fh6/sources/jellyfin_source.hpp"
+#include "fh6/sources/koel_source.hpp"
 #include "fh6/sources/spotify_source.hpp"
 #include "fh6/worker/worker_client.hpp"
 #include "fh6/sources/online_radio_source.hpp"
@@ -186,10 +187,16 @@ void run_bridge(HMODULE self) noexcept {
         }
         if (c.jellyfin.enabled && !mgr.find("jellyfin")) {
             auto src = std::make_unique<sources::JellyfinSource>(c.jellyfin, c.general.ffmpeg_path,
-                                                                  &worker);
+                                                                   &worker);
             if (src->initialize()) mgr.register_source(std::move(src));
         } else if (!c.jellyfin.enabled && mgr.find("jellyfin")) {
             mgr.unregister_source("jellyfin");
+        }
+        if (c.koel.enabled && !mgr.find("koel")) {
+            auto src = std::make_unique<sources::KoelSource>(c.koel, c.general.ffmpeg_path, &worker);
+            if (src->initialize()) mgr.register_source(std::move(src));
+        } else if (!c.koel.enabled && mgr.find("koel")) {
+            mgr.unregister_source("koel");
         }
         if (c.online_radio.enabled && !mgr.find("online_radio")) {
             auto src = std::make_unique<sources::OnlineRadioSource>(c.online_radio,
@@ -282,6 +289,10 @@ void run_bridge(HMODULE self) noexcept {
         if (auto* jf = dynamic_cast<sources::JellyfinSource*>(mgr.find("jellyfin"))) {
             jf->set_ffmpeg_path(c.general.ffmpeg_path);
             jf->set_config(c.jellyfin);
+        }
+        if (auto* kl = dynamic_cast<sources::KoelSource*>(mgr.find("koel"))) {
+            kl->set_ffmpeg_path(c.general.ffmpeg_path);
+            kl->set_config(c.koel);
         }
         if (auto* ext = dynamic_cast<sources::ExternalAudioSource*>(mgr.find("external_audio"))) {
             ext->set_config(c.external_audio);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -135,6 +135,16 @@ Config load_config(const std::filesystem::path& path) {
     cfg.jellyfin.use_favorites = pick<bool>(jf, "use_favorites", cfg.jellyfin.use_favorites);
     cfg.jellyfin.shuffle       = pick<bool>(jf, "shuffle", cfg.jellyfin.shuffle);
 
+    const auto& kl              = section(root, "koel");
+    cfg.koel.enabled           = pick<bool>(kl, "enabled", cfg.koel.enabled);
+    cfg.koel.server_url        = pick<std::string>(kl, "server_url", cfg.koel.server_url);
+    cfg.koel.username          = pick<std::string>(kl, "username", cfg.koel.username);
+    cfg.koel.password          = pick<std::string>(kl, "password", cfg.koel.password);
+    cfg.koel.source_type       = pick<std::string>(kl, "source_type", cfg.koel.source_type);
+    cfg.koel.source_id         = pick<std::string>(kl, "source_id", cfg.koel.source_id);
+    cfg.koel.shuffle           = pick<bool>(kl, "shuffle", cfg.koel.shuffle);
+    cfg.koel.random_count      = pick<int>(kl, "random_count", cfg.koel.random_count);
+
     const auto& or_sec       = section(root, "online_radio");
     cfg.online_radio.enabled = pick<bool>(or_sec, "enabled", cfg.online_radio.enabled);
     const int station_index =
@@ -340,6 +350,16 @@ void save_config(const std::filesystem::path& path, const Config& cfg) {
     e.kv("default_playlist", cfg.jellyfin.default_playlist);
     e.kv("use_favorites", cfg.jellyfin.use_favorites);
     e.kv("shuffle", cfg.jellyfin.shuffle);
+
+    e.header("koel");
+    e.kv("enabled", cfg.koel.enabled);
+    e.kv("server_url", cfg.koel.server_url);
+    e.kv("username", cfg.koel.username);
+    e.kv("password", cfg.koel.password);
+    e.kv("source_type", cfg.koel.source_type);
+    e.kv("source_id", cfg.koel.source_id);
+    e.kv("shuffle", cfg.koel.shuffle);
+    e.kv("random_count", (int64_t)cfg.koel.random_count);
 
     e.header("external_audio");
     e.kv("enabled", cfg.external_audio.enabled);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -3,6 +3,7 @@
 
 #include <toml.hpp>
 
+#include <algorithm>
 #include <fstream>
 #include <span>
 #include <system_error>
@@ -143,7 +144,7 @@ Config load_config(const std::filesystem::path& path) {
     cfg.koel.source_type       = pick<std::string>(kl, "source_type", cfg.koel.source_type);
     cfg.koel.source_id         = pick<std::string>(kl, "source_id", cfg.koel.source_id);
     cfg.koel.shuffle           = pick<bool>(kl, "shuffle", cfg.koel.shuffle);
-    cfg.koel.random_count      = pick<int>(kl, "random_count", cfg.koel.random_count);
+    cfg.koel.random_count      = (std::max)(pick<int>(kl, "random_count", cfg.koel.random_count), 1);
 
     const auto& or_sec       = section(root, "online_radio");
     cfg.online_radio.enabled = pick<bool>(or_sec, "enabled", cfg.online_radio.enabled);

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -4,9 +4,11 @@
 #include "fh6/deps.hpp"
 #include "fh6/fmod/dsp_bridge.hpp"
 #include "fh6/log.hpp"
+#include "fh6/net/http_get.hpp"
 #include "fh6/sources/local_file_source.hpp"
 #include "fh6/sources/youtube_music_source.hpp"
 #include "fh6/sources/jellyfin_source.hpp"
+#include "fh6/sources/koel_source.hpp"
 #include "fh6/sources/external_audio_source.hpp"
 #include "fh6/sources/external_media_session.hpp"
 #include "fh6/sources/spotify_source.hpp"
@@ -33,6 +35,18 @@ namespace fh6::http {
 using json = nlohmann::json;
 
 namespace {
+
+std::string url_encode(const std::string& s) {
+    std::string out;
+    out.reserve(s.size());
+    for (unsigned char c : s) {
+        if (std::isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~')
+            out += static_cast<char>(c);
+        else
+            out += std::format("%{:02X}", c);
+    }
+    return out;
+}
 
 constexpr const char* state_string(PlaybackState s) noexcept {
     switch (s) {
@@ -110,6 +124,12 @@ json source_to_json(IAudioSource* s) {
         j["details"]["shuffle"] = yt->shuffle();
     if (auto* rd = dynamic_cast<sources::OnlineRadioSource*>(s))
         j["details"]["song_history"] = rd->song_history();
+    if (auto* kl = dynamic_cast<sources::KoelSource*>(s)) {
+        j["details"]["source_type"] = kl->source_type();
+        j["details"]["track_count"] = kl->track_count();
+        if (kl->auth_state() == AuthState::error)
+            j["details"]["auth_error"] = kl->auth_error();
+    }
     return j;
 }
 
@@ -171,6 +191,17 @@ json config_to_json(const Config& c) {
              {"default_playlist", c.jellyfin.default_playlist},
              {"use_favorites", c.jellyfin.use_favorites},
              {"shuffle", c.jellyfin.shuffle},
+         }},
+        {"koel",
+         json{
+             {"enabled", c.koel.enabled},
+             {"server_url", c.koel.server_url},
+             {"username", c.koel.username},
+             {"password", c.koel.password},
+             {"source_type", c.koel.source_type},
+             {"source_id", c.koel.source_id},
+             {"shuffle", c.koel.shuffle},
+             {"random_count", c.koel.random_count},
          }},
         {"external_audio",
          json{
@@ -296,6 +327,16 @@ void apply_patch(Config& c, const json& j) {
         c.jellyfin.default_playlist = pull(*it, "default_playlist", c.jellyfin.default_playlist);
         c.jellyfin.use_favorites    = pull(*it, "use_favorites", c.jellyfin.use_favorites);
         c.jellyfin.shuffle          = pull(*it, "shuffle", c.jellyfin.shuffle);
+    }
+    if (auto it = j.find("koel"); it != j.end()) {
+        c.koel.enabled      = pull(*it, "enabled", c.koel.enabled);
+        c.koel.server_url   = pull(*it, "server_url", c.koel.server_url);
+        c.koel.username     = pull(*it, "username", c.koel.username);
+        c.koel.password     = pull(*it, "password", c.koel.password);
+        c.koel.source_type  = pull(*it, "source_type", c.koel.source_type);
+        c.koel.source_id    = pull(*it, "source_id", c.koel.source_id);
+        c.koel.shuffle      = pull(*it, "shuffle", c.koel.shuffle);
+        c.koel.random_count = pull(*it, "random_count", c.koel.random_count);
     }
     if (auto it = j.find("external_audio"); it != j.end()) {
         c.external_audio.enabled     = pull(*it, "enabled", c.external_audio.enabled);
@@ -624,6 +665,7 @@ struct HttpServer::Impl {
 
         if (m == "OPTIONS") return send_response(client, 200, "", "text/plain");
 
+        if (m == "GET" && p == "/favicon.ico") return send_response(client, 200, "", "image/x-icon");
         if (m == "GET" && p == "/api/state") return ok(build_state());
         if (m == "GET" && p == "/api/events") return send_event_snapshot(client);
         if (m == "GET" && p == "/api/sources") return ok(build_sources());
@@ -825,6 +867,74 @@ struct HttpServer::Impl {
             if (was_active) mgr.ring().drain();
             mgr.switch_to("jellyfin");
             return ok();
+        }
+        if (m == "POST" && p == "/api/source/koel/cast") {
+            auto* kl = find_typed<sources::KoelSource>("koel");
+            if (!kl) return fail(404, "Koel not registered – enable it in Settings first");
+            auto j = json::parse(req.body);
+            auto source_type = j.value("source_type", std::string{});
+            auto source_id   = j.value("source_id", std::string{});
+            if (source_type.empty()) return fail(400, "source_type required");
+            const bool was_active = (mgr.active() == kl);
+            auto err = kl->cast(source_type, source_id);
+            if (!err.empty()) return fail(502, err);
+            if (was_active) mgr.ring().drain();
+            mgr.switch_to("koel");
+            return ok();
+        }
+        if (m == "GET" && p.starts_with("/api/source/koel/browse/")) {
+            auto snap = store.snapshot();
+            auto& k   = snap.koel;
+            if (!k.enabled || k.server_url.empty())
+                return fail(400, "Koel not configured");
+            auto auth = std::format("u={}&p={}&v=1.16.1&c=fh6-radio",
+                                     url_encode(k.username), url_encode(k.password));
+            auto su = k.server_url;
+            if (su.ends_with('/')) su.resize(su.size() - 1);
+            auto sub = std::string_view(p).substr(std::string_view("/api/source/koel/browse/").size());
+            std::string method, extra;
+            if (sub == "playlists") { method = "getPlaylists"; }
+            else if (sub == "albums") { method = "getAlbumList2"; extra = "type=newest&size=50"; }
+            else if (sub == "artists") { method = "getArtists"; }
+            else return fail(404, "unknown browse type");
+            auto url = std::format("{}/rest/{}.view?f=json&{}", su, method, auth);
+            if (!extra.empty()) url += "&" + extra;
+            auto body = net::http_get(url);
+            if (!body) return fail(502, "cannot reach Koel server");
+            try {
+                auto root = json::parse(*body);
+                auto resp = root.find("subsonic-response");
+                if (resp == root.end()) return fail(502, "unexpected response");
+                if (resp->value("status", "") != "ok")
+                    return fail(502, resp->value("error", json::object()).value("message", "API error"));
+                json out = json::array();
+                if (sub == "playlists") {
+                    auto lists = resp->find("playlists");
+                    if (lists != resp->end() && lists->is_object()) {
+                        auto& arr = (*lists)["playlist"];
+                        if (arr.is_array()) for (auto& e : arr)
+                            out.push_back({{"id", e.value("id", "")}, {"name", e.value("name", "")}});
+                    }
+                } else if (sub == "albums") {
+                    auto lists = resp->find("albumList2");
+                    if (lists != resp->end() && lists->is_object()) {
+                        auto& arr = (*lists)["album"];
+                        if (arr.is_array()) for (auto& e : arr)
+                            out.push_back({{"id", e.value("id", "")}, {"name", e.value("name", "")}});
+                    }
+                } else if (sub == "artists") {
+                    auto idx = resp->find("artists");
+                    if (idx != resp->end() && idx->is_object()) {
+                        auto& arr = (*idx)["index"];
+                        if (arr.is_array()) for (auto& ix : arr)
+                            for (auto& a : ix["artist"])
+                                out.push_back({{"id", a.value("id", "")}, {"name", a.value("name", "")}});
+                    }
+                }
+                return ok(json{{"items", std::move(out)}});
+            } catch (const std::exception& e) {
+                return fail(502, std::string("parse error: ") + e.what());
+            }
         }
         if (m == "POST" && p == "/api/source/online_radio/cast") {
             auto* rd = find_typed<sources::OnlineRadioSource>("online_radio");

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -926,9 +926,12 @@ struct HttpServer::Impl {
                     auto idx = resp->find("artists");
                     if (idx != resp->end() && idx->is_object()) {
                         auto& arr = (*idx)["index"];
-                        if (arr.is_array()) for (auto& ix : arr)
-                            for (auto& a : ix["artist"])
-                                out.push_back({{"id", a.value("id", "")}, {"name", a.value("name", "")}});
+                        if (arr.is_array()) for (auto& ix : arr) {
+                            auto art = ix.find("artist");
+                            if (art != ix.end() && art->is_array())
+                                for (auto& a : *art)
+                                    out.push_back({{"id", a.value("id", "")}, {"name", a.value("name", "")}});
+                        }
                     }
                 }
                 return ok(json{{"items", std::move(out)}});

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -886,58 +886,138 @@ struct HttpServer::Impl {
             auto snap = store.snapshot();
             auto& k   = snap.koel;
             if (!k.enabled || k.server_url.empty())
-                return fail(400, "Koel not configured");
+                return fail(400, "Subsonic source not configured");
             auto auth = std::format("u={}&p={}&v=1.16.1&c=fh6-radio",
                                      url_encode(k.username), url_encode(k.password));
             auto su = k.server_url;
             if (su.ends_with('/')) su.resize(su.size() - 1);
             auto sub = std::string_view(p).substr(std::string_view("/api/source/koel/browse/").size());
-            std::string method, extra;
-            if (sub == "playlists") { method = "getPlaylists"; }
-            else if (sub == "albums") { method = "getAlbumList2"; extra = "type=newest&size=50"; }
-            else if (sub == "artists") { method = "getArtists"; }
-            else return fail(404, "unknown browse type");
-            auto url = std::format("{}/rest/{}.view?f=json&{}", su, method, auth);
-            if (!extra.empty()) url += "&" + extra;
-            auto body = net::http_get(url);
-            if (!body) return fail(502, "cannot reach Koel server");
-            try {
-                auto root = json::parse(*body);
-                auto resp = root.find("subsonic-response");
-                if (resp == root.end()) return fail(502, "unexpected response");
-                if (resp->value("status", "") != "ok")
-                    return fail(502, resp->value("error", json::object()).value("message", "API error"));
-                json out = json::array();
-                if (sub == "playlists") {
-                    auto lists = resp->find("playlists");
-                    if (lists != resp->end() && lists->is_object()) {
-                        auto& arr = (*lists)["playlist"];
-                        if (arr.is_array()) for (auto& e : arr)
-                            out.push_back({{"id", e.value("id", "")}, {"name", e.value("name", "")}});
+
+            std::string type_str, q_str;
+            auto qpos = sub.find('?');
+            if (qpos != std::string_view::npos) {
+                type_str = std::string(sub.substr(0, qpos));
+                q_str    = std::string(sub.substr(qpos + 1));
+            } else {
+                type_str = std::string(sub);
+            }
+
+            std::string search_q;
+            if (!q_str.empty()) {
+                auto url_decode = [](std::string_view s) {
+                    std::string out;
+                    out.reserve(s.size());
+                    for (size_t i = 0; i < s.size(); ++i) {
+                        if (s[i] == '%' && i + 2 < s.size()) {
+                            unsigned int c = 0;
+                            if (std::sscanf(s.data() + i + 1, "%2x", &c) == 1) {
+                                out += static_cast<char>(c);
+                                i += 2;
+                                continue;
+                            }
+                        }
+                        out += s[i] == '+' ? ' ' : s[i];
                     }
-                } else if (sub == "albums") {
-                    auto lists = resp->find("albumList2");
-                    if (lists != resp->end() && lists->is_object()) {
-                        auto& arr = (*lists)["album"];
-                        if (arr.is_array()) for (auto& e : arr)
-                            out.push_back({{"id", e.value("id", "")}, {"name", e.value("name", "")}});
+                    return out;
+                };
+                size_t pos = 0;
+                while (pos < q_str.size()) {
+                    auto amp = q_str.find('&', pos);
+                    auto eq  = q_str.find('=', pos);
+                    if (eq != std::string::npos && eq < amp) {
+                        auto key = std::string_view(q_str).substr(pos, eq - pos);
+                        auto v_start = eq + 1;
+                        auto v_end   = (std::min)(amp, q_str.size());
+                        if (key == "q")
+                            search_q = url_decode(std::string_view(q_str).substr(v_start, v_end - v_start));
                     }
-                } else if (sub == "artists") {
-                    auto idx = resp->find("artists");
-                    if (idx != resp->end() && idx->is_object()) {
-                        auto& arr = (*idx)["index"];
-                        if (arr.is_array()) for (auto& ix : arr) {
-                            auto art = ix.find("artist");
-                            if (art != ix.end() && art->is_array())
-                                for (auto& a : *art)
-                                    out.push_back({{"id", a.value("id", "")}, {"name", a.value("name", "")}});
+                    if (amp == std::string::npos) break;
+                    pos = amp + 1;
+                }
+            }
+
+            auto fetch_items = [&](std::string method, std::string extra) {
+                struct R { json items; std::string error; bool ok = false; };
+                try {
+                    auto url = std::format("{}/rest/{}.view?f=json&{}", su, method, auth);
+                    if (!extra.empty()) url += "&" + extra;
+                    auto body = net::http_get(url);
+                    if (!body) return R{{}, "cannot reach Subsonic server", false};
+                    auto root = json::parse(*body);
+                    auto resp = root.find("subsonic-response");
+                    if (resp == root.end()) return R{{}, "unexpected response", false};
+                    if (resp->value("status", "") != "ok")
+                        return R{{}, resp->value("error", json::object()).value("message", "API error"), false};
+                    json out = json::array();
+                    if (type_str == "playlists") {
+                        auto lists = resp->find("playlists");
+                        if (lists != resp->end() && lists->is_object()) {
+                            auto& arr = (*lists)["playlist"];
+                            if (arr.is_array()) for (auto& e : arr)
+                                out.push_back({{"id", e.value("id", "")}, {"name", e.value("name", "")}});
+                        }
+                    } else if (type_str == "albums") {
+                        auto& arr_key = (method == "search3") ? (*resp)["searchResult3"]["album"] : (*resp)["albumList2"]["album"];
+                        if (arr_key.is_array()) for (auto& e : arr_key)
+                            out.push_back({{"id", e.value("id", "")}, {"name", e.value("name", "")}});
+                    } else if (type_str == "artists") {
+                        if (method == "search3") {
+                            auto& arr_key = (*resp)["searchResult3"]["artist"];
+                            if (arr_key.is_array()) for (auto& e : arr_key)
+                                out.push_back({{"id", e.value("id", "")}, {"name", e.value("name", "")}});
+                        } else {
+                            auto idx = resp->find("artists");
+                            if (idx != resp->end() && idx->is_object()) {
+                                auto& arr = (*idx)["index"];
+                                if (arr.is_array()) for (auto& ix : arr) {
+                                    auto art = ix.find("artist");
+                                    if (art != ix.end() && art->is_array())
+                                        for (auto& a : *art)
+                                            out.push_back({{"id", a.value("id", "")}, {"name", a.value("name", "")}});
+                                }
+                            }
                         }
                     }
+                    return R{std::move(out), "", true};
+                } catch (const std::exception& e) {
+                    return R{{}, std::string("parse error: ") + e.what(), false};
                 }
-                return ok(json{{"items", std::move(out)}});
-            } catch (const std::exception& e) {
-                return fail(502, std::string("parse error: ") + e.what());
+            };
+
+            bool is_search = false;
+            std::string method, extra;
+            if (type_str == "playlists") {
+                method = "getPlaylists";
+            } else if (type_str == "albums") {
+                if (!search_q.empty()) {
+                    is_search = true;
+                    method    = "search3";
+                    extra     = "albumCount=50&query=" + url_encode(search_q);
+                } else {
+                    method = "getAlbumList2";
+                    extra  = "type=newest&size=500";
+                }
+            } else if (type_str == "artists") {
+                if (!search_q.empty()) {
+                    is_search = true;
+                    method    = "search3";
+                    extra     = "artistCount=50&query=" + url_encode(search_q);
+                } else {
+                    method = "getArtists";
+                }
+            } else {
+                return fail(404, "unknown browse type");
             }
+
+            auto r = fetch_items(method, extra);
+            if (is_search && !r.ok) {
+                // search3 not supported by server – fall back to regular browse
+                r = (type_str == "albums")
+                        ? fetch_items("getAlbumList2", "type=newest&size=500")
+                        : fetch_items("getArtists", "");
+            }
+            if (!r.ok) return fail(502, r.error);
+            return ok(json{{"items", std::move(r.items)}});
         }
         if (m == "POST" && p == "/api/source/online_radio/cast") {
             auto* rd = find_typed<sources::OnlineRadioSource>("online_radio");

--- a/src/sources/koel_source.cpp
+++ b/src/sources/koel_source.cpp
@@ -1,0 +1,716 @@
+#include "fh6/sources/koel_source.hpp"
+#include "fh6/log.hpp"
+#include "fh6/net/http_get.hpp"
+#include "fh6/subprocess.hpp"
+
+#include <nlohmann/json.hpp>
+
+#include <windows.h>
+#include <bcrypt.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <format>
+#include <optional>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace fh6::sources {
+
+namespace {
+
+using subprocess::create_kill_on_close_job;
+using subprocess::describe_launch_failure;
+using subprocess::open_nul;
+using subprocess::open_stderr_log;
+using subprocess::quote;
+using subprocess::spawn_in_job;
+using subprocess::widen;
+
+using json = nlohmann::json;
+
+constexpr std::uint64_t kPcmBytesPerSec = 48000ull * 2ull * 2ull;
+
+bool config_complete(const KoelConfig& c) noexcept {
+    return !c.server_url.empty() && !c.password.empty() && !c.source_type.empty();
+}
+
+bool same_query_target(const KoelConfig& a, const KoelConfig& b) noexcept {
+    return a.server_url == b.server_url && a.password == b.password &&
+           a.username == b.username && a.source_type == b.source_type &&
+           a.source_id == b.source_id && a.random_count == b.random_count;
+}
+
+std::string url_encode(const std::string& s) {
+    std::string out;
+    out.reserve(s.size());
+    for (unsigned char c : s) {
+        if (std::isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~')
+            out += static_cast<char>(c);
+        else
+            out += std::format("%{:02X}", c);
+    }
+    return out;
+}
+
+std::string md5_hex(const std::string& input) {
+    BCRYPT_ALG_HANDLE algo = nullptr;
+    if (BCryptOpenAlgorithmProvider(&algo, BCRYPT_MD5_ALGORITHM, nullptr, 0) != 0)
+        return {};
+
+    DWORD hash_obj_len = 0, hash_len = 0, unused = 0;
+    BCryptGetProperty(algo, BCRYPT_OBJECT_LENGTH, (PUCHAR)&hash_obj_len, sizeof(hash_obj_len),
+                      &unused, 0);
+    BCryptGetProperty(algo, BCRYPT_HASH_LENGTH, (PUCHAR)&hash_len, sizeof(hash_len), &unused, 0);
+
+    std::vector<BYTE> hash_obj(hash_obj_len);
+    std::vector<BYTE> hash(hash_len);
+
+    BCRYPT_HASH_HANDLE h = nullptr;
+    BCryptCreateHash(algo, &h, hash_obj.data(), (ULONG)hash_obj.size(), nullptr, 0, 0);
+    BCryptHashData(h, (PUCHAR)input.data(), (ULONG)input.size(), 0);
+    BCryptFinishHash(h, hash.data(), (ULONG)hash.size(), 0);
+    BCryptDestroyHash(h);
+    BCryptCloseAlgorithmProvider(algo, 0);
+
+    std::string out;
+    out.reserve(hash_len * 2);
+    for (BYTE b : hash)
+        out += std::format("{:02x}", b);
+    return out;
+}
+
+std::string auth_query(const KoelConfig& cfg) {
+    const auto& u = cfg.username.empty() ? "subsonic" : cfg.username;
+    return std::format("u={}&p={}&v=1.16.1&c=fh6-radio",
+                       url_encode(u), url_encode(cfg.password));
+}
+
+std::string api_url(const KoelConfig& cfg, const std::string& method,
+                    const std::string& extra_params = {}) {
+    std::string url = cfg.server_url;
+    if (!url.ends_with('/')) url += '/';
+    url += "rest/" + method + ".view?f=json&" + auth_query(cfg);
+    if (!extra_params.empty()) url += "&" + extra_params;
+    return url;
+}
+
+std::string make_stream_url(const KoelConfig& cfg, const std::string& id) {
+    std::string url = cfg.server_url;
+    if (!url.ends_with('/')) url += '/';
+    url += "rest/stream.view?id=" + url_encode(id) + "&" + auth_query(cfg);
+    return url;
+}
+
+KoelTrack parse_song_entry(const json& entry) {
+    KoelTrack t;
+    t.id     = entry.value("id", "");
+    t.parent = entry.value("parent", "");
+    t.title  = entry.value("title", "Unknown Title");
+    t.artist = entry.value("artist", "Unknown Artist");
+    t.album  = entry.value("album", "");
+    t.duration_ms = static_cast<std::uint64_t>(entry.value("duration", 0)) * 1000ull;
+    // coverArt may be the song ID or the parent (album) ID – try parent first for getCoverArt
+    if (auto ca = entry.find("coverArt"); ca != entry.end() && ca->is_string())
+        t.image_url = ca->get<std::string>();
+    return t;
+}
+
+struct FetchResult {
+    std::vector<KoelTrack> tracks;
+    std::string error;
+};
+
+FetchResult fetch_tracks(const KoelConfig& cfg) {
+    std::string method;
+    std::string extra_params;
+    bool expect_songs_key = true; // true => "song" array; false => "entry" array
+
+    if (cfg.source_type == "favorites") {
+        method = "getStarred2";
+        expect_songs_key = true;
+    } else if (cfg.source_type == "random") {
+        method = "getRandomSongs";
+        extra_params = "size=" + std::to_string(cfg.random_count);
+        expect_songs_key = true;
+    } else if (cfg.source_type == "playlist") {
+        if (cfg.source_id.empty()) {
+            log::error("[koel] playlist source requires source_id");
+            return {{}, "playlist source_type requires a source_id"};
+        }
+        method = "getPlaylist";
+        extra_params = "id=" + url_encode(cfg.source_id);
+        expect_songs_key = false;
+    } else if (cfg.source_type == "album") {
+        if (cfg.source_id.empty()) {
+            log::error("[koel] album source requires source_id");
+            return {{}, "album source_type requires a source_id"};
+        }
+        method = "getAlbum";
+        extra_params = "id=" + url_encode(cfg.source_id);
+        expect_songs_key = true;
+    } else if (cfg.source_type == "artist") {
+        if (cfg.source_id.empty()) {
+            log::error("[koel] artist source requires source_id");
+            return {{}, "artist source_type requires a source_id"};
+        }
+        // Multi-step: getArtist -> album list -> getAlbum per album
+        auto artist_url = api_url(cfg, "getArtist", "id=" + url_encode(cfg.source_id));
+        auto artist_body = net::http_get(artist_url);
+        if (!artist_body) {
+            log::error("[koel] HTTP request failed for getArtist");
+            return {{}, "HTTP request to Koel server failed – check the URL"};
+        }
+
+        std::vector<std::string> album_ids;
+        try {
+            auto root = json::parse(*artist_body);
+            auto resp = root.find("subsonic-response");
+            if (resp == root.end() || !resp->is_object()) {
+                log::error("[koel] getArtist response missing subsonic-response");
+                return {{}, "unexpected response from Koel server (missing subsonic-response)"};
+            }
+            if (resp->value("status", "") != "ok") {
+                auto err_obj = resp->value("error", json::object());
+                auto msg = err_obj.value("message", "unknown error");
+                log::error("[koel] getArtist API error: {}", msg);
+                return {{}, "Koel API error: " + msg};
+            }
+            auto art = resp->find("artist");
+            if (art == resp->end() || !art->is_object()) {
+                log::error("[koel] getArtist missing artist object");
+                return {{}, "unexpected response from Koel server (missing artist)"};
+            }
+            auto albums = art->find("album");
+            if (albums != art->end() && albums->is_array()) {
+                for (const auto& alb : *albums) {
+                    auto id = alb.value("id", "");
+                    if (!id.empty()) album_ids.push_back(std::move(id));
+                }
+            }
+        } catch (const std::exception& e) {
+            log::error("[koel] getArtist JSON parse error: {}", e.what());
+            return {{}, "failed to parse Koel server response: " + std::string(e.what())};
+        }
+
+        if (album_ids.empty()) {
+            log::warn("[koel] artist has no albums");
+            return {{}, {}};
+        }
+
+        std::vector<KoelTrack> out;
+        for (const auto& aid : album_ids) {
+            auto album_url = api_url(cfg, "getAlbum", "id=" + url_encode(aid));
+            auto album_body = net::http_get(album_url);
+            if (!album_body) continue;
+
+            try {
+                auto root  = json::parse(*album_body);
+                auto resp  = root.find("subsonic-response");
+                if (resp == root.end() || !resp->is_object()) continue;
+                auto album = resp->find("album");
+                if (album == resp->end() || !album->is_object()) continue;
+                auto songs = album->find("song");
+                if (songs == album->end() || !songs->is_array()) continue;
+                for (const auto& song : *songs) {
+                    auto t = parse_song_entry(song);
+                    if (!t.id.empty()) out.push_back(std::move(t));
+                }
+            } catch (...) {}
+        }
+
+        log::info("[koel] fetched {} track(s) for artist", out.size());
+        return {std::move(out), {}};
+    } else {
+        log::error("[koel] unknown source_type '{}'", cfg.source_type);
+        return {{}, "unknown source type '" + cfg.source_type + "'"};
+    }
+
+    auto url  = api_url(cfg, method, extra_params);
+    log::info("[koel] fetching {} (method={})", cfg.server_url + "/rest/" + method + ".view", method);
+    auto body = net::http_get(url, "Accept: application/json");
+    if (!body) {
+        log::error("[koel] HTTP request failed for {}", method);
+        log::error("[koel] constructed URL was: {}.view?f=json&u={}&t=...&s=...&v=1.16.1&c=fh6-radio{}",
+                   cfg.server_url + "/rest/" + method, url_encode(cfg.username.empty() ? "subsonic" : cfg.username),
+                   extra_params.empty() ? "" : "&" + extra_params);
+        return {{}, "cannot reach Koel server – check the URL and that the server is running"};
+    }
+
+    std::vector<KoelTrack> out;
+    try {
+        auto root = json::parse(*body);
+        auto resp = root.find("subsonic-response");
+        if (resp == root.end() || !resp->is_object()) {
+            log::error("[koel] response missing subsonic-response");
+            return {{}, "unexpected response from Koel server (not a valid Subsonic API response)"};
+        }
+        if (resp->value("status", "") != "ok") {
+            auto err_obj = resp->value("error", json::object());
+            auto msg = err_obj.value("message", "unknown error");
+            log::error("[koel] API error: {} - {}",
+                       err_obj.value("code", 0), msg);
+            return {{}, "Koel API error: " + msg};
+        }
+
+        const json* container = nullptr;
+        {
+            auto it = resp->end();
+            if (cfg.source_type == "favorites")
+                it = resp->find("starred2");
+            else if (cfg.source_type == "random")
+                it = resp->find("randomSongs");
+            else if (cfg.source_type == "playlist")
+                it = resp->find("playlist");
+            else if (cfg.source_type == "album")
+                it = resp->find("album");
+            if (it != resp->end() && it->is_object())
+                container = &*it;
+        }
+
+        if (!container) {
+            log::error("[koel] no data container in response");
+            return {{}, "unexpected response from Koel server (no " + cfg.source_type + " data)"};
+        }
+
+        const json* entries = nullptr;
+        {
+            auto key   = expect_songs_key ? "song" : "entry";
+            auto it    = container->find(key);
+            if (it != container->end() && it->is_array()) {
+                entries = &*it;
+            } else {
+                auto other = expect_songs_key ? "entry" : "song";
+                it         = container->find(other);
+                if (it != container->end() && it->is_array())
+                    entries = &*it;
+            }
+        }
+
+        if (!entries) {
+            log::error("[koel] no song/entry array in container");
+            return {{}, "no songs found in " + cfg.source_type};
+        }
+
+        out.reserve(entries->size());
+        for (const auto& entry : *entries) {
+            auto t = parse_song_entry(entry);
+            if (!t.id.empty()) out.push_back(std::move(t));
+        }
+    } catch (const std::exception& e) {
+        log::error("[koel] JSON parse error: {}", e.what());
+        return {{}, "failed to parse Koel server response: " + std::string(e.what())};
+    }
+
+    log::info("[koel] fetched {} track(s)", out.size());
+    return {std::move(out), {}};
+}
+
+void shuffle_range(std::vector<KoelTrack>& q, std::size_t from) {
+    if (from >= q.size() || q.size() - from < 2) return;
+    static thread_local std::mt19937 rng{std::random_device{}()};
+    std::shuffle(q.begin() + (std::ptrdiff_t)from, q.end(), rng);
+}
+
+std::mutex& fetch_serializer() {
+    static std::mutex m;
+    return m;
+}
+
+} // namespace
+
+struct KoelSource::Pipe {
+    worker::WorkerClient* worker = nullptr;
+    uint32_t pipeline_id = 0;
+
+    HANDLE job       = nullptr;
+    HANDLE proc      = nullptr;
+
+    HANDLE read_pipe = nullptr;
+    std::uint64_t bytes_written = 0;
+    std::atomic<std::uint64_t> position_ms{0};
+    bool ended                = false;
+    std::size_t for_queue_idx = 0;
+
+    ~Pipe() {
+        if (read_pipe) { CloseHandle(read_pipe); read_pipe = nullptr; }
+        if (worker && pipeline_id) worker->kill_pipeline(pipeline_id);
+        subprocess::reap(proc);
+        if (job) CloseHandle(job);
+    }
+};
+
+KoelSource::KoelSource(KoelConfig cfg, std::filesystem::path ffmpeg_path,
+                       worker::WorkerClient* worker)
+    : cfg_{std::move(cfg)}, ffmpeg_path_{std::move(ffmpeg_path)}, worker_{worker} {}
+
+KoelSource::~KoelSource() {
+    std::scoped_lock lk{mu_};
+    discard_prefetch_locked();
+    stop_pipe_locked();
+}
+
+bool KoelSource::initialize() {
+    if (!cfg_.enabled) return false;
+    if (!config_complete(cfg_)) {
+        auth_state_.store(AuthState::needs_auth, std::memory_order_release);
+        return true;
+    }
+    auto result = fetch_tracks(cfg_);
+    if (result.error.empty()) {
+        auth_state_.store(AuthState::authenticated, std::memory_order_release);
+        {
+            std::scoped_lock lk{mu_};
+            auth_error_.clear();
+        }
+        queue_ = std::move(result.tracks);
+        if (cfg_.shuffle) shuffle_range(queue_, 0);
+    } else {
+        log::error("[koel] initialize: {}", result.error);
+        auth_state_.store(AuthState::error, std::memory_order_release);
+        std::scoped_lock lk{mu_};
+        auth_error_ = result.error;
+    }
+    return true;
+}
+
+void KoelSource::shutdown() noexcept {
+    std::scoped_lock lk{mu_};
+    discard_prefetch_locked();
+    stop_pipe_locked();
+}
+
+std::unique_ptr<KoelSource::Pipe> KoelSource::spawn_pipe_locked(std::size_t for_idx) {
+    if (queue_.empty() || for_idx >= queue_.size()) return nullptr;
+
+    auto pipe           = std::make_unique<Pipe>();
+    pipe->for_queue_idx = for_idx;
+
+    const std::wstring ff = ffmpeg_path_.empty() ? std::wstring{L"ffmpeg"}
+                                                  : ffmpeg_path_.wstring();
+    const std::string stream_url = make_stream_url(cfg_, queue_[for_idx].id);
+
+    std::wstring cmd = quote(ff) +
+        L" -loglevel error -reconnect 1 -reconnect_at_eof 1 -reconnect_streamed 1 "
+        L"-reconnect_delay_max 5 -i " + quote(widen(stream_url)) + L" -f s16le ";
+    if (volume_norm_.load(std::memory_order_acquire))
+        cmd += L"-af loudnorm=I=-14:TP=-2:LRA=11 ";
+    cmd += L"-acodec pcm_s16le -ar 48000 -ac 2 pipe:1";
+
+    if (worker_ && worker_->alive()) {
+        if (auto result = worker_->spawn_single(cmd); result.ok) {
+            pipe->worker      = worker_;
+            pipe->pipeline_id = result.pipeline_id;
+            pipe->read_pipe   = result.pcm_pipe;
+            return pipe;
+        }
+        log::warn("[koel] worker spawn failed for {} -- falling back to direct spawn",
+                  queue_[for_idx].id);
+    }
+
+    auto job = create_kill_on_close_job();
+    if (!job) {
+        log::warn("[koel] CreateJobObject failed ({})", GetLastError());
+        return nullptr;
+    }
+    pipe->job = job;
+
+    SECURITY_ATTRIBUTES sa{sizeof(sa), nullptr, TRUE};
+    HANDLE out_r = nullptr, out_w = nullptr;
+    if (!CreatePipe(&out_r, &out_w, &sa, 1 << 20)) return nullptr;
+    SetHandleInformation(out_r, HANDLE_FLAG_INHERIT, 0);
+
+    HANDLE nul_in  = open_nul(GENERIC_READ);
+    HANDLE err_log = open_stderr_log();
+
+    pipe->proc = spawn_in_job(pipe->job, cmd, nul_in, out_w, err_log);
+    const DWORD ec = pipe->proc ? 0u : GetLastError();
+    CloseHandle(out_w);
+    if (nul_in) CloseHandle(nul_in);
+    if (err_log) CloseHandle(err_log);
+    if (!pipe->proc) {
+        CloseHandle(out_r);
+        log::warn("[koel] failed to launch ffmpeg -- {}",
+                  describe_launch_failure(ff, ec, !ffmpeg_path_.empty()));
+        return nullptr;
+    }
+
+    pipe->read_pipe = out_r;
+    return pipe;
+}
+
+void KoelSource::start_pipe_locked() {
+    stop_pipe_locked();
+    pipe_ = spawn_pipe_locked(current_idx_);
+}
+
+void KoelSource::stop_pipe_locked() {
+    pipe_.reset();
+    state_.store(PlaybackState::stopped, std::memory_order_release);
+}
+
+void KoelSource::discard_prefetch_locked() noexcept { prefetch_.reset(); }
+
+std::size_t KoelSource::next_queue_idx_locked() const noexcept {
+    if (queue_.empty()) return 0;
+    return (current_idx_ + 1) % queue_.size();
+}
+
+bool KoelSource::promote_prefetch_locked(std::size_t expected_idx) {
+    if (!prefetch_ || prefetch_->for_queue_idx != expected_idx) {
+        discard_prefetch_locked();
+        return false;
+    }
+    pipe_ = std::move(prefetch_);
+    return true;
+}
+
+void KoelSource::maybe_spawn_prefetch_locked() {
+    if (!prebuffer_next_.load(std::memory_order_acquire)) return;
+    if (prefetch_ || !pipe_ || queue_.size() < 2) return;
+    constexpr std::uint64_t kViableBytes = 96 * 1024;
+    if (pipe_->bytes_written < kViableBytes) return;
+    prefetch_ = spawn_pipe_locked(next_queue_idx_locked());
+}
+
+void KoelSource::advance_locked(std::ptrdiff_t step) {
+    if (queue_.empty()) return;
+    const auto n = (std::ptrdiff_t)queue_.size();
+    auto i       = (std::ptrdiff_t)current_idx_ + step;
+    current_idx_ = (std::size_t)(((i % n) + n) % n);
+    if (step == 1 && promote_prefetch_locked(current_idx_)) {
+    } else {
+        discard_prefetch_locked();
+        start_pipe_locked();
+    }
+    if (pipe_) state_.store(PlaybackState::playing, std::memory_order_release);
+}
+
+void KoelSource::play() {
+    std::scoped_lock lk{mu_};
+    if (queue_.empty()) return;
+    if (!pipe_) start_pipe_locked();
+    if (pipe_) state_.store(PlaybackState::playing, std::memory_order_release);
+}
+
+void KoelSource::pause() { state_.store(PlaybackState::paused, std::memory_order_release); }
+
+void KoelSource::stop() {
+    std::scoped_lock lk{mu_};
+    discard_prefetch_locked();
+    stop_pipe_locked();
+    current_idx_ = 0;
+}
+
+void KoelSource::next() {
+    std::scoped_lock lk{mu_};
+    advance_locked(+1);
+}
+
+void KoelSource::previous() {
+    std::scoped_lock lk{mu_};
+    advance_locked(-1);
+}
+
+std::string KoelSource::cast(std::string source_type, std::string source_id) {
+    if (source_type.empty()) return "source_type is empty";
+    KoelConfig snap;
+    {
+        std::scoped_lock lk{mu_};
+        snap = cfg_;
+    }
+    snap.source_type = source_type;
+    snap.source_id   = source_id;
+    if (!config_complete(snap)) {
+        if (snap.server_url.empty())
+            return "Koel server URL not configured – set it in Settings first";
+        if (snap.password.empty())
+            return "Koel password/API key not configured – set it in Settings first";
+        return "incomplete Koel configuration";
+    }
+
+    FetchResult result;
+    {
+        std::scoped_lock fetch_lk{fetch_serializer()};
+        result = fetch_tracks(snap);
+    }
+    if (!result.error.empty()) return result.error;
+
+    std::scoped_lock lk{mu_};
+    cfg_.source_type = std::move(source_type);
+    cfg_.source_id   = std::move(source_id);
+    queue_           = std::move(result.tracks);
+    current_idx_     = 0;
+    if (cfg_.shuffle) shuffle_range(queue_, 0);
+    discard_prefetch_locked();
+    start_pipe_locked();
+    if (pipe_) state_.store(PlaybackState::playing, std::memory_order_release);
+    return {};
+}
+
+void KoelSource::set_config(KoelConfig cfg) {
+    bool requery, shuffle_flip;
+    {
+        std::scoped_lock lk{mu_};
+        requery      = !same_query_target(cfg_, cfg) && config_complete(cfg);
+        shuffle_flip = cfg_.shuffle != cfg.shuffle;
+    }
+
+    FetchResult result;
+    if (requery) {
+        std::scoped_lock fetch_lk{fetch_serializer()};
+        result = fetch_tracks(cfg);
+    }
+
+    std::scoped_lock lk{mu_};
+    const bool was_playing = state_.load(std::memory_order_acquire) == PlaybackState::playing;
+    cfg_                   = std::move(cfg);
+
+    if (requery) {
+        if (result.error.empty()) {
+            auth_state_.store(AuthState::authenticated, std::memory_order_release);
+            auth_error_.clear();
+            if (!result.tracks.empty()) {
+                discard_prefetch_locked();
+                stop_pipe_locked();
+                queue_       = std::move(result.tracks);
+                current_idx_ = 0;
+                if (cfg_.shuffle) shuffle_range(queue_, 0);
+                if (was_playing) {
+                    start_pipe_locked();
+                    if (pipe_) state_.store(PlaybackState::playing, std::memory_order_release);
+                }
+            }
+        } else {
+            log::error("[koel] set_config: {}", result.error);
+            auth_state_.store(AuthState::error, std::memory_order_release);
+            auth_error_ = result.error;
+        }
+    } else if (!config_complete(cfg_)) {
+        auth_state_.store(AuthState::needs_auth, std::memory_order_release);
+        auth_error_.clear();
+    }
+    if (shuffle_flip && cfg_.shuffle) {
+        shuffle_range(queue_, current_idx_ + 1);
+        discard_prefetch_locked();
+    }
+}
+
+void KoelSource::set_ffmpeg_path(std::filesystem::path p) {
+    std::scoped_lock lk{mu_};
+    ffmpeg_path_ = std::move(p);
+}
+
+std::string KoelSource::source_type() const {
+    std::scoped_lock lk{mu_};
+    return cfg_.source_type;
+}
+
+std::size_t KoelSource::track_count() const {
+    std::scoped_lock lk{mu_};
+    return queue_.size();
+}
+
+std::string KoelSource::auth_error() const {
+    std::scoped_lock lk{mu_};
+    return auth_error_;
+}
+
+void KoelSource::set_playback_options(const PlaybackConfig& opts) {
+    {
+        std::scoped_lock lk{mu_};
+        eq_.set_options(opts.equalizer_enabled, opts.equalizer_bands, 48000.0f);
+    }
+    volume_norm_.store(opts.volume_normalization, std::memory_order_release);
+    const bool prev =
+        prebuffer_next_.exchange(opts.prebuffer_next_track, std::memory_order_acq_rel);
+    if (prev && !opts.prebuffer_next_track) {
+        std::scoped_lock lk{mu_};
+        discard_prefetch_locked();
+    }
+}
+
+TrackInfo KoelSource::current_track() const {
+    std::scoped_lock lk{mu_};
+    TrackInfo info;
+    if (queue_.empty() || current_idx_ >= queue_.size()) return info;
+    const auto& t    = queue_[current_idx_];
+    info.title       = t.title;
+    info.artist      = t.artist;
+    info.album       = t.album;
+    info.duration_ms = t.duration_ms;
+    if (!t.image_url.empty() && !cfg_.server_url.empty()) {
+        auto cover_id = !t.parent.empty() ? t.parent : t.image_url;
+        std::string url = cfg_.server_url;
+        if (url.ends_with('/')) url.resize(url.size() - 1);
+        info.artwork_url = std::format("{}/rest/getCoverArt.view?id={}&{}",
+                                        url, url_encode(cover_id), auth_query(cfg_));
+    }
+    if (pipe_) info.position_ms = pipe_->position_ms.load(std::memory_order_acquire);
+    return info;
+}
+
+AuthState KoelSource::auth_state() const noexcept {
+    return auth_state_.load(std::memory_order_acquire);
+}
+
+void KoelSource::pump(RingBuffer& ring) {
+    if (state_.load(std::memory_order_acquire) != PlaybackState::playing) return;
+
+    std::scoped_lock lk{mu_};
+    Pipe* p = pipe_.get();
+    if (!p) return;
+
+    auto update_position = [&] {
+        const std::size_t r        = ring.readable();
+        const std::uint64_t played = p->bytes_written > r ? p->bytes_written - r : 0;
+        p->position_ms.store(played * 1000ull / kPcmBytesPerSec, std::memory_order_release);
+    };
+    auto on_eof = [&] {
+        if (p->read_pipe) {
+            CloseHandle(p->read_pipe);
+            p->read_pipe = nullptr;
+        }
+        p->ended = true;
+    };
+
+    if (p->ended) {
+        update_position();
+        if (ring.readable() == 0) advance_locked(+1);
+        return;
+    }
+    if (!p->read_pipe) return;
+
+    DWORD avail = 0;
+    if (!PeekNamedPipe(p->read_pipe, nullptr, 0, nullptr, &avail, nullptr)) {
+        on_eof();
+        return;
+    }
+    while (avail > 0) {
+        const std::size_t writable = ring.writable();
+        if (writable < 4) break;
+        std::size_t want = std::min<std::size_t>(writable, avail);
+        if (want > 4096) want = 4096;
+        want &= ~std::size_t{3};
+        if (!want) break;
+
+        std::byte buf[4096];
+        DWORD got = 0;
+        if (!ReadFile(p->read_pipe, buf, (DWORD)want, &got, nullptr) || got == 0) {
+            on_eof();
+            break;
+        }
+        const DWORD aligned = (got / 4u) * 4u;
+        if (aligned) eq_.process(reinterpret_cast<int16_t*>(buf), aligned / 4u);
+        ring.write(buf, aligned);
+        p->bytes_written += aligned;
+        avail             = avail > got ? avail - got : 0;
+    }
+    update_position();
+    maybe_spawn_prefetch_locked();
+}
+
+} // namespace fh6::sources

--- a/src/sources/koel_source.cpp
+++ b/src/sources/koel_source.cpp
@@ -62,17 +62,26 @@ std::string md5_hex(const std::string& input) {
         return {};
 
     DWORD hash_obj_len = 0, hash_len = 0, unused = 0;
-    BCryptGetProperty(algo, BCRYPT_OBJECT_LENGTH, (PUCHAR)&hash_obj_len, sizeof(hash_obj_len),
-                      &unused, 0);
-    BCryptGetProperty(algo, BCRYPT_HASH_LENGTH, (PUCHAR)&hash_len, sizeof(hash_len), &unused, 0);
+    auto st = BCryptGetProperty(algo, BCRYPT_OBJECT_LENGTH, (PUCHAR)&hash_obj_len,
+                                sizeof(hash_obj_len), &unused, 0);
+    if (st != 0) { BCryptCloseAlgorithmProvider(algo, 0); return {}; }
+    st = BCryptGetProperty(algo, BCRYPT_HASH_LENGTH, (PUCHAR)&hash_len, sizeof(hash_len),
+                           &unused, 0);
+    if (st != 0) { BCryptCloseAlgorithmProvider(algo, 0); return {}; }
 
     std::vector<BYTE> hash_obj(hash_obj_len);
     std::vector<BYTE> hash(hash_len);
 
     BCRYPT_HASH_HANDLE h = nullptr;
-    BCryptCreateHash(algo, &h, hash_obj.data(), (ULONG)hash_obj.size(), nullptr, 0, 0);
-    BCryptHashData(h, (PUCHAR)input.data(), (ULONG)input.size(), 0);
-    BCryptFinishHash(h, hash.data(), (ULONG)hash.size(), 0);
+    st = BCryptCreateHash(algo, &h, hash_obj.data(), (ULONG)hash_obj.size(), nullptr, 0, 0);
+    if (st != 0) { BCryptCloseAlgorithmProvider(algo, 0); return {}; }
+
+    st = BCryptHashData(h, (PUCHAR)input.data(), (ULONG)input.size(), 0);
+    if (st != 0) { BCryptDestroyHash(h); BCryptCloseAlgorithmProvider(algo, 0); return {}; }
+
+    st = BCryptFinishHash(h, hash.data(), (ULONG)hash.size(), 0);
+    if (st != 0) { BCryptDestroyHash(h); BCryptCloseAlgorithmProvider(algo, 0); return {}; }
+
     BCryptDestroyHash(h);
     BCryptCloseAlgorithmProvider(algo, 0);
 
@@ -219,7 +228,11 @@ FetchResult fetch_tracks(const KoelConfig& cfg) {
                     auto t = parse_song_entry(song);
                     if (!t.id.empty()) out.push_back(std::move(t));
                 }
-            } catch (...) {}
+            } catch (const std::exception& e) {
+                log::warn("[koel] getAlbum JSON parse (album {}) : {}", aid, e.what());
+            } catch (...) {
+                log::warn("[koel] getAlbum JSON parse (album {}) : unknown exception", aid);
+            }
         }
 
         log::info("[koel] fetched {} track(s) for artist", out.size());

--- a/src/sources/koel_source.cpp
+++ b/src/sources/koel_source.cpp
@@ -387,6 +387,7 @@ bool KoelSource::initialize() {
             std::scoped_lock lk{mu_};
             auth_error_.clear();
             queue_ = std::move(result.tracks);
+            cached_artwork_idx_ = SIZE_MAX;
             if (cfg_.shuffle) shuffle_range(queue_, 0);
         }
     } else {
@@ -565,6 +566,7 @@ std::string KoelSource::cast(std::string source_type, std::string source_id) {
     cfg_.source_id   = std::move(source_id);
     queue_           = std::move(result.tracks);
     current_idx_     = 0;
+    cached_artwork_idx_ = SIZE_MAX;
     if (cfg_.shuffle) shuffle_range(queue_, 0);
     discard_prefetch_locked();
     start_pipe_locked();
@@ -599,6 +601,7 @@ void KoelSource::set_config(KoelConfig cfg) {
                 stop_pipe_locked();
                 queue_       = std::move(result.tracks);
                 current_idx_ = 0;
+                cached_artwork_idx_ = SIZE_MAX;
                 if (cfg_.shuffle) shuffle_range(queue_, 0);
                 if (was_playing) {
                     start_pipe_locked();

--- a/src/sources/koel_source.cpp
+++ b/src/sources/koel_source.cpp
@@ -94,6 +94,14 @@ std::string md5_hex(const std::string& input) {
 
 std::string auth_query(const KoelConfig& cfg) {
     const auto& u = cfg.username.empty() ? "subsonic" : cfg.username;
+    // Prefer token-based auth (Subsonic / OpenSubsonic standard).
+    // Falls back to password-based for servers that don't support tokens.
+    static thread_local std::mt19937 rng{std::random_device{}()};
+    auto salt = std::to_string(rng());
+    auto token = md5_hex(cfg.password + salt);
+    if (!token.empty())
+        return std::format("u={}&t={}&s={}&v=1.16.1&c=fh6-radio",
+                           url_encode(u), token, url_encode(salt));
     return std::format("u={}&p={}&v=1.16.1&c=fh6-radio",
                        url_encode(u), url_encode(cfg.password));
 }
@@ -378,9 +386,9 @@ bool KoelSource::initialize() {
         {
             std::scoped_lock lk{mu_};
             auth_error_.clear();
+            queue_ = std::move(result.tracks);
+            if (cfg_.shuffle) shuffle_range(queue_, 0);
         }
-        queue_ = std::move(result.tracks);
-        if (cfg_.shuffle) shuffle_range(queue_, 0);
     } else {
         log::error("[koel] initialize: {}", result.error);
         auth_state_.store(AuthState::error, std::memory_order_release);
@@ -656,11 +664,15 @@ TrackInfo KoelSource::current_track() const {
     info.album       = t.album;
     info.duration_ms = t.duration_ms;
     if (!t.image_url.empty() && !cfg_.server_url.empty()) {
-        auto cover_id = !t.parent.empty() ? t.parent : t.image_url;
-        std::string url = cfg_.server_url;
-        if (url.ends_with('/')) url.resize(url.size() - 1);
-        info.artwork_url = std::format("{}/rest/getCoverArt.view?id={}&{}",
-                                        url, url_encode(cover_id), auth_query(cfg_));
+        if (current_idx_ != cached_artwork_idx_) {
+            auto cover_id = !t.parent.empty() ? t.parent : t.image_url;
+            std::string url = cfg_.server_url;
+            if (url.ends_with('/')) url.resize(url.size() - 1);
+            cached_artwork_url_ = std::format("{}/rest/getCoverArt.view?id={}&{}",
+                                              url, url_encode(cover_id), auth_query(cfg_));
+            cached_artwork_idx_ = current_idx_;
+        }
+        info.artwork_url = cached_artwork_url_;
     }
     if (pipe_) info.position_ms = pipe_->position_ms.load(std::memory_order_acquire);
     return info;

--- a/src/sources/koel_source.cpp
+++ b/src/sources/koel_source.cpp
@@ -179,7 +179,7 @@ FetchResult fetch_tracks(const KoelConfig& cfg) {
         auto artist_body = net::http_get(artist_url);
         if (!artist_body) {
             log::error("[koel] HTTP request failed for getArtist");
-            return {{}, "HTTP request to Koel server failed – check the URL"};
+                            return {{}, "HTTP request to Subsonic server failed – check the URL"};
         }
 
         std::vector<std::string> album_ids;
@@ -188,18 +188,18 @@ FetchResult fetch_tracks(const KoelConfig& cfg) {
             auto resp = root.find("subsonic-response");
             if (resp == root.end() || !resp->is_object()) {
                 log::error("[koel] getArtist response missing subsonic-response");
-                return {{}, "unexpected response from Koel server (missing subsonic-response)"};
+                            return {{}, "unexpected response from Subsonic server (missing subsonic-response)"};
             }
             if (resp->value("status", "") != "ok") {
                 auto err_obj = resp->value("error", json::object());
                 auto msg = err_obj.value("message", "unknown error");
                 log::error("[koel] getArtist API error: {}", msg);
-                return {{}, "Koel API error: " + msg};
+                            return {{}, "Subsonic API error: " + msg};
             }
             auto art = resp->find("artist");
             if (art == resp->end() || !art->is_object()) {
                 log::error("[koel] getArtist missing artist object");
-                return {{}, "unexpected response from Koel server (missing artist)"};
+                            return {{}, "unexpected response from Subsonic server (missing artist)"};
             }
             auto albums = art->find("album");
             if (albums != art->end() && albums->is_array()) {
@@ -210,7 +210,7 @@ FetchResult fetch_tracks(const KoelConfig& cfg) {
             }
         } catch (const std::exception& e) {
             log::error("[koel] getArtist JSON parse error: {}", e.what());
-            return {{}, "failed to parse Koel server response: " + std::string(e.what())};
+                            return {{}, "failed to parse Subsonic server response: " + std::string(e.what())};
         }
 
         if (album_ids.empty()) {
@@ -258,7 +258,7 @@ FetchResult fetch_tracks(const KoelConfig& cfg) {
         log::error("[koel] constructed URL was: {}.view?f=json&u={}&t=...&s=...&v=1.16.1&c=fh6-radio{}",
                    cfg.server_url + "/rest/" + method, url_encode(cfg.username.empty() ? "subsonic" : cfg.username),
                    extra_params.empty() ? "" : "&" + extra_params);
-        return {{}, "cannot reach Koel server – check the URL and that the server is running"};
+                            return {{}, "cannot reach Subsonic server – check the URL and that the server is running"};
     }
 
     std::vector<KoelTrack> out;
@@ -267,14 +267,14 @@ FetchResult fetch_tracks(const KoelConfig& cfg) {
         auto resp = root.find("subsonic-response");
         if (resp == root.end() || !resp->is_object()) {
             log::error("[koel] response missing subsonic-response");
-            return {{}, "unexpected response from Koel server (not a valid Subsonic API response)"};
+                            return {{}, "unexpected response from Subsonic server (not a valid Subsonic API response)"};
         }
         if (resp->value("status", "") != "ok") {
             auto err_obj = resp->value("error", json::object());
             auto msg = err_obj.value("message", "unknown error");
             log::error("[koel] API error: {} - {}",
                        err_obj.value("code", 0), msg);
-            return {{}, "Koel API error: " + msg};
+                            return {{}, "Subsonic API error: " + msg};
         }
 
         const json* container = nullptr;
@@ -294,7 +294,7 @@ FetchResult fetch_tracks(const KoelConfig& cfg) {
 
         if (!container) {
             log::error("[koel] no data container in response");
-            return {{}, "unexpected response from Koel server (no " + cfg.source_type + " data)"};
+                            return {{}, "unexpected response from Subsonic server (no " + cfg.source_type + " data)"};
         }
 
         const json* entries = nullptr;
@@ -323,7 +323,7 @@ FetchResult fetch_tracks(const KoelConfig& cfg) {
         }
     } catch (const std::exception& e) {
         log::error("[koel] JSON parse error: {}", e.what());
-        return {{}, "failed to parse Koel server response: " + std::string(e.what())};
+                            return {{}, "failed to parse Subsonic server response: " + std::string(e.what())};
     }
 
     log::info("[koel] fetched {} track(s)", out.size());
@@ -548,10 +548,10 @@ std::string KoelSource::cast(std::string source_type, std::string source_id) {
     snap.source_id   = source_id;
     if (!config_complete(snap)) {
         if (snap.server_url.empty())
-            return "Koel server URL not configured – set it in Settings first";
+                return "Subsonic server URL not configured – set it in Settings first";
         if (snap.password.empty())
-            return "Koel password/API key not configured – set it in Settings first";
-        return "incomplete Koel configuration";
+                return "Subsonic password/API key not configured – set it in Settings first";
+            return "incomplete Subsonic configuration";
     }
 
     FetchResult result;

--- a/ui/dist/index.html
+++ b/ui/dist/index.html
@@ -71,6 +71,26 @@
         </form>
       </section>
 
+      <section class="card" id="koel-cast-card" hidden>
+        <h2>Koel Radio</h2>
+        <p class="muted">
+          Select a source type and pick from the list, then click Play.
+        </p>
+        <form id="koel-cast" class="row" style="flex-wrap: wrap; gap: 8px;">
+          <select id="koel-source-type" style="flex: 1; min-width: 140px;">
+            <option value="favorites">Favorites</option>
+            <option value="playlist">Playlist</option>
+            <option value="album">Album</option>
+            <option value="artist">Artist</option>
+            <option value="random">Random</option>
+          </select>
+          <select id="koel-source-id" style="flex: 1; min-width: 160px;" disabled>
+            <option value="">—</option>
+          </select>
+          <button type="submit" class="btn filled">Play</button>
+        </form>
+      </section>
+
       <section class="card" id="output-card" hidden>
         <h2>Output</h2>
         <label class="slider">

--- a/ui/dist/index.html
+++ b/ui/dist/index.html
@@ -72,7 +72,7 @@
       </section>
 
       <section class="card" id="koel-cast-card" hidden>
-        <h2>Koel Radio</h2>
+        <h2>Koel / Subsonic</h2>
         <p class="muted">
           Select a source type, use the search to filter, pick from the list, then Play.
         </p>

--- a/ui/dist/index.html
+++ b/ui/dist/index.html
@@ -74,7 +74,7 @@
       <section class="card" id="koel-cast-card" hidden>
         <h2>Koel Radio</h2>
         <p class="muted">
-          Select a source type and pick from the list, then click Play.
+          Select a source type, use the search to filter, pick from the list, then Play.
         </p>
         <form id="koel-cast" class="row" style="flex-wrap: wrap; gap: 8px;">
           <select id="koel-source-type" style="flex: 1; min-width: 140px;">
@@ -84,9 +84,8 @@
             <option value="artist">Artist</option>
             <option value="random">Random</option>
           </select>
-          <select id="koel-source-id" style="flex: 1; min-width: 160px;" disabled>
-            <option value="">—</option>
-          </select>
+          <input type="text" id="koel-source-id" placeholder="Search and select…" autocomplete="off" style="flex: 1; min-width: 200px;" list="koel-datalist" disabled>
+          <datalist id="koel-datalist"></datalist>
           <button type="submit" class="btn filled">Play</button>
         </form>
       </section>

--- a/ui/dist/js/api.js
+++ b/ui/dist/js/api.js
@@ -25,6 +25,9 @@ export const api = {
     request("/api/source/youtube_music/shuffle", { method: "POST", body: { shuffle } }),
   castJellyfin: playlistId =>
     request("/api/source/jellyfin/cast", { method: "POST", body: { playlist_id: playlistId } }),
+  castKoel: (sourceType, sourceId) =>
+    request("/api/source/koel/cast", { method: "POST", body: { source_type: sourceType, source_id: sourceId } }),
+  browseKoel: type => request("/api/source/koel/browse/" + type),
   setGain: gain => request("/api/options", { method: "POST", body: { output_gain: gain } }),
   getExternalAudio: () => request("/api/external_audio/devices"),
   putExternalAudio: config => request("/api/external_audio/config", { method: "PUT", body: config }),

--- a/ui/dist/js/main.js
+++ b/ui/dist/js/main.js
@@ -34,6 +34,7 @@ const refs = {
   outputCard: $("#output-card"),
   ytCard: $("#yt-cast-card"),
   jfCard: $("#jf-cast-card"),
+  koelCard: $("#koel-cast-card"),
   ytShuffle: $("#yt-shuffle"),
   drawer: $("#drawer"),
   scrim: $("#scrim"),
@@ -151,6 +152,7 @@ function render() {
   // Source-specific cards only show while that source is on air.
   refs.ytCard.hidden = active !== "youtube_music";
   refs.jfCard.hidden = active !== "jellyfin";
+  refs.koelCard.hidden = active !== "koel";
   const shuffleOn = !!available.find(s => s.name === "youtube_music")?.details?.shuffle;
   refs.ytShuffle.classList.toggle("toggled", shuffleOn);
   refs.ytShuffle.setAttribute("aria-pressed", String(shuffleOn));
@@ -180,6 +182,46 @@ $("#yt-shuffle").addEventListener("click", async () => {
   try {
     await api.shuffleYoutube(shuffle);
     toast(shuffle ? "Shuffle on" : "Shuffle off");
+  } catch (err) {
+    toast(err.message, true);
+  }
+});
+
+$("#koel-source-type").addEventListener("change", async () => {
+  const type = $("#koel-source-type").value;
+  const sel = $("#koel-source-id");
+  sel.innerHTML = "";
+  if (type === "favorites" || type === "random") {
+    sel.disabled = true;
+    sel.innerHTML = '<option value="">—</option>';
+    return;
+  }
+  sel.disabled = false;
+  sel.innerHTML = '<option value="">Loading…</option>';
+  try {
+    const data = await api.browseKoel(type === "playlist" ? "playlists" : type + "s");
+    const items = data.items || [];
+    sel.innerHTML = '<option value="">Select ' + type + '…</option>';
+    items.forEach(item => {
+      const opt = document.createElement("option");
+      opt.value = item.id;
+      opt.textContent = item.name;
+      sel.appendChild(opt);
+    });
+  } catch (err) {
+    sel.innerHTML = '<option value="">Error loading</option>';
+    toast(err.message, true);
+  }
+});
+
+$("#koel-cast").addEventListener("submit", async e => {
+  e.preventDefault();
+  const sourceType = $("#koel-source-type").value;
+  const sel = $("#koel-source-id");
+  const sourceId = sel.disabled ? "" : sel.value.trim();
+  try {
+    await api.castKoel(sourceType, sourceId);
+    toast("Playing…");
   } catch (err) {
     toast(err.message, true);
   }

--- a/ui/dist/js/main.js
+++ b/ui/dist/js/main.js
@@ -187,29 +187,44 @@ $("#yt-shuffle").addEventListener("click", async () => {
   }
 });
 
+let koelItems = [];
+
+function populateKoelDatalist(items) {
+  const dl = $("#koel-datalist");
+  dl.innerHTML = "";
+  items.forEach(item => {
+    const opt = document.createElement("option");
+    opt.value = item.name;
+    dl.appendChild(opt);
+  });
+}
+
+function koelLookupId(name) {
+  const match = koelItems.find(i => i.name === name);
+  return match ? match.id : "";
+}
+
 $("#koel-source-type").addEventListener("change", async () => {
   const type = $("#koel-source-type").value;
-  const sel = $("#koel-source-id");
-  sel.innerHTML = "";
+  const input = $("#koel-source-id");
   if (type === "favorites" || type === "random") {
-    sel.disabled = true;
-    sel.innerHTML = '<option value="">—</option>';
+    input.disabled = true;
+    input.value = "";
+    input.placeholder = "—";
+    koelItems = [];
+    populateKoelDatalist([]);
     return;
   }
-  sel.disabled = false;
-  sel.innerHTML = '<option value="">Loading…</option>';
+  input.disabled = false;
+  input.value = "";
+  input.placeholder = "Loading…";
   try {
     const data = await api.browseKoel(type === "playlist" ? "playlists" : type + "s");
-    const items = data.items || [];
-    sel.innerHTML = '<option value="">Select ' + type + '…</option>';
-    items.forEach(item => {
-      const opt = document.createElement("option");
-      opt.value = item.id;
-      opt.textContent = item.name;
-      sel.appendChild(opt);
-    });
+    koelItems = data.items || [];
+    populateKoelDatalist(koelItems);
+    input.placeholder = "Search and select…";
   } catch (err) {
-    sel.innerHTML = '<option value="">Error loading</option>';
+    input.placeholder = "Error loading";
     toast(err.message, true);
   }
 });
@@ -217,8 +232,12 @@ $("#koel-source-type").addEventListener("change", async () => {
 $("#koel-cast").addEventListener("submit", async e => {
   e.preventDefault();
   const sourceType = $("#koel-source-type").value;
-  const sel = $("#koel-source-id");
-  const sourceId = sel.disabled ? "" : sel.value.trim();
+  const input = $("#koel-source-id");
+  const sourceId = input.disabled ? "" : koelLookupId(input.value.trim());
+  if (!input.disabled && !sourceId) {
+    toast("Pick a valid item from the list", true);
+    return;
+  }
   try {
     await api.castKoel(sourceType, sourceId);
     toast("Playing…");

--- a/ui/dist/js/main.js
+++ b/ui/dist/js/main.js
@@ -229,6 +229,24 @@ $("#koel-source-type").addEventListener("change", async () => {
   }
 });
 
+let koelSearchTimer = null;
+
+$("#koel-source-id").addEventListener("input", () => {
+  const type = $("#koel-source-type").value;
+  if (type === "favorites" || type === "random") return;
+  clearTimeout(koelSearchTimer);
+  const q = $("#koel-source-id").value.trim();
+  koelSearchTimer = setTimeout(async () => {
+    const browseType = type === "playlist" ? "playlists" : type + "s";
+    try {
+      const suffix = q ? "?q=" + encodeURIComponent(q) : "";
+      const data = await api.browseKoel(browseType + suffix);
+      koelItems = data.items || [];
+      populateKoelDatalist(koelItems);
+    } catch (_) { /* keep previous list on error */ }
+  }, 300);
+});
+
 $("#koel-cast").addEventListener("submit", async e => {
   e.preventDefault();
   const sourceType = $("#koel-source-type").value;

--- a/ui/dist/js/render/sources.js
+++ b/ui/dist/js/render/sources.js
@@ -49,13 +49,14 @@ export function renderSources(node, state, cfg, onSwitch) {
     ...list.map(s => {
       const stateCls =
         s.auth_state === "needs_auth" ? "warn" : s.auth_state === "error" ? "err" : "";
-      const showNote =
-        (s.auth_state === "needs_auth" || s.auth_state === "error") && s.auth_instructions;
+      const note =
+        s.auth_state === "error" && s.details?.auth_error ? s.details.auth_error :
+        s.auth_state === "needs_auth" ? s.auth_instructions : "";
       const children = [
         el("div", { class: "source-name" }, s.display_name),
         el("div", { class: "source-state " + stateCls }, stateText(s)),
       ];
-      if (showNote) children.push(el("div", { class: "source-note" }, s.auth_instructions));
+      if (note) children.push(el("div", { class: "source-note" }, note));
       const tile = el(
         "button",
         { type: "button", class: "source" + (s.name === active ? " active" : "") },

--- a/ui/dist/js/schema.js
+++ b/ui/dist/js/schema.js
@@ -4,6 +4,7 @@ export const SOURCE_SECTIONS = [
   ["local_files", "Local files"],
   ["youtube_music", "YouTube Music"],
   ["jellyfin", "Jellyfin"],
+  ["koel", "Koel"],
   ["external_audio", "External Audio"],
   ["spotify", "Spotify Connect"],
 ];
@@ -52,6 +53,16 @@ export const SCHEMA = [
       ["default_playlist", "Default Playlist", "text"],
       ["use_favorites", "Use Favorites", "checkbox"],
       ["shuffle", "Shuffle", "checkbox"],
+    ],
+  ],
+  [
+    "koel",
+    "Koel",
+    [
+      ["enabled", "Enabled", "checkbox"],
+      ["server_url", "Server URL (e.g. 'https://koel.example.com' or 'https://koel.example.com/api/subsonic')", "text"],
+      ["username", "Username (your Koel email)", "text"],
+      ["password", "Password / API Key", "text"],
     ],
   ],
   ["external_audio", "External Audio", [["enabled", "Enabled", "checkbox"]]],

--- a/ui/dist/js/schema.js
+++ b/ui/dist/js/schema.js
@@ -60,9 +60,9 @@ export const SCHEMA = [
     "Koel",
     [
       ["enabled", "Enabled", "checkbox"],
-      ["server_url", "Server URL (e.g. 'https://koel.example.com' or 'https://koel.example.com/api/subsonic')", "text"],
-      ["username", "Username (your Koel email)", "text"],
-      ["password", "Password / API Key", "text"],
+      ["server_url", "Server URL (e.g. 'https://koel.example.com')", "text"],
+      ["username", "Email", "text"],
+      ["password", "API Key", "text"],
     ],
   ],
   ["external_audio", "External Audio", [["enabled", "Enabled", "checkbox"]]],

--- a/ui/dist/js/schema.js
+++ b/ui/dist/js/schema.js
@@ -4,7 +4,7 @@ export const SOURCE_SECTIONS = [
   ["local_files", "Local files"],
   ["youtube_music", "YouTube Music"],
   ["jellyfin", "Jellyfin"],
-  ["koel", "Koel"],
+  ["koel", "Koel / Subsonic"],
   ["external_audio", "External Audio"],
   ["spotify", "Spotify Connect"],
 ];
@@ -57,7 +57,7 @@ export const SCHEMA = [
   ],
   [
     "koel",
-    "Koel",
+    "Koel / Subsonic",
     [
       ["enabled", "Enabled", "checkbox"],
       ["server_url", "Server URL (e.g. 'https://koel.example.com')", "text"],


### PR DESCRIPTION
Implement a new audio source that streams from Koel (and any Subsonic-compatible server) via the Subsonic REST API, with config persistence, real-time credential validation, album artwork, and a dynamic content browser integrated into the web UI.

## IMPORTANT
This implementation is designed to be compatible with any server implementing the Subsonic API, such as Koel, Navidrome, Airsonic, and Gonic, etc. It includes fallback mechanisms for servers that do not support OpenSubsonic extensions (like search3), ensuring broad compatibility across various server implementations.

_BUT_, I've **only** tested it on Koel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Koel music server added as a first-class audio source with play/pause/stop/next/previous, queueing, shuffle, random selection, prefetching, and playback state/track metadata reporting.

* **HTTP API**
  * Browse Koel content (favorites, playlists, albums, artists), cast/select Koel sources, and added GET /favicon.ico. Server exposes Koel details including source type, track count, and auth status.

* **Documentation / Config**
  * New disabled-by-default [koel] example config and load/save support with auth and selection options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->