### PR TITLE
feat(tidal): add native TIDAL playback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ add_library(version SHARED
     src/sources/local_file_source.cpp
     src/sources/youtube_music_source.cpp
     src/sources/jellyfin_source.cpp
+    src/sources/tidal_source.cpp
     src/sources/external_audio_source.cpp
     src/sources/external_media_session.cpp
     src/sources/spotify_source.cpp

--- a/config.example.toml
+++ b/config.example.toml
@@ -89,3 +89,14 @@ equalizer_enabled    = false
 equalizer_bands      = [0.0, 0.0, 0.0, 0.0, 0.0]   # 60/250/1000/4000/12000 Hz, [-6, +6] dB
 force_stereo_audio   = true        # off => mono (avoids metallic phase-cancellation on the 3D radio channel)
 prebuffer_next_track = true        # pre-spawn the next track's pipeline so transitions skip the "(loading)" gap
+
+[tidal]
+enabled          = false
+client_id        = ""              # blank = use the default python-tidal client
+client_secret    = ""              # blank = use the default python-tidal secret
+access_token     = ""
+refresh_token    = ""
+expiry_time      = 0
+default_playlist = ""              # TIDAL playlist ID (UUID format)
+shuffle          = true
+audio_quality    = "HIGH"          # LOW | HIGH | LOSSLESS | HI_RES

--- a/include/fh6/config.hpp
+++ b/include/fh6/config.hpp
@@ -83,6 +83,18 @@ struct OnlineRadioConfig {
     size_t default_station_index = 0;
 };
 
+struct TidalConfig {
+    bool enabled = false;
+    std::string client_id;
+    std::string client_secret;
+    std::string access_token;
+    std::string refresh_token;
+    uint64_t expiry_time = 0;
+    std::string default_playlist;
+    bool shuffle = true;
+    std::string audio_quality = "HIGH";
+};
+
 struct AudioConfig {
     float output_gain = 1.0f;
 };
@@ -110,6 +122,7 @@ struct Config {
     GeneralConfig general;
     LocalFilesConfig local_files;
     YouTubeMusicConfig youtube_music;
+    TidalConfig tidal;
     AudioConfig audio;
     JellyfinConfig jellyfin;
     ExternalAudioConfig external_audio;

--- a/include/fh6/sources/tidal_source.hpp
+++ b/include/fh6/sources/tidal_source.hpp
@@ -1,0 +1,123 @@
+#pragma once
+
+#include "fh6/audio_source.hpp"
+#include "fh6/config.hpp"
+#include "fh6/config_store.hpp"
+#include "fh6/playback_dsp.hpp"
+#include "fh6/ring_buffer.hpp"
+
+#include <atomic>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace fh6::sources {
+
+struct TidalTrack {
+    std::string id;
+    std::string title;
+    std::string artist;
+    std::string album;
+    std::string artwork_url;
+    uint64_t duration_ms = 0;
+};
+
+// Streams TIDAL audio tracks by fetching dynamic stream/manifest URLs via the
+// TIDAL API, then passing them into ffmpeg to pipe PCM.
+// Handles OAuth2 Device Authorization Flow automatically using WinHTTP.
+class TidalSource final : public IAudioSource {
+public:
+    TidalSource(TidalConfig cfg, std::filesystem::path ffmpeg_path, ConfigStore& store);
+    ~TidalSource() override;
+
+    std::string_view name() const noexcept override         { return "tidal"; }
+    std::string_view display_name() const noexcept override { return "Tidal Music"; }
+
+    bool initialize() override;
+    void shutdown() noexcept override;
+
+    void play() override;
+    void pause() override;
+    void stop() override;
+    void next() override;
+    void previous() override;
+    void pump(RingBuffer& ring) override;
+
+    // Hot configuration updates from the dashboard settings drawer.
+    void set_config(TidalConfig cfg);
+    void set_ffmpeg_path(std::filesystem::path p);
+
+    // Dynamic playlist cast (e.g. POST /api/source/tidal/cast)
+    bool cast(std::string playlist_id);
+
+    // Exchange standard OAuth2 Authorization Code
+    bool exchange_authorization_code(const std::string& code);
+
+    void set_playback_options(const PlaybackConfig& opts) override;
+
+    TrackInfo current_track() const override;
+
+    struct QueueSnapshot {
+        std::size_t cursor = 0;
+        std::vector<TidalTrack> entries;
+    };
+    QueueSnapshot queue_snapshot() const;
+    bool jump_to(std::size_t index);
+    std::size_t track_count() const;
+    std::size_t current_index() const;
+    PlaybackState playback_state() const noexcept override {
+        return state_.load(std::memory_order_acquire);
+    }
+    AuthState auth_state() const noexcept override {
+        return auth_.load(std::memory_order_acquire);
+    }
+    std::string auth_instructions() const override;
+    SourceCapabilities capabilities() const noexcept override { return {false, true, true}; }
+
+private:
+    struct Pipe;
+
+    // mu_ held
+    bool refresh_queue_locked();
+    std::unique_ptr<Pipe> spawn_pipe_locked(std::size_t for_idx);
+    void start_pipe_locked();
+    void stop_pipe_locked();
+    void discard_prefetch_locked() noexcept;
+    bool promote_prefetch_locked(std::size_t expected_idx);
+    void maybe_spawn_prefetch_locked();
+    std::size_t next_queue_idx_locked() const noexcept;
+    void advance_locked(std::ptrdiff_t step);
+
+    // Background thread for Device Code polling & Token refreshing
+    void run_auth_loop();
+    void stop_auth_thread() noexcept;
+    bool refresh_access_token();
+
+    TidalConfig cfg_;
+    std::filesystem::path ffmpeg_path_;
+    ConfigStore& store_;
+
+    mutable std::mutex mu_;
+    std::vector<TidalTrack> queue_;
+    std::size_t current_idx_ = 0;
+    std::unique_ptr<Pipe> pipe_;
+    std::unique_ptr<Pipe> prefetch_;
+    std::atomic<PlaybackState> state_{PlaybackState::stopped};
+
+    // OAuth2 Device Auth state
+    std::atomic<AuthState> auth_{AuthState::none_required};
+    std::string auth_user_code_;
+    std::string auth_verification_uri_;
+    std::thread auth_thread_;
+    std::atomic<bool> stop_auth_thread_{false};
+
+    EqualizerStage eq_;
+    std::atomic<bool> volume_norm_{false};
+    std::atomic<bool> prebuffer_next_{true};
+};
+
+} // namespace fh6::sources

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,6 +93,7 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -206,6 +207,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -254,6 +256,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1074,9 +1077,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1091,9 +1091,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1108,9 +1105,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1125,9 +1119,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1142,9 +1133,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1159,9 +1147,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1176,9 +1161,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1193,9 +1175,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1210,9 +1189,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1227,9 +1203,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1244,9 +1217,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1261,9 +1231,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1278,9 +1245,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1504,6 +1468,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1856,6 +1821,7 @@
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mdn-data": "2.27.1",
         "source-map-js": "^1.2.1"
@@ -2146,6 +2112,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2938,6 +2905,7 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -3436,6 +3404,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -3485,6 +3454,7 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -4225,6 +4195,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -65,6 +65,10 @@ Copy-Item (Join-Path $build "Release\version.dll") $dist
 Copy-Item (Join-Path $build "Release\fh6-radio-worker.exe") (Join-Path $dist "fh6-radio")
 Copy-Item -Recurse (Join-Path $root "ui\dist") (Join-Path $dist "fh6-radio\ui")
 Copy-Item (Join-Path $root "config.example.toml") (Join-Path $dist "fh6-radio\config.toml")
+Copy-Item (Join-Path $root "src\sources\tidal_helper.py") (Join-Path $dist "fh6-radio\tidal_helper.py")
+if (Test-Path (Join-Path $root "python-tidal\tidalapi")) {
+    Copy-Item -Recurse -Force (Join-Path $root "python-tidal\tidalapi") (Join-Path $dist "fh6-radio\tidalapi")
+}
 
 Copy-Item (Join-Path $PSScriptRoot "dist-readme.txt") (Join-Path $dist "README.txt")
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -57,6 +57,10 @@ cp "$build/version.dll"            "$dist/"
 cp "$build/fh6-radio-worker.exe"   "$dist/fh6-radio/"
 cp -r "$root/ui/dist"              "$dist/fh6-radio/ui"
 cp "$root/config.example.toml"     "$dist/fh6-radio/config.toml"
+cp "$root/src/sources/tidal_helper.py" "$dist/fh6-radio/tidal_helper.py"
+if [ -d "$root/python-tidal/tidalapi" ]; then
+    cp -r "$root/python-tidal/tidalapi" "$dist/fh6-radio/tidalapi"
+fi
 
 cp "$root/scripts/dist-readme.txt" "$dist/README.txt"
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -38,6 +38,12 @@ Backup-AndCopy (Join-Path $dist "version.dll") (Join-Path $GameDir "version.dll"
 $dataDir = Join-Path $GameDir "fh6-radio"
 if (-not (Test-Path $dataDir)) { New-Item -ItemType Directory -Force -Path $dataDir | Out-Null }
 Copy-Item -Recurse -Force (Join-Path $dist "fh6-radio\ui") $dataDir
+if (Test-Path (Join-Path $dist "fh6-radio\tidal_helper.py")) {
+    Copy-Item -Force (Join-Path $dist "fh6-radio\tidal_helper.py") $dataDir
+}
+if (Test-Path (Join-Path $dist "fh6-radio\tidalapi")) {
+    Copy-Item -Recurse -Force (Join-Path $dist "fh6-radio\tidalapi") $dataDir
+}
 $cfg = Join-Path $dataDir "config.toml"
 if (-not (Test-Path $cfg)) {
     Copy-Item (Join-Path $dist "fh6-radio\config.toml") $cfg

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -39,6 +39,12 @@ backup_and_copy "$dist/version.dll" "$game/version.dll"
 
 mkdir -p "$game/fh6-radio"
 cp -rfT "$dist/fh6-radio/ui" "$game/fh6-radio/ui"
+if [ -f "$dist/fh6-radio/tidal_helper.py" ]; then
+    cp "$dist/fh6-radio/tidal_helper.py" "$game/fh6-radio/tidal_helper.py"
+fi
+if [ -d "$dist/fh6-radio/tidalapi" ]; then
+    cp -rfT "$dist/fh6-radio/tidalapi" "$game/fh6-radio/tidalapi"
+fi
 if [ ! -f "$game/fh6-radio/config.toml" ]; then
     cp "$dist/fh6-radio/config.toml" "$game/fh6-radio/config.toml"
     printf '\033[33m  + fh6-radio/config.toml  (seeded from example)\033[0m\n'

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -17,6 +17,7 @@
 #include "fh6/sources/spotify_source.hpp"
 #include "fh6/worker/worker_client.hpp"
 #include "fh6/sources/online_radio_source.hpp"
+#include "fh6/sources/tidal_source.hpp"
 
 #include <windows.h>
 #include <array>
@@ -168,7 +169,7 @@ void run_bridge(HMODULE self) noexcept {
     // Register/unregister sources to match the enabled flags. Called at
     // startup and on every config change so toggling enabled adds/removes
     // the dashboard tile live, without a game restart.
-    auto sync_sources = [&mgr, &data_dir, &worker](const Config& c) {
+    auto sync_sources = [&mgr, &data_dir, &worker, &store](const Config& c) {
         if (c.local_files.enabled && !mgr.find("local_files")) {
             auto src = std::make_unique<sources::LocalFileSource>(
                 c.local_files, c.general.ffmpeg_path, data_dir / "local_index.json", &worker);
@@ -197,6 +198,12 @@ void run_bridge(HMODULE self) noexcept {
             if (src->initialize()) mgr.register_source(std::move(src));
         } else if (!c.online_radio.enabled && mgr.find("online_radio")) {
             mgr.unregister_source("online_radio");
+        }
+        if (c.tidal.enabled && !mgr.find("tidal")) {
+            auto src = std::make_unique<sources::TidalSource>(c.tidal, c.general.ffmpeg_path, store);
+            if (src->initialize()) mgr.register_source(std::move(src));
+        } else if (!c.tidal.enabled && mgr.find("tidal")) {
+            mgr.unregister_source("tidal");
         }
 
         if (c.external_audio.enabled && !mgr.find("external_audio")) {
@@ -282,6 +289,10 @@ void run_bridge(HMODULE self) noexcept {
         if (auto* jf = dynamic_cast<sources::JellyfinSource*>(mgr.find("jellyfin"))) {
             jf->set_ffmpeg_path(c.general.ffmpeg_path);
             jf->set_config(c.jellyfin);
+        }
+        if (auto* td = dynamic_cast<sources::TidalSource*>(mgr.find("tidal"))) {
+            td->set_ffmpeg_path(c.general.ffmpeg_path);
+            td->set_config(c.tidal);
         }
         if (auto* ext = dynamic_cast<sources::ExternalAudioSource*>(mgr.find("external_audio"))) {
             ext->set_config(c.external_audio);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -117,6 +117,16 @@ Config load_config(const std::filesystem::path& path) {
     cfg.youtube_music.yt_dlp_path      = pick_path(ym, "yt_dlp_path");
     cfg.youtube_music.default_playlist = pick<std::string>(ym, "default_playlist", "");
     cfg.youtube_music.shuffle          = pick<bool>(ym, "shuffle", cfg.youtube_music.shuffle);
+    const auto& td = section(root, "tidal");
+    cfg.tidal.enabled = pick<bool>(td, "enabled", cfg.tidal.enabled);
+    cfg.tidal.client_id = pick<std::string>(td, "client_id", cfg.tidal.client_id);
+    cfg.tidal.client_secret = pick<std::string>(td, "client_secret", cfg.tidal.client_secret);
+    cfg.tidal.access_token = pick<std::string>(td, "access_token", cfg.tidal.access_token);
+    cfg.tidal.refresh_token = pick<std::string>(td, "refresh_token", cfg.tidal.refresh_token);
+    cfg.tidal.expiry_time = static_cast<uint64_t>(pick<int64_t>(td, "expiry_time", cfg.tidal.expiry_time));
+    cfg.tidal.default_playlist = pick<std::string>(td, "default_playlist", cfg.tidal.default_playlist);
+    cfg.tidal.shuffle = pick<bool>(td, "shuffle", cfg.tidal.shuffle);
+    cfg.tidal.audio_quality = pick<std::string>(td, "audio_quality", cfg.tidal.audio_quality);
 
     const auto& sp             = section(root, "spotify");
     cfg.spotify.enabled        = pick<bool>(sp, "enabled", cfg.spotify.enabled);
@@ -331,6 +341,16 @@ void save_config(const std::filesystem::path& path, const Config& cfg) {
     e.kv_path("yt_dlp_path", cfg.youtube_music.yt_dlp_path);
     e.kv("default_playlist", cfg.youtube_music.default_playlist);
     e.kv("shuffle", cfg.youtube_music.shuffle);
+    e.header("tidal");
+    e.kv("enabled", cfg.tidal.enabled);
+    e.kv("client_id", cfg.tidal.client_id);
+    e.kv("client_secret", cfg.tidal.client_secret);
+    e.kv("access_token", cfg.tidal.access_token);
+    e.kv("refresh_token", cfg.tidal.refresh_token);
+    e.kv("expiry_time", (int64_t)cfg.tidal.expiry_time);
+    e.kv("default_playlist", cfg.tidal.default_playlist);
+    e.kv("shuffle", cfg.tidal.shuffle);
+    e.kv("audio_quality", cfg.tidal.audio_quality);
 
     e.header("jellyfin");
     e.kv("enabled", cfg.jellyfin.enabled);

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -7,6 +7,7 @@
 #include "fh6/sources/local_file_source.hpp"
 #include "fh6/sources/youtube_music_source.hpp"
 #include "fh6/sources/jellyfin_source.hpp"
+#include "fh6/sources/tidal_source.hpp"
 #include "fh6/sources/external_audio_source.hpp"
 #include "fh6/sources/external_media_session.hpp"
 #include "fh6/sources/spotify_source.hpp"
@@ -110,6 +111,10 @@ json source_to_json(IAudioSource* s) {
         j["details"]["shuffle"] = yt->shuffle();
     if (auto* rd = dynamic_cast<sources::OnlineRadioSource*>(s))
         j["details"]["song_history"] = rd->song_history();
+    if (auto* td = dynamic_cast<sources::TidalSource*>(s)) {
+        j["details"]["track_count"]   = td->track_count();
+        j["details"]["current_index"] = td->current_index();
+    }
     return j;
 }
 
@@ -171,6 +176,18 @@ json config_to_json(const Config& c) {
              {"default_playlist", c.jellyfin.default_playlist},
              {"use_favorites", c.jellyfin.use_favorites},
              {"shuffle", c.jellyfin.shuffle},
+         }},
+        {"tidal",
+         json{
+             {"enabled", c.tidal.enabled},
+             {"client_id", c.tidal.client_id},
+             {"client_secret", c.tidal.client_secret},
+             {"access_token", c.tidal.access_token},
+             {"refresh_token", c.tidal.refresh_token},
+             {"expiry_time", c.tidal.expiry_time},
+             {"default_playlist", c.tidal.default_playlist},
+             {"shuffle", c.tidal.shuffle},
+             {"audio_quality", c.tidal.audio_quality},
          }},
         {"external_audio",
          json{
@@ -296,6 +313,17 @@ void apply_patch(Config& c, const json& j) {
         c.jellyfin.default_playlist = pull(*it, "default_playlist", c.jellyfin.default_playlist);
         c.jellyfin.use_favorites    = pull(*it, "use_favorites", c.jellyfin.use_favorites);
         c.jellyfin.shuffle          = pull(*it, "shuffle", c.jellyfin.shuffle);
+    }
+    if (auto it = j.find("tidal"); it != j.end()) {
+        c.tidal.enabled          = pull(*it, "enabled", c.tidal.enabled);
+        c.tidal.client_id        = pull(*it, "client_id", c.tidal.client_id);
+        c.tidal.client_secret    = pull(*it, "client_secret", c.tidal.client_secret);
+        c.tidal.access_token     = pull(*it, "access_token", c.tidal.access_token);
+        c.tidal.refresh_token    = pull(*it, "refresh_token", c.tidal.refresh_token);
+        c.tidal.expiry_time      = static_cast<uint64_t>(pull(*it, "expiry_time", static_cast<int64_t>(c.tidal.expiry_time)));
+        c.tidal.default_playlist = pull(*it, "default_playlist", c.tidal.default_playlist);
+        c.tidal.shuffle          = pull(*it, "shuffle", c.tidal.shuffle);
+        c.tidal.audio_quality    = pull(*it, "audio_quality", c.tidal.audio_quality);
     }
     if (auto it = j.find("external_audio"); it != j.end()) {
         c.external_audio.enabled     = pull(*it, "enabled", c.external_audio.enabled);
@@ -477,6 +505,33 @@ bool serve_file(SOCKET client, const std::filesystem::path& file) {
     return true;
 }
 
+std::string get_query_param(std::string_view path, std::string_view name) {
+    size_t q = path.find('?');
+    if (q == std::string_view::npos) return {};
+    std::string_view query = path.substr(q + 1);
+    
+    size_t pos = 0;
+    while (true) {
+        pos = query.find(name, pos);
+        if (pos == std::string_view::npos) return {};
+        
+        bool prefix_ok = (pos == 0 || query[pos - 1] == '&');
+        size_t next_idx = pos + name.size();
+        bool suffix_ok = (next_idx < query.size() && query[next_idx] == '=');
+        
+        if (prefix_ok && suffix_ok) {
+            size_t start = next_idx + 1;
+            size_t end = query.find('&', start);
+            if (end == std::string_view::npos) {
+                return std::string(query.substr(start));
+            } else {
+                return std::string(query.substr(start, end - start));
+            }
+        }
+        pos += 1;
+    }
+}
+
 } // namespace
 
 struct HttpServer::Impl {
@@ -655,6 +710,168 @@ struct HttpServer::Impl {
             deps.retry();
             return ok();
         }
+        if (m == "GET" && p.starts_with("/api/source/tidal/callback")) {
+            auto* td = find_typed<sources::TidalSource>("tidal");
+            if (!td) return fail(404, "TIDAL not registered");
+
+            std::string code = get_query_param(p, "code");
+            if (code.empty()) {
+                const char* html = R"html(<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>TIDAL Link Failed</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            background-color: #0b0c10;
+            color: #c5c6c7;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+            margin: 0;
+        }
+        .container {
+            text-align: center;
+            padding: 2.5rem;
+            background-color: #1f2833;
+            border-radius: 12px;
+            box-shadow: 0 8px 30px rgba(0, 0, 0, 0.5);
+            max-width: 480px;
+        }
+        h1 {
+            color: #ff4d4d;
+            margin-bottom: 1rem;
+        }
+        p {
+            font-size: 1.1rem;
+            line-height: 1.6;
+            margin-bottom: 2rem;
+        }
+        .cross {
+            font-size: 4rem;
+            color: #ff4d4d;
+            margin-bottom: 1rem;
+            display: inline-block;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="cross">✗</div>
+        <h1>TIDAL Link Failed</h1>
+        <p>No authorization code was found in the query parameters. Please restart the link process from the settings drawer.</p>
+    </div>
+</body>
+</html>)html";
+                return send_response(client, 400, html, "text/html");
+            }
+
+            if (td->exchange_authorization_code(code)) {
+                const char* html = R"html(<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>TIDAL Link Successful</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            background-color: #0b0c10;
+            color: #c5c6c7;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+            margin: 0;
+        }
+        .container {
+            text-align: center;
+            padding: 2.5rem;
+            background-color: #1f2833;
+            border-radius: 12px;
+            box-shadow: 0 8px 30px rgba(0, 0, 0, 0.5);
+            max-width: 480px;
+        }
+        h1 {
+            color: #66fcf1;
+            margin-bottom: 1rem;
+        }
+        p {
+            font-size: 1.1rem;
+            line-height: 1.6;
+            margin-bottom: 2rem;
+        }
+        .checkmark {
+            font-size: 4rem;
+            color: #45f3ff;
+            margin-bottom: 1rem;
+            display: inline-block;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="checkmark">✓</div>
+        <h1>TIDAL Linked Successfully!</h1>
+        <p>Your TIDAL account has been connected to FH6 Universal Radio. You can close this window and return to the game dashboard.</p>
+    </div>
+</body>
+</html>)html";
+                return send_response(client, 200, html, "text/html");
+            } else {
+                const char* html = R"html(<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>TIDAL Link Failed</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            background-color: #0b0c10;
+            color: #c5c6c7;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+            margin: 0;
+        }
+        .container {
+            text-align: center;
+            padding: 2.5rem;
+            background-color: #1f2833;
+            border-radius: 12px;
+            box-shadow: 0 8px 30px rgba(0, 0, 0, 0.5);
+            max-width: 480px;
+        }
+        h1 {
+            color: #ff4d4d;
+            margin-bottom: 1rem;
+        }
+        p {
+            font-size: 1.1rem;
+            line-height: 1.6;
+            margin-bottom: 2rem;
+        }
+        .cross {
+            font-size: 4rem;
+            color: #ff4d4d;
+            margin-bottom: 1rem;
+            display: inline-block;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="cross">✗</div>
+        <h1>TIDAL Link Failed</h1>
+        <p>Failed to exchange authorization code for tokens. Please check your developer credentials (Client ID and Secret) and try again.</p>
+    </div>
+</body>
+</html>)html";
+                return send_response(client, 400, html, "text/html");
+            }
+        }
         if (m == "GET" && p == "/api/source/local_files/queue") {
             auto* lf = find_typed<sources::LocalFileSource>("local_files");
             if (!lf) return fail(404, "local_files not registered");
@@ -745,6 +962,13 @@ struct HttpServer::Impl {
         }
         if (m == "POST" && p == "/api/source/switch") {
             auto src = json::parse(req.body).at("source").get<std::string>();
+            if (src == "tidal") {
+                if (auto* td = find_typed<sources::TidalSource>("tidal")) {
+                    if (td->auth_state() != AuthState::authenticated) {
+                        return fail(400, "TIDAL is not authenticated. Please link your account.");
+                    }
+                }
+            }
             return mgr.switch_to(src) ? ok() : fail(404, "unknown source");
         }
         if (m == "GET" && p == "/api/external_audio/devices") {
@@ -843,6 +1067,42 @@ struct HttpServer::Impl {
             if (was_active) mgr.ring().drain();
             rd->play();
             mgr.switch_to("online_radio");
+            return ok();
+        }
+        if (m == "POST" && p == "/api/source/tidal/cast") {
+            auto* td = find_typed<sources::TidalSource>("tidal");
+            if (!td) return fail(404, "tidal not registered");
+            if (td->auth_state() != AuthState::authenticated) {
+                return fail(401, "TIDAL is not authenticated. Please link your account first.");
+            }
+            auto playlist_id = json::parse(req.body).value("playlist_id", std::string{});
+            if (playlist_id.empty()) return fail(400, "playlist_id required");
+            const bool was_active = (mgr.active() == td);
+            if (!td->cast(std::move(playlist_id))) return fail(502, "TIDAL playlist cast failed");
+            if (was_active) mgr.ring().drain();
+            mgr.switch_to("tidal");
+            return ok();
+        }
+        if (m == "GET" && p == "/api/source/tidal/queue") {
+            auto* td = find_typed<sources::TidalSource>("tidal");
+            if (!td) return fail(404, "tidal not registered");
+            auto snap   = td->queue_snapshot();
+            json tracks = json::array();
+            for (std::size_t i = 0; i < snap.entries.size(); ++i) {
+                const auto& e = snap.entries[i];
+                tracks.push_back(
+                    json{{"index", i}, {"title", e.title}, {"artist", e.artist}, {"album", e.album}, {"artwork_url", e.artwork_url}});
+            }
+            return ok(json{{"cursor", snap.cursor}, {"tracks", tracks}});
+        }
+        if (m == "POST" && p == "/api/source/tidal/play") {
+            auto* td = find_typed<sources::TidalSource>("tidal");
+            if (!td) return fail(404, "tidal not registered");
+            auto idx              = json::parse(req.body).value("index", std::size_t{0});
+            const bool was_active = (mgr.active() == td);
+            if (!td->jump_to(idx)) return fail(400, "index out of range");
+            if (was_active) mgr.ring().drain();
+            mgr.switch_to("tidal");
             return ok();
         }
         if (m == "POST" && p == "/api/source/local_files/rescan") {

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -181,9 +181,9 @@ json config_to_json(const Config& c) {
          json{
              {"enabled", c.tidal.enabled},
              {"client_id", c.tidal.client_id},
-             {"client_secret", c.tidal.client_secret},
-             {"access_token", c.tidal.access_token},
-             {"refresh_token", c.tidal.refresh_token},
+             {"client_secret", c.tidal.client_secret.empty() ? "" : "********"},
+             {"has_access_token", !c.tidal.access_token.empty()},
+             {"has_refresh_token", !c.tidal.refresh_token.empty()},
              {"expiry_time", c.tidal.expiry_time},
              {"default_playlist", c.tidal.default_playlist},
              {"shuffle", c.tidal.shuffle},
@@ -317,10 +317,17 @@ void apply_patch(Config& c, const json& j) {
     if (auto it = j.find("tidal"); it != j.end()) {
         c.tidal.enabled          = pull(*it, "enabled", c.tidal.enabled);
         c.tidal.client_id        = pull(*it, "client_id", c.tidal.client_id);
-        c.tidal.client_secret    = pull(*it, "client_secret", c.tidal.client_secret);
+        std::string secret       = pull(*it, "client_secret", c.tidal.client_secret);
+        if (secret != "********") {
+            c.tidal.client_secret = secret;
+        }
         c.tidal.access_token     = pull(*it, "access_token", c.tidal.access_token);
         c.tidal.refresh_token    = pull(*it, "refresh_token", c.tidal.refresh_token);
-        c.tidal.expiry_time      = static_cast<uint64_t>(pull(*it, "expiry_time", static_cast<int64_t>(c.tidal.expiry_time)));
+        int64_t expiry_tmp       = pull(*it, "expiry_time", static_cast<int64_t>(c.tidal.expiry_time));
+        if (expiry_tmp < 0) {
+            expiry_tmp = 0;
+        }
+        c.tidal.expiry_time      = static_cast<uint64_t>(expiry_tmp);
         c.tidal.default_playlist = pull(*it, "default_playlist", c.tidal.default_playlist);
         c.tidal.shuffle          = pull(*it, "shuffle", c.tidal.shuffle);
         c.tidal.audio_quality    = pull(*it, "audio_quality", c.tidal.audio_quality);
@@ -400,6 +407,7 @@ constexpr std::string_view status_text(int code) noexcept {
     switch (code) {
         case 200: return "OK";
         case 400: return "Bad Request";
+        case 401: return "Unauthorized";
         case 404: return "Not Found";
         case 502: return "Bad Gateway";
         default: return "Internal Server Error";
@@ -505,6 +513,40 @@ bool serve_file(SOCKET client, const std::filesystem::path& file) {
     return true;
 }
 
+std::string url_decode(std::string_view str) {
+    std::string decoded;
+    decoded.reserve(str.size());
+    for (size_t i = 0; i < str.size(); ++i) {
+        if (str[i] == '%') {
+            if (i + 2 < str.size()) {
+                char hex1 = str[i + 1];
+                char hex2 = str[i + 2];
+                if (std::isxdigit(static_cast<unsigned char>(hex1)) &&
+                    std::isxdigit(static_cast<unsigned char>(hex2))) {
+                    auto hex_val = [](char c) -> int {
+                        if (c >= '0' && c <= '9') return c - '0';
+                        if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+                        if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+                        return 0;
+                    };
+                    char decoded_char = static_cast<char>((hex_val(hex1) << 4) + hex_val(hex2));
+                    decoded += decoded_char;
+                    i += 2;
+                } else {
+                    return {}; // Invalid escape
+                }
+            } else {
+                return {}; // Invalid escape
+            }
+        } else if (str[i] == '+') {
+            decoded += ' ';
+        } else {
+            decoded += str[i];
+        }
+    }
+    return decoded;
+}
+
 std::string get_query_param(std::string_view path, std::string_view name) {
     size_t q = path.find('?');
     if (q == std::string_view::npos) return {};
@@ -523,9 +565,9 @@ std::string get_query_param(std::string_view path, std::string_view name) {
             size_t start = next_idx + 1;
             size_t end = query.find('&', start);
             if (end == std::string_view::npos) {
-                return std::string(query.substr(start));
+                return url_decode(query.substr(start));
             } else {
-                return std::string(query.substr(start, end - start));
+                return url_decode(query.substr(start, end - start));
             }
         }
         pos += 1;

--- a/src/sources/tidal_helper.py
+++ b/src/sources/tidal_helper.py
@@ -98,11 +98,11 @@ def main():
     subcommand = sys.argv[1]
 
     if subcommand == "login":
-        client_id = ""
-        client_secret = ""
-        if len(sys.argv) > 2 and sys.argv[2] != "" and sys.argv[2] != '""':
+        client_id = os.environ.get("TIDAL_CLIENT_ID", "")
+        client_secret = os.environ.get("TIDAL_CLIENT_SECRET", "")
+        if not client_id and len(sys.argv) > 2 and sys.argv[2] != "" and sys.argv[2] != '""':
             client_id = sys.argv[2]
-        if len(sys.argv) > 3 and sys.argv[3] != "" and sys.argv[3] != '""':
+        if not client_secret and len(sys.argv) > 3 and sys.argv[3] != "" and sys.argv[3] != '""':
             client_secret = sys.argv[3]
 
         session = tidalapi.Session()
@@ -146,17 +146,20 @@ def main():
             print(json.dumps({"status": "error", "error": "Session verification failed after login"}), flush=True)
 
     elif subcommand == "refresh":
-        if len(sys.argv) < 3:
+        refresh_token = os.environ.get("TIDAL_REFRESH_TOKEN", "")
+        client_id = os.environ.get("TIDAL_CLIENT_ID", "")
+        client_secret = os.environ.get("TIDAL_CLIENT_SECRET", "")
+
+        if not refresh_token and len(sys.argv) > 2:
+            refresh_token = sys.argv[2]
+        if not client_id and len(sys.argv) > 3 and sys.argv[3] != "" and sys.argv[3] != '""':
+            client_id = sys.argv[3]
+        if not client_secret and len(sys.argv) > 4 and sys.argv[4] != "" and sys.argv[4] != '""':
+            client_secret = sys.argv[4]
+
+        if not refresh_token:
             print(json.dumps({"status": "error", "error": "Missing refresh_token"}), flush=True)
             sys.exit(1)
-
-        refresh_token = sys.argv[2]
-        client_id = ""
-        client_secret = ""
-        if len(sys.argv) > 3 and sys.argv[3] != "" and sys.argv[3] != '""':
-            client_id = sys.argv[3]
-        if len(sys.argv) > 4 and sys.argv[4] != "" and sys.argv[4] != '""':
-            client_secret = sys.argv[4]
 
         session = tidalapi.Session()
         if client_id:
@@ -193,12 +196,19 @@ def main():
             handle_exception("Token refresh failed", e)
 
     elif subcommand == "playlist":
-        if len(sys.argv) < 4:
-            print(json.dumps({"status": "error", "error": "Usage: playlist <playlist_id> <access_token>"}), flush=True)
+        access_token = os.environ.get("TIDAL_ACCESS_TOKEN", "")
+        if not access_token and len(sys.argv) > 3:
+            access_token = sys.argv[3]
+
+        if len(sys.argv) < 3:
+            print(json.dumps({"status": "error", "error": "Usage: playlist <playlist_id> [access_token]"}), flush=True)
             sys.exit(1)
 
         playlist_id = sys.argv[2]
-        access_token = sys.argv[3]
+
+        if not access_token:
+            print(json.dumps({"status": "error", "error": "Missing access_token"}), flush=True)
+            sys.exit(1)
 
         session = tidalapi.Session()
         loaded = session.load_oauth_session("Bearer", access_token)
@@ -259,13 +269,23 @@ def main():
             handle_exception("Failed to fetch tracks", e)
 
     elif subcommand == "stream":
-        if len(sys.argv) < 5:
-            print(json.dumps({"status": "error", "error": "Usage: stream <track_id> <access_token> <quality>"}), flush=True)
+        access_token = os.environ.get("TIDAL_ACCESS_TOKEN", "")
+        
+        if len(sys.argv) == 4:
+            track_id = sys.argv[2]
+            quality_str = sys.argv[3]
+        elif len(sys.argv) >= 5:
+            track_id = sys.argv[2]
+            if not access_token:
+                access_token = sys.argv[3]
+            quality_str = sys.argv[4]
+        else:
+            print(json.dumps({"status": "error", "error": "Usage: stream <track_id> <quality>"}), flush=True)
             sys.exit(1)
 
-        track_id = sys.argv[2]
-        access_token = sys.argv[3]
-        quality_str = sys.argv[4]
+        if not access_token:
+            print(json.dumps({"status": "error", "error": "Missing access_token"}), flush=True)
+            sys.exit(1)
 
         session = tidalapi.Session()
         loaded = session.load_oauth_session("Bearer", access_token)

--- a/src/sources/tidal_helper.py
+++ b/src/sources/tidal_helper.py
@@ -1,0 +1,320 @@
+import sys
+import os
+import json
+import time
+import datetime
+import tempfile
+import subprocess
+from pathlib import Path
+
+# Helper directory and venv directory
+helper_dir = Path(__file__).parent.resolve()
+venv_dir = helper_dir / "venv"
+
+if sys.platform == "win32":
+    venv_python = venv_dir / "Scripts" / "python.exe"
+else:
+    venv_python = venv_dir / "bin" / "python"
+
+# Check if we are running in our local venv
+in_venv = (Path(sys.prefix).resolve() == venv_dir.resolve())
+
+if not in_venv:
+    try:
+        # Create venv if it doesn't exist
+        if not venv_dir.exists():
+            print("Creating local virtual environment (venv) inside fh6-radio...", file=sys.stderr)
+            subprocess.check_call([sys.executable, "-m", "venv", str(venv_dir)], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        
+        # Check if tidalapi is installed inside the venv
+        try:
+            subprocess.check_call([str(venv_python), "-c", "import tidalapi"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            has_tidalapi = True
+        except subprocess.CalledProcessError:
+            has_tidalapi = False
+
+        if not has_tidalapi:
+            print("Installing tidalapi to local virtual environment...", file=sys.stderr)
+            subprocess.check_call([str(venv_python), "-m", "pip", "install", "tidalapi"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        
+        # Re-execute using the venv python
+        res = subprocess.run([str(venv_python), "-u"] + sys.argv, capture_output=False)
+        sys.exit(res.returncode)
+    except Exception as e:
+        print(json.dumps({
+            "status": "error", 
+            "error": f"Failed to bootstrap virtual environment: {str(e)}"
+        }), flush=True)
+        sys.exit(1)
+
+# Add local search paths for tidalapi (as fallback)
+sys.path.insert(0, str(helper_dir / "python-tidal"))
+sys.path.insert(0, str(helper_dir))
+
+try:
+    import requests
+    import dateutil
+    import typing_extensions
+    import ratelimit
+    import isodate
+    import mpegdash
+    import pyaes
+    import tidalapi
+    from tidalapi import Quality
+except ImportError as e:
+    print(json.dumps({
+        "status": "error",
+        "error": f"Failed to import tidalapi: {str(e)}"
+    }), flush=True)
+    sys.exit(1)
+
+def handle_exception(context, exc):
+    import requests
+    if isinstance(exc, requests.exceptions.HTTPError):
+        resp = exc.response
+        details = resp.text
+        try:
+            js = resp.json()
+            if "error_description" in js:
+                details = js["error_description"]
+            elif "error" in js:
+                details = js["error"]
+            elif "message" in js:
+                details = js["message"]
+        except:
+            pass
+        
+        err_msg = f"{context}: HTTP {resp.status_code} {resp.reason} ({details}) for URL: {resp.url}"
+        print(json.dumps({"status": "error", "error": err_msg}), flush=True)
+    else:
+        err_msg = f"{context}: {str(exc)}"
+        print(json.dumps({"status": "error", "error": err_msg}), flush=True)
+
+def main():
+    if len(sys.argv) < 2:
+        print(json.dumps({"status": "error", "error": "Missing subcommand (login, refresh, playlist, stream)"}), flush=True)
+        sys.exit(1)
+
+    subcommand = sys.argv[1]
+
+    if subcommand == "login":
+        client_id = ""
+        client_secret = ""
+        if len(sys.argv) > 2 and sys.argv[2] != "" and sys.argv[2] != '""':
+            client_id = sys.argv[2]
+        if len(sys.argv) > 3 and sys.argv[3] != "" and sys.argv[3] != '""':
+            client_secret = sys.argv[3]
+
+        session = tidalapi.Session()
+        if client_id:
+            session.config.client_id = client_id
+            if client_secret:
+                session.config.client_secret = client_secret
+            else:
+                session.config.client_secret = client_id
+
+        try:
+            login, future = session.login_oauth()
+        except Exception as e:
+            handle_exception("Failed to start OAuth flow", e)
+            sys.exit(1)
+
+        # Print verification URL and user code immediately to stdout for C++ to parse
+        print(json.dumps({
+            "verification_uri": login.verification_uri_complete,
+            "user_code": login.user_code
+        }), flush=True)
+
+        # Block until authenticated or timeout
+        try:
+            future.result()
+        except Exception as e:
+            handle_exception("Authentication polling failed", e)
+            sys.exit(1)
+
+        if session.check_login():
+            expires_in = 3600
+            if session.expiry_time:
+                expires_in = int((session.expiry_time - datetime.datetime.utcnow()).total_seconds())
+            print(json.dumps({
+                "status": "success",
+                "access_token": session.access_token,
+                "refresh_token": session.refresh_token,
+                "expires_in": expires_in
+            }), flush=True)
+        else:
+            print(json.dumps({"status": "error", "error": "Session verification failed after login"}), flush=True)
+
+    elif subcommand == "refresh":
+        if len(sys.argv) < 3:
+            print(json.dumps({"status": "error", "error": "Missing refresh_token"}), flush=True)
+            sys.exit(1)
+
+        refresh_token = sys.argv[2]
+        client_id = ""
+        client_secret = ""
+        if len(sys.argv) > 3 and sys.argv[3] != "" and sys.argv[3] != '""':
+            client_id = sys.argv[3]
+        if len(sys.argv) > 4 and sys.argv[4] != "" and sys.argv[4] != '""':
+            client_secret = sys.argv[4]
+
+        session = tidalapi.Session()
+        if client_id:
+            session.config.client_id = client_id
+            if client_secret:
+                session.config.client_secret = client_secret
+            else:
+                session.config.client_secret = client_id
+
+        try:
+            success = session.token_refresh(refresh_token)
+            if success:
+                loaded = session.load_oauth_session(
+                    token_type="Bearer",
+                    access_token=session.access_token,
+                    refresh_token=session.refresh_token,
+                    expiry_time=session.expiry_time
+                )
+                if loaded and session.check_login():
+                    expires_in = 3600
+                    if session.expiry_time:
+                        expires_in = int((session.expiry_time - datetime.datetime.utcnow()).total_seconds())
+                    print(json.dumps({
+                        "status": "success",
+                        "access_token": session.access_token,
+                        "refresh_token": session.refresh_token,
+                        "expires_in": expires_in
+                    }), flush=True)
+                else:
+                    print(json.dumps({"status": "error", "error": "Token refresh failed session validation"}), flush=True)
+            else:
+                print(json.dumps({"status": "error", "error": "Token refresh failed"}), flush=True)
+        except Exception as e:
+            handle_exception("Token refresh failed", e)
+
+    elif subcommand == "playlist":
+        if len(sys.argv) < 4:
+            print(json.dumps({"status": "error", "error": "Usage: playlist <playlist_id> <access_token>"}), flush=True)
+            sys.exit(1)
+
+        playlist_id = sys.argv[2]
+        access_token = sys.argv[3]
+
+        session = tidalapi.Session()
+        loaded = session.load_oauth_session("Bearer", access_token)
+        if not loaded:
+            print(json.dumps({"status": "error", "error": "Failed to load OAuth session with provided access token"}), flush=True)
+            sys.exit(1)
+
+        try:
+            # Try loading as playlist first, fall back to mix if it fails
+            try:
+                playlist = session.playlist(playlist_id)
+                # Cap at 500 tracks to avoid large pagination/parsing delays and memory bloat
+                tracks = playlist.tracks(limit=500)
+            except Exception as playlist_err:
+                try:
+                    mix = session.mix(playlist_id)
+                    # For mixes, retrieve all items (which are Track or Video objects)
+                    tracks = mix.items()
+                    # Cap at 500 tracks
+                    tracks = tracks[:500]
+                except Exception as mix_err:
+                    raise Exception(f"Failed as playlist ({str(playlist_err)}) and as mix ({str(mix_err)})")
+
+            tracks_json = []
+            for track in tracks:
+                # Skip video entries in mixes
+                if type(track).__name__ == 'Video':
+                    continue
+
+                if hasattr(track, 'artists') and track.artists:
+                    artist_name = ", ".join(art.name for art in track.artists if art and art.name)
+                elif hasattr(track, 'artist') and track.artist and track.artist.name:
+                    artist_name = track.artist.name
+                else:
+                    artist_name = ""
+
+                album_art = ""
+                if hasattr(track, 'album') and track.album:
+                    try:
+                        album_art = track.album.image(dimensions=320)
+                    except:
+                        pass
+
+                tracks_json.append({
+                    "id": str(track.id),
+                    "title": track.name if track.name else "",
+                    "artist": artist_name,
+                    "album": track.album.name if track.album and track.album.name else "",
+                    "artwork_url": album_art,
+                    "duration_ms": int(track.duration * 1000) if track.duration else 0
+                })
+
+            print(json.dumps({
+                "status": "success",
+                "tracks": tracks_json
+            }), flush=True)
+        except Exception as e:
+            handle_exception("Failed to fetch tracks", e)
+
+    elif subcommand == "stream":
+        if len(sys.argv) < 5:
+            print(json.dumps({"status": "error", "error": "Usage: stream <track_id> <access_token> <quality>"}), flush=True)
+            sys.exit(1)
+
+        track_id = sys.argv[2]
+        access_token = sys.argv[3]
+        quality_str = sys.argv[4]
+
+        session = tidalapi.Session()
+        loaded = session.load_oauth_session("Bearer", access_token)
+        if not loaded:
+            print(json.dumps({"status": "error", "error": "Failed to load OAuth session with provided access token"}), flush=True)
+            sys.exit(1)
+
+        quality_map = {
+            "LOW": Quality.low_96k,
+            "HIGH": Quality.low_320k,
+            "LOSSLESS": Quality.high_lossless,
+            "HI_RES": Quality.hi_res_lossless
+        }
+        target_quality = quality_map.get(quality_str, Quality.low_320k)
+        session.audio_quality = target_quality
+
+        try:
+            track = session.track(track_id)
+            stream = track.get_stream()
+            manifest = stream.get_stream_manifest()
+
+            if stream.is_mpd:
+                manifest_data = stream.get_manifest_data()
+                temp_dir = tempfile.gettempdir()
+                temp_file_path = os.path.join(temp_dir, f"tidal_{track_id}.mpd")
+                with open(temp_file_path, "w", encoding="utf-8") as f:
+                    f.write(manifest_data)
+                
+                print(json.dumps({
+                    "status": "success",
+                    "urls": [temp_file_path],
+                    "mime_type": "application/dash+xml"
+                }), flush=True)
+            elif stream.is_bts:
+                urls = manifest.get_urls()
+                print(json.dumps({
+                    "status": "success",
+                    "urls": urls,
+                    "mime_type": stream.manifest_mime_type if stream.manifest_mime_type else "audio/mp4"
+                }), flush=True)
+            else:
+                print(json.dumps({"status": "error", "error": "Unknown stream manifest format"}), flush=True)
+        except Exception as e:
+            handle_exception("Failed to resolve stream", e)
+            sys.exit(1)
+
+    else:
+        print(json.dumps({"status": "error", "error": f"Unknown subcommand: {subcommand}"}), flush=True)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/src/sources/tidal_source.cpp
+++ b/src/sources/tidal_source.cpp
@@ -31,6 +31,10 @@ using subprocess::spawn_in_job;
 using subprocess::widen;
 using subprocess::narrow;
 
+// DEFAULT_TIDAL_CLIENT_ID and DEFAULT_TIDAL_CLIENT_SECRET are public client ID/secret keys
+// retrieved from the open-source python-tidal library. They are widely distributed public
+// keys intended to allow community applications to access the TIDAL API out-of-the-box
+// and do not represent a credential leak of proprietary secrets.
 constexpr std::string_view DEFAULT_TIDAL_CLIENT_ID = "fX2JxdmntZWK0ixT";
 constexpr std::string_view DEFAULT_TIDAL_CLIENT_SECRET = "1Nn9AfDAjxrgJFJbKNWLeAyKGVGmINuXPPLHVXAvxAg=";
 
@@ -171,7 +175,14 @@ bool read_line_from_pipe(HANDLE pipe, std::string& line) {
     return !line.empty() || got > 0;
 }
 
-std::string run_tidal_helper(const std::wstring& args) {
+struct TidalEnv {
+    std::string access_token;
+    std::string refresh_token;
+    std::string client_id;
+    std::string client_secret;
+};
+
+std::string run_tidal_helper(const std::wstring& args, const TidalEnv& env = {}) {
     HANDLE job = create_kill_on_close_job();
     if (!job) {
         log::warn("[tidal] failed to create job for helper");
@@ -192,8 +203,34 @@ std::string run_tidal_helper(const std::wstring& args) {
 
     std::wstring cmd = L"python -u fh6-radio\\tidal_helper.py " + args;
 
+    if (!env.access_token.empty()) {
+        SetEnvironmentVariableW(L"TIDAL_ACCESS_TOKEN", widen(env.access_token).c_str());
+    }
+    if (!env.refresh_token.empty()) {
+        SetEnvironmentVariableW(L"TIDAL_REFRESH_TOKEN", widen(env.refresh_token).c_str());
+    }
+    if (!env.client_id.empty()) {
+        SetEnvironmentVariableW(L"TIDAL_CLIENT_ID", widen(env.client_id).c_str());
+    }
+    if (!env.client_secret.empty()) {
+        SetEnvironmentVariableW(L"TIDAL_CLIENT_SECRET", widen(env.client_secret).c_str());
+    }
+
     HANDLE proc = spawn_in_job(job, cmd, nul_in, wr, err_log);
     const DWORD ec = proc ? 0u : GetLastError();
+
+    if (!env.access_token.empty()) {
+        SetEnvironmentVariableW(L"TIDAL_ACCESS_TOKEN", nullptr);
+    }
+    if (!env.refresh_token.empty()) {
+        SetEnvironmentVariableW(L"TIDAL_REFRESH_TOKEN", nullptr);
+    }
+    if (!env.client_id.empty()) {
+        SetEnvironmentVariableW(L"TIDAL_CLIENT_ID", nullptr);
+    }
+    if (!env.client_secret.empty()) {
+        SetEnvironmentVariableW(L"TIDAL_CLIENT_SECRET", nullptr);
+    }
     CloseHandle(wr);
     if (nul_in) CloseHandle(nul_in);
     if (err_log) CloseHandle(err_log);
@@ -442,15 +479,14 @@ bool TidalSource::refresh_queue_locked() {
     }
 
     std::wstring args = widen(std::format(
-        "playlist {} {}",
-        cfg_.default_playlist,
-        cfg_.access_token
+        "playlist {}",
+        cfg_.default_playlist
     ));
 
     std::string raw;
     {
         std::scoped_lock fetch_lk{fetch_serializer()};
-        raw = run_tidal_helper(args);
+        raw = run_tidal_helper(args, TidalEnv{ .access_token = cfg_.access_token });
     }
 
     if (raw.empty()) {
@@ -515,16 +551,15 @@ std::unique_ptr<TidalSource::Pipe> TidalSource::spawn_pipe_locked(std::size_t fo
     }
 
     std::wstring args = widen(std::format(
-        "stream {} {} {}",
+        "stream {} {}",
         track_id,
-        cfg_.access_token,
         quality
     ));
 
     std::string raw;
     {
         std::scoped_lock fetch_lk{fetch_serializer()};
-        raw = run_tidal_helper(args);
+        raw = run_tidal_helper(args, TidalEnv{ .access_token = cfg_.access_token });
     }
 
     if (raw.empty()) {
@@ -706,12 +741,6 @@ void TidalSource::run_auth_loop() {
         std::string client_id = get_effective_client_id(cfg_.client_id);
         std::string client_secret = get_effective_client_secret(cfg_.client_id, cfg_.client_secret);
 
-        std::wstring cmd = L"login";
-        if (!client_id.empty()) {
-            cmd += L" " + widen(client_id);
-            cmd += L" " + (client_secret.empty() ? L"\"\"" : widen(client_secret));
-        }
-
         HANDLE job = create_kill_on_close_job();
         if (!job) {
             Sleep(5000);
@@ -730,9 +759,21 @@ void TidalSource::run_auth_loop() {
         HANDLE nul_in = open_nul(GENERIC_READ);
         HANDLE err_log = open_stderr_log();
 
-        std::wstring helper_cmd = L"python -u fh6-radio\\tidal_helper.py " + cmd;
+        std::wstring helper_cmd = L"python -u fh6-radio\\tidal_helper.py login";
 
-        HANDLE proc = spawn_in_job(job, helper_cmd, nul_in, wr, err_log);
+        HANDLE proc = nullptr;
+        {
+            std::scoped_lock env_lk{fetch_serializer()};
+            if (!client_id.empty()) {
+                SetEnvironmentVariableW(L"TIDAL_CLIENT_ID", widen(client_id).c_str());
+                if (!client_secret.empty()) {
+                    SetEnvironmentVariableW(L"TIDAL_CLIENT_SECRET", widen(client_secret).c_str());
+                }
+            }
+            proc = spawn_in_job(job, helper_cmd, nul_in, wr, err_log);
+            SetEnvironmentVariableW(L"TIDAL_CLIENT_ID", nullptr);
+            SetEnvironmentVariableW(L"TIDAL_CLIENT_SECRET", nullptr);
+        }
         const DWORD ec = proc ? 0u : GetLastError();
         CloseHandle(wr);
         if (nul_in) CloseHandle(nul_in);
@@ -807,25 +848,38 @@ void TidalSource::run_auth_loop() {
                 }
                 const auto root = nlohmann::json::parse(rest);
                 if (root.value("status", "") == "success") {
-                    std::scoped_lock lk{mu_};
-                    cfg_.access_token = root.value("access_token", "");
-                    cfg_.refresh_token = root.value("refresh_token", "");
-                    int token_expires_in = root.value("expires_in", 3600);
-                    cfg_.expiry_time = static_cast<uint64_t>(std::time(nullptr)) + token_expires_in;
-                    auth_.store(AuthState::authenticated, std::memory_order_release);
-                    auth_user_code_.clear();
-                    auth_verification_uri_.clear();
+                    std::string access_token;
+                    std::string refresh_token;
+                    uint64_t expiry_time = 0;
+                    {
+                        std::scoped_lock lk{mu_};
+                        cfg_.access_token = root.value("access_token", "");
+                        cfg_.refresh_token = root.value("refresh_token", "");
+                        int token_expires_in = root.value("expires_in", 3600);
+                        cfg_.expiry_time = static_cast<uint64_t>(std::time(nullptr)) + token_expires_in;
+                        auth_.store(AuthState::authenticated, std::memory_order_release);
+                        auth_user_code_.clear();
+                        auth_verification_uri_.clear();
 
-                    store_.patch([this](Config& c) {
-                        c.tidal.access_token = cfg_.access_token;
-                        c.tidal.refresh_token = cfg_.refresh_token;
-                        c.tidal.expiry_time = cfg_.expiry_time;
+                        access_token = cfg_.access_token;
+                        refresh_token = cfg_.refresh_token;
+                        expiry_time = cfg_.expiry_time;
+                    }
+
+                    store_.patch([&](Config& c) {
+                        c.tidal.access_token = access_token;
+                        c.tidal.refresh_token = refresh_token;
+                        c.tidal.expiry_time = expiry_time;
                     });
 
                     log::info("[tidal] account linked successfully via python helper!");
-                    refresh_queue_locked();
+                    {
+                        std::scoped_lock lk{mu_};
+                        refresh_queue_locked();
+                    }
                     break;
-                } else {
+                }
+ else {
                     log::error("[tidal] account link helper failed: {}", root.value("error", "Unknown error"));
                 }
             } catch (const std::exception& e) {
@@ -846,17 +900,16 @@ bool TidalSource::refresh_access_token() {
     std::string client_secret = get_effective_client_secret(cfg_.client_id, cfg_.client_secret);
     if (cfg_.refresh_token.empty()) return false;
 
-    std::wstring args = widen(std::format(
-        "refresh {} {} {}",
-        cfg_.refresh_token,
-        client_id.empty() ? "\"\"" : client_id,
-        client_secret.empty() ? "\"\"" : client_secret
-    ));
+    std::wstring args = L"refresh";
 
     std::string raw;
     {
         std::scoped_lock fetch_lk{fetch_serializer()};
-        raw = run_tidal_helper(args);
+        raw = run_tidal_helper(args, TidalEnv{
+            .refresh_token = cfg_.refresh_token,
+            .client_id = client_id,
+            .client_secret = client_secret
+        });
     }
 
     if (raw.empty()) {
@@ -894,17 +947,25 @@ bool TidalSource::refresh_access_token() {
         }
         int expires_in = root.value("expires_in", 3600);
 
-        std::scoped_lock lk{mu_};
-        cfg_.access_token = access_token;
-        cfg_.expiry_time = static_cast<uint64_t>(std::time(nullptr)) + expires_in;
-        if (!refresh_token.empty()) {
-            cfg_.refresh_token = refresh_token;
+        std::string final_access_token;
+        std::string final_refresh_token;
+        uint64_t final_expiry_time = 0;
+        {
+            std::scoped_lock lk{mu_};
+            cfg_.access_token = access_token;
+            cfg_.expiry_time = static_cast<uint64_t>(std::time(nullptr)) + expires_in;
+            if (!refresh_token.empty()) {
+                cfg_.refresh_token = refresh_token;
+            }
+            final_access_token = cfg_.access_token;
+            final_refresh_token = cfg_.refresh_token;
+            final_expiry_time = cfg_.expiry_time;
         }
 
-        store_.patch([this](Config& c) {
-            c.tidal.access_token = cfg_.access_token;
-            c.tidal.refresh_token = cfg_.refresh_token;
-            c.tidal.expiry_time = cfg_.expiry_time;
+        store_.patch([&](Config& c) {
+            c.tidal.access_token = final_access_token;
+            c.tidal.refresh_token = final_refresh_token;
+            c.tidal.expiry_time = final_expiry_time;
         });
 
         log::info("[tidal] access token refreshed successfully via helper");
@@ -916,15 +977,22 @@ bool TidalSource::refresh_access_token() {
 }
 
 bool TidalSource::exchange_authorization_code(const std::string& code) {
-    std::scoped_lock lk{mu_};
-    
-    std::string client_id = get_effective_client_id(cfg_.client_id);
-    std::string client_secret = get_effective_client_secret(cfg_.client_id, cfg_.client_secret);
+    std::string client_id;
+    std::string client_secret;
+    {
+        std::scoped_lock lk{mu_};
+        client_id = get_effective_client_id(cfg_.client_id);
+        client_secret = get_effective_client_secret(cfg_.client_id, cfg_.client_secret);
+    }
     if (client_id.empty() || client_secret.empty()) {
         log::error("[tidal] cannot exchange authorization code: client_id or client_secret is empty");
         return false;
     }
 
+    // Note: The redirect_uri uses a hardcoded port 8420 which matches the default general port
+    // (cfg.general.port). The OAuth client credentials used for the default TIDAL auth flow
+    // have this specific URL pre-registered with TIDAL. If the server port is changed in the configuration,
+    // authentication may fail unless a different client credentials pair is registered with the matching redirect URI.
     std::string body = std::format(
         "grant_type=authorization_code&code={}&redirect_uri={}&client_id={}&client_secret={}",
         url_encode(code),
@@ -949,28 +1017,37 @@ bool TidalSource::exchange_authorization_code(const std::string& code) {
 
     try {
         const auto root = nlohmann::json::parse(res->body);
-        cfg_.access_token = root.value("access_token", "");
-        cfg_.refresh_token = root.value("refresh_token", "");
+        std::string access_token = root.value("access_token", "");
+        std::string refresh_token = root.value("refresh_token", "");
         int expires_in = root.value("expires_in", 3600);
-        cfg_.expiry_time = static_cast<uint64_t>(std::time(nullptr)) + expires_in;
+        uint64_t expiry_time = static_cast<uint64_t>(std::time(nullptr)) + expires_in;
 
-        if (cfg_.access_token.empty()) {
+        if (access_token.empty()) {
             log::error("[tidal] token exchange returned empty access_token");
             return false;
         }
 
-        auth_.store(AuthState::authenticated, std::memory_order_release);
-        auth_verification_uri_.clear();
-        auth_user_code_.clear();
+        {
+            std::scoped_lock lk{mu_};
+            cfg_.access_token = access_token;
+            cfg_.refresh_token = refresh_token;
+            cfg_.expiry_time = expiry_time;
+            auth_.store(AuthState::authenticated, std::memory_order_release);
+            auth_verification_uri_.clear();
+            auth_user_code_.clear();
+        }
 
         store_.patch([&](Config& c) {
-            c.tidal.access_token = cfg_.access_token;
-            c.tidal.refresh_token = cfg_.refresh_token;
-            c.tidal.expiry_time = cfg_.expiry_time;
+            c.tidal.access_token = access_token;
+            c.tidal.refresh_token = refresh_token;
+            c.tidal.expiry_time = expiry_time;
         });
 
         log::info("[tidal] account linked via web authorization successfully!");
-        refresh_queue_locked();
+        {
+            std::scoped_lock lk{mu_};
+            refresh_queue_locked();
+        }
         return true;
     } catch (const std::exception& e) {
         log::error("[tidal] JSON parse error on token exchange: {}", e.what());

--- a/src/sources/tidal_source.cpp
+++ b/src/sources/tidal_source.cpp
@@ -1,0 +1,1009 @@
+#include "fh6/sources/tidal_source.hpp"
+#include "fh6/log.hpp"
+#include "fh6/subprocess.hpp"
+
+#include <nlohmann/json.hpp>
+
+#include <windows.h>
+#include <winhttp.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <format>
+#include <memory>
+#include <optional>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace fh6::sources {
+
+namespace {
+
+using subprocess::create_kill_on_close_job;
+using subprocess::describe_launch_failure;
+using subprocess::open_nul;
+using subprocess::open_stderr_log;
+using subprocess::quote;
+using subprocess::spawn_in_job;
+using subprocess::widen;
+using subprocess::narrow;
+
+constexpr std::string_view DEFAULT_TIDAL_CLIENT_ID = "fX2JxdmntZWK0ixT";
+constexpr std::string_view DEFAULT_TIDAL_CLIENT_SECRET = "1Nn9AfDAjxrgJFJbKNWLeAyKGVGmINuXPPLHVXAvxAg=";
+
+inline std::string get_effective_client_id(const std::string& custom_id) {
+    return custom_id.empty() ? std::string(DEFAULT_TIDAL_CLIENT_ID) : custom_id;
+}
+
+inline std::string get_effective_client_secret(const std::string& custom_id, const std::string& custom_secret) {
+    return custom_id.empty() ? std::string(DEFAULT_TIDAL_CLIENT_SECRET) : custom_secret;
+}
+
+constexpr std::uint64_t kPcmBytesPerSec = 48000ull * 2ull * 2ull;
+constexpr int kHttpTimeoutMs = 5000;
+
+struct WinHttpDeleter {
+    void operator()(void* h) const noexcept { if (h) WinHttpCloseHandle(h); }
+};
+using WinHttpHandle = std::unique_ptr<void, WinHttpDeleter>;
+
+struct HttpResponse {
+    DWORD status = 0;
+    std::string body;
+};
+
+// Unified WinHTTP request helper
+std::optional<HttpResponse> http_request(
+    const std::wstring& wmethod,
+    const std::wstring& whost,
+    INTERNET_PORT port,
+    const std::wstring& wpath,
+    const std::string& body = "",
+    const std::wstring& extra_headers = L""
+) {
+    WinHttpHandle session{WinHttpOpen(L"FH6 Universal Radio/1.0",
+                                       WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY,
+                                       WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0)};
+    if (!session) return std::nullopt;
+    WinHttpSetTimeouts(session.get(), kHttpTimeoutMs, kHttpTimeoutMs,
+                       kHttpTimeoutMs, kHttpTimeoutMs);
+
+    WinHttpHandle conn{WinHttpConnect(session.get(), whost.c_str(), port, 0)};
+    if (!conn) return std::nullopt;
+
+    WinHttpHandle req{WinHttpOpenRequest(conn.get(), wmethod.c_str(), wpath.c_str(), nullptr,
+                                          WINHTTP_NO_REFERER, WINHTTP_DEFAULT_ACCEPT_TYPES,
+                                          port == 443 ? WINHTTP_FLAG_SECURE : 0)};
+    if (!req) return std::nullopt;
+
+    if (!extra_headers.empty()) {
+        WinHttpAddRequestHeaders(req.get(), extra_headers.c_str(), (ULONG)-1L, WINHTTP_ADDREQ_FLAG_ADD);
+    }
+
+    const void* body_data = body.empty() ? WINHTTP_NO_REQUEST_DATA : body.data();
+    DWORD body_len = body.empty() ? 0 : static_cast<DWORD>(body.size());
+    if (!WinHttpSendRequest(req.get(), WINHTTP_NO_ADDITIONAL_HEADERS, 0,
+                            const_cast<void*>(body_data), body_len, body_len, 0) ||
+        !WinHttpReceiveResponse(req.get(), nullptr)) {
+        log::error("[tidal] HTTP request failed (err {})", GetLastError());
+        return std::nullopt;
+    }
+
+    DWORD status = 0, status_sz = sizeof(status);
+    WinHttpQueryHeaders(req.get(), WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
+                        WINHTTP_HEADER_NAME_BY_INDEX, &status, &status_sz, WINHTTP_NO_HEADER_INDEX);
+
+    std::string response_body;
+    for (;;) {
+        DWORD avail = 0;
+        if (!WinHttpQueryDataAvailable(req.get(), &avail) || avail == 0) break;
+        const std::size_t off = response_body.size();
+        response_body.resize(off + avail);
+        DWORD got = 0;
+        if (!WinHttpReadData(req.get(), response_body.data() + off, avail, &got)) break;
+        response_body.resize(off + got);
+        if (got == 0) break;
+    }
+
+    HttpResponse res;
+    res.status = status;
+    res.body = std::move(response_body);
+    return res;
+}
+
+std::string base64_decode(const std::string& in) {
+    std::string out;
+    std::vector<int> T(256, -1);
+    for (int i = 0; i < 64; i++) {
+        T["ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"[i]] = i;
+    }
+    int val = 0, valb = -8;
+    for (unsigned char c : in) {
+        if (T[c] == -1) continue;
+        val = (val << 6) + T[c];
+        valb += 6;
+        if (valb >= 0) {
+            out.push_back(char((val >> valb) & 0xFF));
+            valb -= 8;
+        }
+    }
+    return out;
+}
+
+std::string url_encode(const std::string& value) {
+    std::string out;
+    out.reserve(value.size());
+    for (char c : value) {
+        if (std::isalnum((unsigned char)c) || c == '-' || c == '_' || c == '.' || c == '~') {
+            out.push_back(c);
+        } else {
+            out += std::format("%{:02X}", (unsigned char)c);
+        }
+    }
+    return out;
+}
+
+void shuffle_range(std::vector<TidalTrack>& q, std::size_t from) {
+    if (from >= q.size() || q.size() - from < 2) return;
+    static thread_local std::mt19937 rng{std::random_device{}()};
+    std::shuffle(q.begin() + (std::ptrdiff_t)from, q.end(), rng);
+}
+
+std::mutex& fetch_serializer() {
+    static std::mutex m;
+    return m;
+}
+
+bool read_line_from_pipe(HANDLE pipe, std::string& line) {
+    line.clear();
+    char c = 0;
+    DWORD got = 0;
+    while (ReadFile(pipe, &c, 1, &got, nullptr) && got > 0) {
+        if (c == '\n') break;
+        line.push_back(c);
+    }
+    while (!line.empty() && (line.back() == '\r' || line.back() == ' ' || line.back() == '\t')) {
+        line.pop_back();
+    }
+    return !line.empty() || got > 0;
+}
+
+std::string run_tidal_helper(const std::wstring& args) {
+    HANDLE job = create_kill_on_close_job();
+    if (!job) {
+        log::warn("[tidal] failed to create job for helper");
+        return "";
+    }
+
+    SECURITY_ATTRIBUTES sa{sizeof(sa), nullptr, TRUE};
+    HANDLE rd = nullptr, wr = nullptr;
+    if (!CreatePipe(&rd, &wr, &sa, 0)) {
+        CloseHandle(job);
+        log::warn("[tidal] failed to create pipe for helper");
+        return "";
+    }
+    SetHandleInformation(rd, 0, HANDLE_FLAG_INHERIT);
+
+    HANDLE nul_in = open_nul(GENERIC_READ);
+    HANDLE err_log = open_stderr_log();
+
+    std::wstring cmd = L"python -u fh6-radio\\tidal_helper.py " + args;
+
+    HANDLE proc = spawn_in_job(job, cmd, nul_in, wr, err_log);
+    const DWORD ec = proc ? 0u : GetLastError();
+    CloseHandle(wr);
+    if (nul_in) CloseHandle(nul_in);
+    if (err_log) CloseHandle(err_log);
+
+    if (!proc) {
+        CloseHandle(rd);
+        CloseHandle(job);
+        log::error("[tidal] failed to launch tidal_helper.py (err {}). Make sure python is on PATH.", ec);
+        return "";
+    }
+
+    std::string out;
+    char buf[4096];
+    DWORD got = 0;
+    while (ReadFile(rd, buf, sizeof(buf), &got, nullptr) && got > 0) {
+        out.append(buf, got);
+    }
+
+    CloseHandle(rd);
+    CloseHandle(proc);
+    CloseHandle(job);
+    return out;
+}
+
+} // namespace
+
+struct TidalSource::Pipe {
+    HANDLE job       = nullptr;
+    HANDLE proc      = nullptr;
+    HANDLE read_pipe = nullptr;
+    std::uint64_t bytes_written = 0;
+    std::atomic<std::uint64_t> position_ms{0};
+    bool ended = false;
+    std::size_t for_queue_idx = 0;
+
+    ~Pipe() {
+        if (read_pipe) CloseHandle(read_pipe);
+        if (job)       CloseHandle(job);
+        if (proc)      CloseHandle(proc);
+    }
+};
+
+TidalSource::TidalSource(TidalConfig cfg, std::filesystem::path ffmpeg_path, ConfigStore& store)
+    : cfg_{std::move(cfg)}, ffmpeg_path_{std::move(ffmpeg_path)}, store_{store} {
+    if (cfg_.access_token.empty() || cfg_.refresh_token.empty()) {
+        auth_.store(AuthState::needs_auth, std::memory_order_release);
+    } else {
+        auth_.store(AuthState::authenticated, std::memory_order_release);
+    }
+}
+
+TidalSource::~TidalSource() {
+    stop_auth_thread();
+    std::scoped_lock lk{mu_};
+    discard_prefetch_locked();
+    stop_pipe_locked();
+}
+
+bool TidalSource::initialize() {
+    if (!cfg_.enabled) return false;
+
+    // Trigger auth polling or token refresh if already authenticated
+    if (auth_.load(std::memory_order_acquire) == AuthState::authenticated) {
+        uint64_t now = static_cast<uint64_t>(std::time(nullptr));
+        if (cfg_.expiry_time <= now + 300) {
+            refresh_access_token();
+        }
+        // Fetch default playlist tracks
+        if (!cfg_.default_playlist.empty()) {
+            std::scoped_lock lk{mu_};
+            refresh_queue_locked();
+        }
+    } else {
+        // Start device authorization code polling thread
+        stop_auth_thread_.store(false, std::memory_order_release);
+        auth_thread_ = std::thread(&TidalSource::run_auth_loop, this);
+    }
+
+    return true;
+}
+
+void TidalSource::shutdown() noexcept {
+    stop_auth_thread();
+    std::scoped_lock lk{mu_};
+    discard_prefetch_locked();
+    stop_pipe_locked();
+}
+
+void TidalSource::stop_auth_thread() noexcept {
+    stop_auth_thread_.store(true, std::memory_order_release);
+    if (auth_thread_.joinable()) {
+        auth_thread_.join();
+    }
+}
+
+void TidalSource::play() {
+    std::scoped_lock lk{mu_};
+    if (auth_.load(std::memory_order_acquire) != AuthState::authenticated) return;
+    if (queue_.empty()) return;
+    if (!pipe_) start_pipe_locked();
+    if (pipe_) state_.store(PlaybackState::playing, std::memory_order_release);
+}
+
+void TidalSource::pause() {
+    state_.store(PlaybackState::paused, std::memory_order_release);
+}
+
+void TidalSource::stop() {
+    std::scoped_lock lk{mu_};
+    discard_prefetch_locked();
+    stop_pipe_locked();
+    current_idx_ = 0;
+}
+
+void TidalSource::next() {
+    std::scoped_lock lk{mu_};
+    advance_locked(+1);
+}
+
+void TidalSource::previous() {
+    std::scoped_lock lk{mu_};
+    advance_locked(-1);
+}
+
+void TidalSource::advance_locked(std::ptrdiff_t step) {
+    if (queue_.empty()) return;
+    const auto n = (std::ptrdiff_t)queue_.size();
+    auto i = (std::ptrdiff_t)current_idx_ + step;
+    current_idx_ = (std::size_t)(((i % n) + n) % n);
+    if (step == 1 && promote_prefetch_locked(current_idx_)) {
+        // Prefetch promoted successfully
+    } else {
+        discard_prefetch_locked();
+        start_pipe_locked();
+    }
+    if (pipe_) state_.store(PlaybackState::playing, std::memory_order_release);
+}
+
+bool TidalSource::cast(std::string playlist_id) {
+    if (playlist_id.empty() || auth_.load(std::memory_order_acquire) != AuthState::authenticated) return false;
+
+    log::info("[tidal] casting playlist ID '{}'", playlist_id);
+
+    std::scoped_lock lk{mu_};
+    cfg_.default_playlist = playlist_id;
+    if (refresh_queue_locked()) {
+        current_idx_ = 0;
+        if (cfg_.shuffle) shuffle_range(queue_, 0);
+        discard_prefetch_locked();
+        start_pipe_locked();
+        if (pipe_) state_.store(PlaybackState::playing, std::memory_order_release);
+        return true;
+    }
+    return false;
+}
+
+void TidalSource::set_config(TidalConfig cfg) {
+    std::scoped_lock lk{mu_};
+    bool enable_flip = cfg_.enabled != cfg.enabled;
+    bool shuffle_flip = cfg_.shuffle != cfg.shuffle;
+    bool playlist_change = cfg_.default_playlist != cfg.default_playlist;
+    bool credentials_changed = cfg_.client_id != cfg.client_id || cfg_.client_secret != cfg.client_secret;
+
+    cfg_ = std::move(cfg);
+
+    if (cfg_.access_token.empty() || cfg_.refresh_token.empty()) {
+        auth_.store(AuthState::needs_auth, std::memory_order_release);
+    } else {
+        auth_.store(AuthState::authenticated, std::memory_order_release);
+    }
+
+    if (enable_flip || playlist_change || credentials_changed) {
+        discard_prefetch_locked();
+        stop_pipe_locked();
+        if (auth_.load(std::memory_order_acquire) == AuthState::authenticated) {
+            refresh_queue_locked();
+            current_idx_ = 0;
+            if (cfg_.shuffle) shuffle_range(queue_, 0);
+        } else {
+            queue_.clear();
+            stop_auth_thread();
+            stop_auth_thread_.store(false, std::memory_order_release);
+            auth_thread_ = std::thread(&TidalSource::run_auth_loop, this);
+        }
+    } else if (shuffle_flip && cfg_.shuffle) {
+        shuffle_range(queue_, current_idx_ + 1);
+        discard_prefetch_locked();
+    }
+}
+
+void TidalSource::set_ffmpeg_path(std::filesystem::path p) {
+    std::scoped_lock lk{mu_};
+    ffmpeg_path_ = std::move(p);
+}
+
+void TidalSource::set_playback_options(const PlaybackConfig& opts) {
+    {
+        std::scoped_lock lk{mu_};
+        eq_.set_options(opts.equalizer_enabled, opts.equalizer_bands, 48000.0f);
+    }
+    volume_norm_.store(opts.volume_normalization, std::memory_order_release);
+    const bool prev = prebuffer_next_.exchange(opts.prebuffer_next_track,
+                                                std::memory_order_acq_rel);
+    if (prev && !opts.prebuffer_next_track) {
+        std::scoped_lock lk{mu_};
+        discard_prefetch_locked();
+    }
+}
+
+TrackInfo TidalSource::current_track() const {
+    std::scoped_lock lk{mu_};
+    TrackInfo info;
+    if (queue_.empty() || current_idx_ >= queue_.size()) return info;
+    const auto& t    = queue_[current_idx_];
+    info.title       = t.title;
+    info.artist      = t.artist;
+    info.album       = t.album;
+    info.artwork_url = t.artwork_url;
+    info.duration_ms = t.duration_ms;
+    if (pipe_) info.position_ms = pipe_->position_ms.load(std::memory_order_acquire);
+    return info;
+}
+
+std::string TidalSource::auth_instructions() const {
+    std::scoped_lock lk{mu_};
+    if (auth_.load(std::memory_order_acquire) == AuthState::needs_auth && !auth_verification_uri_.empty()) {
+        if (!auth_user_code_.empty()) {
+            return std::format("Go to <a href=\"{}\" target=\"_blank\">{}</a> and enter code <strong>{}</strong> to link your TIDAL account.",
+                               auth_verification_uri_, auth_verification_uri_, auth_user_code_);
+        }
+        return std::format("Go to <a href=\"{}\" target=\"_blank\">{}</a> to link your TIDAL account.",
+                           auth_verification_uri_, auth_verification_uri_);
+    }
+    return "TIDAL is not authenticated. Please enable TIDAL in settings to generate an authentication link.";
+}
+
+bool TidalSource::refresh_queue_locked() {
+    if (cfg_.default_playlist.empty() || auth_.load(std::memory_order_acquire) != AuthState::authenticated) return false;
+
+    // Check token expiry
+    uint64_t now = static_cast<uint64_t>(std::time(nullptr));
+    if (cfg_.expiry_time <= now + 300) {
+        mu_.unlock();
+        refresh_access_token();
+        mu_.lock();
+    }
+
+    std::wstring args = widen(std::format(
+        "playlist {} {}",
+        cfg_.default_playlist,
+        cfg_.access_token
+    ));
+
+    std::string raw;
+    {
+        std::scoped_lock fetch_lk{fetch_serializer()};
+        raw = run_tidal_helper(args);
+    }
+
+    if (raw.empty()) {
+        log::error("[tidal] playlist helper returned empty output");
+        return false;
+    }
+
+    try {
+        const auto root = nlohmann::json::parse(raw);
+        if (root.value("status", "") != "success") {
+            log::error("[tidal] playlist helper error: {}", root.value("error", "Unknown error"));
+            return false;
+        }
+
+        const auto items = root.find("tracks");
+        if (items == root.end() || !items->is_array()) {
+            log::error("[tidal] playlist helper response missing tracks array");
+            return false;
+        }
+
+        std::vector<TidalTrack> tracks;
+        tracks.reserve(items->size());
+
+        for (const auto& item : *items) {
+            TidalTrack t;
+            t.id = item.value("id", "");
+            t.title = item.value("title", "");
+            t.artist = item.value("artist", "");
+            t.album = item.value("album", "");
+            t.artwork_url = item.value("artwork_url", "");
+            t.duration_ms = item.value("duration_ms", 0ull);
+            tracks.push_back(t);
+        }
+
+        queue_ = std::move(tracks);
+        if (cfg_.shuffle && queue_.size() > 1) {
+            shuffle_range(queue_, current_idx_ + 1);
+        }
+        log::info("[tidal] resolved {} track(s) from playlist via helper", queue_.size());
+        return true;
+    } catch (const std::exception& e) {
+        log::error("[tidal] JSON parse error on helper playlist fetch: {} (raw: {})", e.what(), raw);
+        return false;
+    }
+}
+
+std::unique_ptr<TidalSource::Pipe> TidalSource::spawn_pipe_locked(std::size_t for_idx) {
+    if (queue_.empty() || for_idx >= queue_.size() || auth_.load(std::memory_order_acquire) != AuthState::authenticated) return nullptr;
+
+    // Check token expiry
+    uint64_t now = static_cast<uint64_t>(std::time(nullptr));
+    if (cfg_.expiry_time <= now + 300) {
+        mu_.unlock();
+        refresh_access_token();
+        mu_.lock();
+    }
+
+    const std::string track_id = queue_[for_idx].id;
+    std::string quality = cfg_.audio_quality;
+    if (quality != "LOW" && quality != "HIGH" && quality != "LOSSLESS" && quality != "HI_RES") {
+        quality = "HIGH";
+    }
+
+    std::wstring args = widen(std::format(
+        "stream {} {} {}",
+        track_id,
+        cfg_.access_token,
+        quality
+    ));
+
+    std::string raw;
+    {
+        std::scoped_lock fetch_lk{fetch_serializer()};
+        raw = run_tidal_helper(args);
+    }
+
+    if (raw.empty()) {
+        log::error("[tidal] stream helper returned empty output");
+        return nullptr;
+    }
+
+    std::string stream_url;
+    try {
+        const auto root = nlohmann::json::parse(raw);
+        if (root.value("status", "") != "success") {
+            log::error("[tidal] stream helper error: {}", root.value("error", "Unknown error"));
+            return nullptr;
+        }
+
+        std::string mime_type = root.value("mime_type", "");
+        if (root.contains("urls") && root["urls"].is_array() && !root["urls"].empty()) {
+            stream_url = root["urls"][0].get<std::string>();
+        } else if (mime_type == "application/dash+xml") {
+            stream_url = std::format("https://api.tidal.com/v1/tracks/{}/playbackinfo?playbackMode=STREAM&assetPresentation=FULL&audioQuality={}", track_id, quality);
+        }
+    } catch (const std::exception& e) {
+        log::error("[tidal] JSON parse error on helper stream: {} (raw: {})", e.what(), raw);
+        return nullptr;
+    }
+
+    if (stream_url.empty()) {
+        log::error("[tidal] failed to resolve stream URL for track {}", track_id);
+        return nullptr;
+    }
+
+    auto pipe = std::make_unique<Pipe>();
+    pipe->for_queue_idx = for_idx;
+    pipe->job = create_kill_on_close_job();
+    if (!pipe->job) {
+        log::warn("[tidal] CreateJobObject failed ({})", GetLastError());
+        return nullptr;
+    }
+
+    SECURITY_ATTRIBUTES sa{sizeof(sa), nullptr, TRUE};
+    HANDLE out_r = nullptr, out_w = nullptr;
+    if (!CreatePipe(&out_r, &out_w, &sa, 1 << 20)) return nullptr;
+    SetHandleInformation(out_r, HANDLE_FLAG_INHERIT, 0);
+
+    HANDLE nul_in = open_nul(GENERIC_READ);
+    HANDLE err_log = open_stderr_log();
+
+    const std::wstring ff = ffmpeg_path_.empty() ? std::wstring{L"ffmpeg"} : ffmpeg_path_.wstring();
+    const std::wstring auth_hdr = widen(std::format("Authorization: Bearer {}\r\n", cfg_.access_token));
+
+    std::wstring cmd = quote(ff) + L" -loglevel error -headers " + quote(auth_hdr) + L" -reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 5 -i " + quote(widen(stream_url)) + L" -f s16le ";
+    if (volume_norm_.load(std::memory_order_acquire)) {
+        cmd += L"-af loudnorm=I=-14:TP=-2:LRA=11 ";
+    }
+    cmd += L"-acodec pcm_s16le -ar 48000 -ac 2 pipe:1";
+
+    pipe->proc = spawn_in_job(pipe->job, cmd, nul_in, out_w, err_log);
+    const DWORD ec = pipe->proc ? 0u : GetLastError();
+    CloseHandle(out_w);
+    if (nul_in) CloseHandle(nul_in);
+    if (err_log) CloseHandle(err_log);
+
+    if (!pipe->proc) {
+        CloseHandle(out_r);
+        log::warn("[tidal] failed to launch ffmpeg -- {}", describe_launch_failure(ff, ec, !ffmpeg_path_.empty()));
+        return nullptr;
+    }
+
+    pipe->read_pipe = out_r;
+    return pipe;
+}
+
+void TidalSource::start_pipe_locked() {
+    stop_pipe_locked();
+    pipe_ = spawn_pipe_locked(current_idx_);
+    if (pipe_) {
+        state_.store(PlaybackState::playing, std::memory_order_release);
+    }
+}
+
+void TidalSource::stop_pipe_locked() {
+    pipe_.reset();
+    state_.store(PlaybackState::stopped, std::memory_order_release);
+}
+
+void TidalSource::discard_prefetch_locked() noexcept {
+    prefetch_.reset();
+}
+
+bool TidalSource::promote_prefetch_locked(std::size_t expected_idx) {
+    if (!prefetch_ || prefetch_->for_queue_idx != expected_idx) {
+        discard_prefetch_locked();
+        return false;
+    }
+    pipe_ = std::move(prefetch_);
+    return true;
+}
+
+void TidalSource::maybe_spawn_prefetch_locked() {
+    if (!prebuffer_next_.load(std::memory_order_acquire)) return;
+    if (prefetch_ || !pipe_ || queue_.size() < 2) return;
+    constexpr std::uint64_t kViableBytes = 96 * 1024;
+    if (pipe_->bytes_written < kViableBytes) return;
+    prefetch_ = spawn_pipe_locked(next_queue_idx_locked());
+}
+
+std::size_t TidalSource::next_queue_idx_locked() const noexcept {
+    if (queue_.empty()) return 0;
+    return (current_idx_ + 1) % queue_.size();
+}
+
+void TidalSource::pump(RingBuffer& ring) {
+    if (state_.load(std::memory_order_acquire) != PlaybackState::playing) return;
+
+    std::scoped_lock lk{mu_};
+    Pipe* p = pipe_.get();
+    if (!p) return;
+
+    auto update_position = [&] {
+        const std::size_t r = ring.readable();
+        const std::uint64_t played = p->bytes_written > r ? p->bytes_written - r : 0;
+        p->position_ms.store(played * 1000ull / kPcmBytesPerSec, std::memory_order_release);
+    };
+    auto on_eof = [&] {
+        if (p->read_pipe) {
+            CloseHandle(p->read_pipe);
+            p->read_pipe = nullptr;
+        }
+        p->ended = true;
+    };
+
+    if (p->ended) {
+        update_position();
+        if (ring.readable() == 0) advance_locked(+1);
+        return;
+    }
+    if (!p->read_pipe) return;
+
+    DWORD avail = 0;
+    if (!PeekNamedPipe(p->read_pipe, nullptr, 0, nullptr, &avail, nullptr)) {
+        on_eof();
+        return;
+    }
+    while (avail > 0) {
+        const std::size_t writable = ring.writable();
+        if (writable < 4) break;
+        std::size_t want = std::min<std::size_t>(writable, avail);
+        if (want > 4096) want = 4096;
+        want &= ~std::size_t{3};
+        if (!want) break;
+
+        std::byte buf[4096];
+        DWORD got = 0;
+        if (!ReadFile(p->read_pipe, buf, (DWORD)want, &got, nullptr) || got == 0) {
+            on_eof();
+            break;
+        }
+        const DWORD aligned = (got / 4u) * 4u;
+        if (aligned) {
+            eq_.process(reinterpret_cast<int16_t*>(buf), aligned / 4u);
+        }
+        ring.write(buf, aligned);
+        p->bytes_written += aligned;
+        avail = avail > got ? avail - got : 0;
+    }
+    update_position();
+    maybe_spawn_prefetch_locked();
+}
+
+// OAuth2 Thread functions
+void TidalSource::run_auth_loop() {
+    log::info("[tidal] starting device link auth loop via helper");
+
+    while (!stop_auth_thread_.load(std::memory_order_acquire)) {
+        if (auth_.load(std::memory_order_acquire) == AuthState::authenticated) {
+            break;
+        }
+
+        std::string client_id = get_effective_client_id(cfg_.client_id);
+        std::string client_secret = get_effective_client_secret(cfg_.client_id, cfg_.client_secret);
+
+        std::wstring cmd = L"login";
+        if (!client_id.empty()) {
+            cmd += L" " + widen(client_id);
+            cmd += L" " + (client_secret.empty() ? L"\"\"" : widen(client_secret));
+        }
+
+        HANDLE job = create_kill_on_close_job();
+        if (!job) {
+            Sleep(5000);
+            continue;
+        }
+
+        SECURITY_ATTRIBUTES sa{sizeof(sa), nullptr, TRUE};
+        HANDLE rd = nullptr, wr = nullptr;
+        if (!CreatePipe(&rd, &wr, &sa, 0)) {
+            CloseHandle(job);
+            Sleep(5000);
+            continue;
+        }
+        SetHandleInformation(rd, 0, HANDLE_FLAG_INHERIT);
+
+        HANDLE nul_in = open_nul(GENERIC_READ);
+        HANDLE err_log = open_stderr_log();
+
+        std::wstring helper_cmd = L"python -u fh6-radio\\tidal_helper.py " + cmd;
+
+        HANDLE proc = spawn_in_job(job, helper_cmd, nul_in, wr, err_log);
+        const DWORD ec = proc ? 0u : GetLastError();
+        CloseHandle(wr);
+        if (nul_in) CloseHandle(nul_in);
+        if (err_log) CloseHandle(err_log);
+
+        if (!proc) {
+            CloseHandle(rd);
+            CloseHandle(job);
+            log::error("[tidal] failed to launch login helper (err {}). Make sure python is on PATH.", ec);
+            for (int k = 0; k < 10 && !stop_auth_thread_.load(std::memory_order_acquire); ++k) {
+                Sleep(1000);
+            }
+            continue;
+        }
+
+        std::string first_line;
+        if (!read_line_from_pipe(rd, first_line)) {
+            log::error("[tidal] helper login exited immediately or failed to print verification details");
+            CloseHandle(rd);
+            CloseHandle(proc);
+            CloseHandle(job);
+            Sleep(5000);
+            continue;
+        }
+
+        std::string verification_uri, user_code;
+        try {
+            const auto root = nlohmann::json::parse(first_line);
+            if (root.contains("error")) {
+                log::error("[tidal] helper login error: {}", root.value("error", "Unknown error"));
+                CloseHandle(rd);
+                CloseHandle(proc);
+                CloseHandle(job);
+                Sleep(5000);
+                continue;
+            }
+            verification_uri = root.value("verification_uri", "");
+            user_code = root.value("user_code", "");
+        } catch (const std::exception& e) {
+            log::error("[tidal] helper first-line JSON parse error: {} (raw: {})", e.what(), first_line);
+            CloseHandle(rd);
+            CloseHandle(proc);
+            CloseHandle(job);
+            Sleep(5000);
+            continue;
+        }
+
+        {
+            std::scoped_lock lk{mu_};
+            auth_user_code_ = user_code;
+            auth_verification_uri_ = verification_uri;
+            auth_.store(AuthState::needs_auth, std::memory_order_release);
+        }
+
+        log::info("[tidal] please link your account: {} (code: {})", verification_uri, user_code);
+
+        std::string rest;
+        char buf[1024];
+        DWORD got = 0;
+        while (ReadFile(rd, buf, sizeof(buf), &got, nullptr) && got > 0) {
+            rest.append(buf, got);
+        }
+
+        CloseHandle(rd);
+        CloseHandle(proc);
+        CloseHandle(job);
+
+        if (!rest.empty()) {
+            try {
+                while (!rest.empty() && (rest.back() == '\r' || rest.back() == '\n' || rest.back() == ' ')) {
+                    rest.pop_back();
+                }
+                const auto root = nlohmann::json::parse(rest);
+                if (root.value("status", "") == "success") {
+                    std::scoped_lock lk{mu_};
+                    cfg_.access_token = root.value("access_token", "");
+                    cfg_.refresh_token = root.value("refresh_token", "");
+                    int token_expires_in = root.value("expires_in", 3600);
+                    cfg_.expiry_time = static_cast<uint64_t>(std::time(nullptr)) + token_expires_in;
+                    auth_.store(AuthState::authenticated, std::memory_order_release);
+                    auth_user_code_.clear();
+                    auth_verification_uri_.clear();
+
+                    store_.patch([this](Config& c) {
+                        c.tidal.access_token = cfg_.access_token;
+                        c.tidal.refresh_token = cfg_.refresh_token;
+                        c.tidal.expiry_time = cfg_.expiry_time;
+                    });
+
+                    log::info("[tidal] account linked successfully via python helper!");
+                    refresh_queue_locked();
+                    break;
+                } else {
+                    log::error("[tidal] account link helper failed: {}", root.value("error", "Unknown error"));
+                }
+            } catch (const std::exception& e) {
+                log::error("[tidal] helper final JSON parse error: {} (raw: {})", e.what(), rest);
+            }
+        }
+
+        for (int k = 0; k < 5 && !stop_auth_thread_.load(std::memory_order_acquire); ++k) {
+            Sleep(1000);
+        }
+    }
+}
+
+bool TidalSource::refresh_access_token() {
+    log::info("[tidal] refreshing expired access token via helper");
+
+    std::string client_id = get_effective_client_id(cfg_.client_id);
+    std::string client_secret = get_effective_client_secret(cfg_.client_id, cfg_.client_secret);
+    if (cfg_.refresh_token.empty()) return false;
+
+    std::wstring args = widen(std::format(
+        "refresh {} {} {}",
+        cfg_.refresh_token,
+        client_id.empty() ? "\"\"" : client_id,
+        client_secret.empty() ? "\"\"" : client_secret
+    ));
+
+    std::string raw;
+    {
+        std::scoped_lock fetch_lk{fetch_serializer()};
+        raw = run_tidal_helper(args);
+    }
+
+    if (raw.empty()) {
+        log::error("[tidal] token refresh helper returned empty output");
+        return false;
+    }
+
+    try {
+        const auto root = nlohmann::json::parse(raw);
+        if (root.value("status", "") != "success") {
+            log::error("[tidal] token refresh helper error: {}", root.value("error", "Unknown error"));
+            {
+                std::scoped_lock lk{mu_};
+                cfg_.access_token.clear();
+                cfg_.refresh_token.clear();
+                cfg_.expiry_time = 0;
+                auth_.store(AuthState::needs_auth, std::memory_order_release);
+                queue_.clear();
+            }
+            store_.patch([this](Config& c) {
+                c.tidal.access_token.clear();
+                c.tidal.refresh_token.clear();
+                c.tidal.expiry_time = 0;
+            });
+            stop_auth_thread();
+            stop_auth_thread_.store(false, std::memory_order_release);
+            auth_thread_ = std::thread(&TidalSource::run_auth_loop, this);
+            return false;
+        }
+
+        std::string access_token = root.value("access_token", "");
+        std::string refresh_token;
+        if (root.contains("refresh_token") && !root["refresh_token"].is_null()) {
+            refresh_token = root["refresh_token"].get<std::string>();
+        }
+        int expires_in = root.value("expires_in", 3600);
+
+        std::scoped_lock lk{mu_};
+        cfg_.access_token = access_token;
+        cfg_.expiry_time = static_cast<uint64_t>(std::time(nullptr)) + expires_in;
+        if (!refresh_token.empty()) {
+            cfg_.refresh_token = refresh_token;
+        }
+
+        store_.patch([this](Config& c) {
+            c.tidal.access_token = cfg_.access_token;
+            c.tidal.refresh_token = cfg_.refresh_token;
+            c.tidal.expiry_time = cfg_.expiry_time;
+        });
+
+        log::info("[tidal] access token refreshed successfully via helper");
+        return true;
+    } catch (const std::exception& e) {
+        log::error("[tidal] JSON parse error on helper token refresh: {} (raw: {})", e.what(), raw);
+        return false;
+    }
+}
+
+bool TidalSource::exchange_authorization_code(const std::string& code) {
+    std::scoped_lock lk{mu_};
+    
+    std::string client_id = get_effective_client_id(cfg_.client_id);
+    std::string client_secret = get_effective_client_secret(cfg_.client_id, cfg_.client_secret);
+    if (client_id.empty() || client_secret.empty()) {
+        log::error("[tidal] cannot exchange authorization code: client_id or client_secret is empty");
+        return false;
+    }
+
+    std::string body = std::format(
+        "grant_type=authorization_code&code={}&redirect_uri={}&client_id={}&client_secret={}",
+        url_encode(code),
+        url_encode("http://localhost:8420/api/source/tidal/callback"),
+        url_encode(client_id),
+        url_encode(client_secret)
+    );
+    std::wstring headers = L"Content-Type: application/x-www-form-urlencoded\r\n";
+
+    std::optional<HttpResponse> res;
+    {
+        std::scoped_lock fetch_lk{fetch_serializer()};
+        res = http_request(L"POST", L"auth.tidal.com", 443, L"/v1/oauth2/token", body, headers);
+    }
+
+    if (!res || res->status != 200) {
+        log::error("[tidal] failed to exchange authorization code (status {}): {}", 
+                   res ? res->status : 0, 
+                   res ? res->body : "No response body");
+        return false;
+    }
+
+    try {
+        const auto root = nlohmann::json::parse(res->body);
+        cfg_.access_token = root.value("access_token", "");
+        cfg_.refresh_token = root.value("refresh_token", "");
+        int expires_in = root.value("expires_in", 3600);
+        cfg_.expiry_time = static_cast<uint64_t>(std::time(nullptr)) + expires_in;
+
+        if (cfg_.access_token.empty()) {
+            log::error("[tidal] token exchange returned empty access_token");
+            return false;
+        }
+
+        auth_.store(AuthState::authenticated, std::memory_order_release);
+        auth_verification_uri_.clear();
+        auth_user_code_.clear();
+
+        store_.patch([&](Config& c) {
+            c.tidal.access_token = cfg_.access_token;
+            c.tidal.refresh_token = cfg_.refresh_token;
+            c.tidal.expiry_time = cfg_.expiry_time;
+        });
+
+        log::info("[tidal] account linked via web authorization successfully!");
+        refresh_queue_locked();
+        return true;
+    } catch (const std::exception& e) {
+        log::error("[tidal] JSON parse error on token exchange: {}", e.what());
+        return false;
+    }
+}
+
+TidalSource::QueueSnapshot TidalSource::queue_snapshot() const {
+    std::scoped_lock lk{mu_};
+    QueueSnapshot snap;
+    snap.cursor = current_idx_;
+    snap.entries = queue_;
+    return snap;
+}
+
+bool TidalSource::jump_to(std::size_t index) {
+    std::scoped_lock lk{mu_};
+    if (index >= queue_.size()) return false;
+    current_idx_ = index;
+    discard_prefetch_locked();
+    start_pipe_locked();
+    if (pipe_) state_.store(PlaybackState::playing, std::memory_order_release);
+    return true;
+}
+
+std::size_t TidalSource::track_count() const {
+    std::scoped_lock lk{mu_};
+    return queue_.size();
+}
+
+std::size_t TidalSource::current_index() const {
+    std::scoped_lock lk{mu_};
+    return current_idx_;
+}
+
+} // namespace fh6::sources

--- a/ui/dist/index.html
+++ b/ui/dist/index.html
@@ -71,6 +71,25 @@
         </form>
       </section>
 
+      <section class="card" id="tidal-cast-card" hidden>
+        <h2>Play TIDAL Playlist</h2>
+        <p class="muted">
+          Enter a TIDAL Playlist or Mix ID. The radio will switch sources and start streaming immediately.
+        </p>
+        <form id="tidal-cast" class="row">
+          <input type="text" id="tidal-url" placeholder="e.g. 696db989-7a42-4513-bf7d-1e51958e4855" autocomplete="off" />
+          <button type="submit" class="btn filled">Play</button>
+        </form>
+        <div class="lf-queue" id="tidal-queue" style="margin-top: 1.5rem;" hidden>
+          <div class="lf-queue-head row">
+            <label class="field-label">Playlist Tracks</label>
+            <span class="muted" id="tidal-queue-count">0 tracks</span>
+          </div>
+          <input type="text" id="tidal-queue-search" placeholder="Search the playlist…" autocomplete="off" />
+          <ul class="lf-tracklist" id="tidal-track-list"></ul>
+        </div>
+      </section>
+
       <section class="card" id="output-card" hidden>
         <h2>Output</h2>
         <label class="slider">

--- a/ui/dist/js/api.js
+++ b/ui/dist/js/api.js
@@ -25,6 +25,11 @@ export const api = {
     request("/api/source/youtube_music/shuffle", { method: "POST", body: { shuffle } }),
   castJellyfin: playlistId =>
     request("/api/source/jellyfin/cast", { method: "POST", body: { playlist_id: playlistId } }),
+  castTidal: playlistId =>
+    request("/api/source/tidal/cast", { method: "POST", body: { playlist_id: playlistId } }),
+  getTidalQueue: () => request("/api/source/tidal/queue"),
+  playTidalIndex: index =>
+    request("/api/source/tidal/play", { method: "POST", body: { index } }),
   setGain: gain => request("/api/options", { method: "POST", body: { output_gain: gain } }),
   getExternalAudio: () => request("/api/external_audio/devices"),
   putExternalAudio: config => request("/api/external_audio/config", { method: "PUT", body: config }),

--- a/ui/dist/js/main.js
+++ b/ui/dist/js/main.js
@@ -12,6 +12,7 @@ import { createDeps } from "./render/deps.js";
 import { createExternalAudio } from "./render/externalAudio.js";
 import { createLocalFiles } from "./render/localFiles.js";
 import { createOnlineRadio } from "./render/onlineRadio.js";
+import { createTidal } from "./render/tidal.js";
 
 let state = null;
 let cfg = null;
@@ -34,6 +35,7 @@ const refs = {
   outputCard: $("#output-card"),
   ytCard: $("#yt-cast-card"),
   jfCard: $("#jf-cast-card"),
+  tidalCard: $("#tidal-cast-card"),
   ytShuffle: $("#yt-shuffle"),
   drawer: $("#drawer"),
   scrim: $("#scrim"),
@@ -89,6 +91,11 @@ const onlineRadio = createOnlineRadio(mainEl, {
   },
 });
 
+const tidal = createTidal(mainEl, {
+  getState: () => state,
+  getConfig: () => cfg,
+});
+
 async function switchSource(name) {
   try {
     await api.switchSource(name);
@@ -142,6 +149,7 @@ function render() {
   externalAudio.render();
   localFiles.render();
   onlineRadio.render();
+  tidal.render();
 
   refs.sourceCard.hidden = false;
   refs.outputCard.hidden = !state.sources?.active;
@@ -151,6 +159,7 @@ function render() {
   // Source-specific cards only show while that source is on air.
   refs.ytCard.hidden = active !== "youtube_music";
   refs.jfCard.hidden = active !== "jellyfin";
+  refs.tidalCard.hidden = active !== "tidal";
   const shuffleOn = !!available.find(s => s.name === "youtube_music")?.details?.shuffle;
   refs.ytShuffle.classList.toggle("toggled", shuffleOn);
   refs.ytShuffle.setAttribute("aria-pressed", String(shuffleOn));
@@ -198,6 +207,19 @@ $("#jf-cast").addEventListener("submit", async e => {
   }
 });
 
+$("#tidal-cast").addEventListener("submit", async e => {
+  e.preventDefault();
+  const playlistId = $("#tidal-url").value.trim();
+  if (!playlistId) return;
+  try {
+    await api.castTidal(playlistId);
+    $("#tidal-url").value = "";
+    toast("Playing TIDAL playlist…");
+  } catch (err) {
+    toast(err.message, true);
+  }
+});
+
 $("#open-settings").addEventListener("click", async () => {
   try {
     cfg = await api.getConfig();
@@ -221,6 +243,7 @@ $("#save-config").addEventListener("click", async () => {
     externalAudio.invalidate();
     localFiles.invalidate();
     onlineRadio.invalidate();
+    tidal.invalidate();
     state = await api.getState().catch(() => state);
     render();
     toast("Saved");
@@ -236,6 +259,7 @@ $("#reload-config").addEventListener("click", async () => {
     externalAudio.invalidate();
     localFiles.invalidate();
     onlineRadio.invalidate();
+    tidal.invalidate();
     renderSettings(refs.form, cfg);
     render();
     toast("Reloaded from disk");

--- a/ui/dist/js/render/sources.js
+++ b/ui/dist/js/render/sources.js
@@ -1,5 +1,6 @@
 import { el } from "../dom.js";
 import { changed } from "../store.js";
+import { toast } from "../toast.js";
 
 function detailLine(s) {
   if (s.name === "local_files" && s.details?.track_count != null) {
@@ -55,13 +56,26 @@ export function renderSources(node, state, cfg, onSwitch) {
         el("div", { class: "source-name" }, s.display_name),
         el("div", { class: "source-state " + stateCls }, stateText(s)),
       ];
-      if (showNote) children.push(el("div", { class: "source-note" }, s.auth_instructions));
+      if (showNote) children.push(el("div", { class: "source-note", html: s.auth_instructions }));
+
+      const isTidalUnauthed = s.name === "tidal" && s.auth_state !== "none_required" && s.auth_state !== "authenticated";
+      const classes = ["source"];
+      if (s.name === active) classes.push("active");
+      if (isTidalUnauthed) classes.push("unauthorized");
+
       const tile = el(
         "button",
-        { type: "button", class: "source" + (s.name === active ? " active" : "") },
+        { type: "button", class: classes.join(" ") },
         children,
       );
-      tile.addEventListener("click", () => onSwitch(s.name));
+      tile.addEventListener("click", (e) => {
+        if (e.target.tagName === "A") return;
+        if (isTidalUnauthed) {
+          toast("Please link your TIDAL account using the link below.", true);
+          return;
+        }
+        onSwitch(s.name);
+      });
       return tile;
     }),
   );

--- a/ui/dist/js/render/tidal.js
+++ b/ui/dist/js/render/tidal.js
@@ -1,0 +1,122 @@
+import { api } from "../api.js";
+import { $, el } from "../dom.js";
+import { toast } from "../toast.js";
+
+const fold = s => (s || "").normalize("NFD").replace(/\p{Diacritic}/gu, "").toLowerCase();
+
+export function createTidal(main, ctx) {
+  let queue = { cursor: 0, tracks: [] };
+  let search = "";
+
+  const container = $("#tidal-queue");
+  const countEl = $("#tidal-queue-count");
+  const searchInput = $("#tidal-queue-search");
+  const trackList = $("#tidal-track-list");
+
+  async function loadQueue() {
+    try {
+      queue = await api.getTidalQueue();
+    } catch {
+      queue = { cursor: 0, tracks: [] };
+    }
+    renderQueue();
+  }
+
+  function renderQueue() {
+    if (!queue.tracks || !queue.tracks.length) {
+      container.hidden = true;
+      return;
+    }
+    container.hidden = false;
+
+    const terms = fold(search).split(/\s+/).filter(Boolean);
+    const rows = queue.tracks.filter(t => {
+      if (!terms.length) return true;
+      const hay = fold(`${t.title} ${t.artist || ""} ${t.album || ""}`);
+      return terms.every(w => hay.includes(w));
+    });
+
+    countEl.textContent = `${queue.tracks.length} tracks`;
+    trackList.replaceChildren(
+      ...rows.map(t => {
+        const art = t.artwork_url
+          ? el("img", {
+              src: t.artwork_url,
+              alt: "",
+              style: "width: 40px; height: 40px; border-radius: var(--radius-sm); object-fit: cover; flex-shrink: 0;",
+            })
+          : el("div", {
+              style: "width: 40px; height: 40px; border-radius: var(--radius-sm); background: var(--surface-raise); flex-shrink: 0; display: flex; align-items: center; justify-content: center; font-size: 20px; color: var(--text-muted);",
+              html: "♪",
+            });
+
+        const li = el(
+          "li",
+          {
+            class: "lf-track" + (t.index === queue.cursor ? " current" : ""),
+            style: "flex-direction: row; align-items: center; gap: 12px;",
+          },
+          [
+            art,
+            el("div", { style: "display: flex; flex-direction: column; gap: 2px; flex-grow: 1; min-width: 0;" }, [
+              el("span", { class: "lf-track-title", style: "white-space: nowrap; overflow: hidden; text-overflow: ellipsis;" }, t.artist ? `${t.title} — ${t.artist}` : t.title),
+              t.album ? el("span", { class: "lf-track-folder muted", style: "white-space: nowrap; overflow: hidden; text-overflow: ellipsis;" }, t.album) : null,
+            ]),
+          ],
+        );
+        li.addEventListener("click", async () => {
+          try {
+            await api.playTidalIndex(t.index);
+            queue.cursor = t.index;
+            renderQueue();
+          } catch (e) {
+            toast(e.message, true);
+          }
+        });
+        return li;
+      }),
+    );
+
+    if (!rows.length) {
+      trackList.append(
+        el("li", { class: "muted" }, terms.length ? "No matches." : "Queue is empty."),
+      );
+    }
+  }
+
+  searchInput.addEventListener("input", () => {
+    search = searchInput.value;
+    renderQueue();
+  });
+
+  // --- lifecycle ------------------------------------------------------------
+  let lastTrackCount = -1;
+  let lastCurrentIndex = -1;
+
+  function render() {
+    const state = ctx.getState();
+    const isActive = state?.sources?.active === "tidal";
+    if (!isActive) {
+      container.hidden = true;
+      return;
+    }
+
+    const td = state?.sources?.available?.find(s => s.name === "tidal");
+    const tc = td?.details?.track_count ?? -1;
+    const ci = td?.details?.current_index ?? -1;
+
+    if (tc !== lastTrackCount || ci !== lastCurrentIndex) {
+      lastTrackCount = tc;
+      lastCurrentIndex = ci;
+      loadQueue();
+    }
+  }
+
+  return {
+    render,
+    invalidate: () => {
+      lastTrackCount = -1;
+      lastCurrentIndex = -1;
+    },
+  };
+}

--- a/ui/dist/js/schema.js
+++ b/ui/dist/js/schema.js
@@ -4,6 +4,7 @@ export const SOURCE_SECTIONS = [
   ["local_files", "Local files"],
   ["youtube_music", "YouTube Music"],
   ["jellyfin", "Jellyfin"],
+  ["tidal", "Tidal Music"],
   ["external_audio", "External Audio"],
   ["spotify", "Spotify Connect"],
 ];
@@ -52,6 +53,18 @@ export const SCHEMA = [
       ["default_playlist", "Default Playlist", "text"],
       ["use_favorites", "Use Favorites", "checkbox"],
       ["shuffle", "Shuffle", "checkbox"],
+    ],
+  ],
+  [
+    "tidal",
+    "Tidal Music",
+    [
+      ["enabled", "Enabled", "checkbox"],
+      ["client_id", "Client ID (optional)", "text"],
+      ["client_secret", "Client Secret (optional)", "text"],
+      ["default_playlist", "Default Playlist ID", "text"],
+      ["shuffle", "Shuffle", "checkbox"],
+      ["audio_quality", "Audio Quality", "select", ["LOW", "HIGH", "LOSSLESS", "HI_RES"]],
     ],
   ],
   ["external_audio", "External Audio", [["enabled", "Enabled", "checkbox"]]],

--- a/ui/test/render/settings.test.js
+++ b/ui/test/render/settings.test.js
@@ -13,8 +13,13 @@ describe("renderSettings", () => {
       general: { port: 8420 },
       local_files: { enabled: true },
       playback: { equalizer_bands: [1, 2, 3, 4, 5], race_start_playback: "restart" },
+      tidal: { enabled: true, client_id: "my-id", audio_quality: "LOSSLESS" },
     });
-    expect(form().querySelectorAll("fieldset").length).toBe(10);
+    const tidalEnabled = form().querySelector("#f-tidal-enabled");
+    expect(tidalEnabled).not.toBeNull();
+    expect(tidalEnabled.checked).toBe(true);
+    expect(form().querySelector("#f-tidal-client_id").value).toBe("my-id");
+    expect(form().querySelector("#f-tidal-audio_quality").value).toBe("LOSSLESS");
     expect(form().querySelector("#f-general-port").value).toBe("8420");
     expect(form().querySelector("#f-local_files-enabled").checked).toBe(true);
 

--- a/ui/test/render/settings.test.js
+++ b/ui/test/render/settings.test.js
@@ -14,7 +14,7 @@ describe("renderSettings", () => {
       local_files: { enabled: true },
       playback: { equalizer_bands: [1, 2, 3, 4, 5], race_start_playback: "restart" },
     });
-    expect(form().querySelectorAll("fieldset").length).toBe(9);
+    expect(form().querySelectorAll("fieldset").length).toBe(10);
     expect(form().querySelector("#f-general-port").value).toBe("8420");
     expect(form().querySelector("#f-local_files-enabled").checked).toBe(true);
 


### PR DESCRIPTION
This commit adds tidal support using the tidalapi pypi package. This is due to the Tidal API rejecting any other implementation of the API in native (I tried but kept getting errors from the tidal api that said device wasn't a limited input device, which is required to use code based auth and not a redirect to localhost)

- Offloads TIDAL authentication (OAuth2 device flow), token refreshing, and stream resolving to a local Python subprocess.
- Bootstraps dependencies inside an isolated local virtual environment (venv) to prevent system package contamination.
- Supports streaming both playlists and algorithm mixes.
- Adds an interactive, searchable playlist track list under the TIDAL card with active track highlighting and click-to-play.
- Implements album cover artwork next to track list items and on the main Now Playing display/backdrop.
- Passes global reconnect options to FFmpeg to make streams resilient against packet drops and CDN skipping.  

I've been playing with this fork for a while and haven't had any issues

Screenshots:
<img width="897" height="1016" alt="Screenshot 2026-06-09 223828" src="https://github.com/user-attachments/assets/7d7725bb-85d7-4a22-b3c2-8ff4042c0071" />
<img width="1416" height="1163" alt="Screenshot 2026-06-09 223832" src="https://github.com/user-attachments/assets/64a05b77-642f-412f-9a5d-3518c34ca26f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TIDAL streaming integration with auth, playback controls, playlist casting, queue management, shuffle and selectable audio quality
  * OAuth device-link and web authorization flows for account linkage

* **Tests**
  * Updated settings UI test to include TIDAL controls

* **Chores**
  * Build/install packaging updated to stage TIDAL helper and Python dependencies
  * Config schema extended with a TIDAL section and example entries
<!-- end of auto-generated comment: release notes by coderabbit.ai -->