### PR TITLE
Finalize worker logic, add Vanilla Radio support, and fix external audio deadlock

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -64,6 +64,12 @@ cache_dir          = 'spotify_cache'   # folder to save the Spotify Connect auth
 enabled               = true
 default_station_index = 0 # index of radio station in list (0 refers to start of the list)
 
+# when selected as the active source, this puts the DSP into passthrough mode
+# it bypasses the mod's custom audio injection, allowing the game's original radio stations to play normally
+# requires streamer mode off
+[vanilla_radio]
+enabled               = false
+
 # you can add as many stations as you want below. name + url are required; the
 # rest are filled in automatically when you save a station from the dashboard's
 # Discover tab (radio-browser.info) and are optional when adding by hand.

--- a/include/fh6/config.hpp
+++ b/include/fh6/config.hpp
@@ -106,6 +106,10 @@ struct SpotifyConfig {
     std::filesystem::path cache_dir = "spotify_cache";
 };
 
+struct VanillaRadioConfig {
+    bool enabled = false;
+};
+
 struct Config {
     GeneralConfig general;
     LocalFilesConfig local_files;
@@ -115,6 +119,7 @@ struct Config {
     ExternalAudioConfig external_audio;
     SpotifyConfig spotify;
     OnlineRadioConfig online_radio;
+    VanillaRadioConfig vanilla_radio;
     PlaybackConfig playback;
 };
 

--- a/include/fh6/sources/external_audio_source.hpp
+++ b/include/fh6/sources/external_audio_source.hpp
@@ -75,6 +75,8 @@ private:
     mutable std::string art_key_;
     mutable ArtworkImage art_;
 
+    TrackInfo cached_track_;
+
     std::mutex queue_mu_;
     std::vector<int16_t> pcm_queue_;
     std::size_t queue_offset_ = 0;

--- a/include/fh6/sources/vanilla_radio_source.hpp
+++ b/include/fh6/sources/vanilla_radio_source.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#include "fh6/audio_source.hpp"
+
+namespace fh6::sources {
+
+class VanillaRadioSource : public IAudioSource {
+public:
+    std::string_view name() const noexcept override { return "vanilla_radio"; }
+    std::string_view display_name() const noexcept override { return "Vanilla Radio"; }
+    bool initialize() override { return true; }
+    void shutdown() noexcept override {}
+    
+    void play() override { state_ = PlaybackState::playing; }
+    void pause() override { state_ = PlaybackState::paused; }
+    void stop() override { state_ = PlaybackState::stopped; }
+    
+    TrackInfo current_track() const override { return {"Vanilla Radio", "In-game Audio", "", ""}; }
+    PlaybackState playback_state() const noexcept override { return state_; }
+    AuthState auth_state() const noexcept override { return AuthState::none_required; }
+    SourceCapabilities capabilities() const noexcept override { return {}; }
+private:
+    PlaybackState state_ = PlaybackState::stopped;
+};
+
+} // namespace fh6::sources

--- a/include/fh6/sources/vanilla_radio_source.hpp
+++ b/include/fh6/sources/vanilla_radio_source.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <atomic>
 #include "fh6/audio_source.hpp"
 
 namespace fh6::sources {
@@ -10,16 +11,18 @@ public:
     bool initialize() override { return true; }
     void shutdown() noexcept override {}
     
-    void play() override { state_ = PlaybackState::playing; }
-    void pause() override { state_ = PlaybackState::paused; }
-    void stop() override { state_ = PlaybackState::stopped; }
+    void play() override { state_.store(PlaybackState::playing, std::memory_order_relaxed); }
+    void pause() override { state_.store(PlaybackState::paused, std::memory_order_relaxed); }
+    void stop() override { state_.store(PlaybackState::stopped, std::memory_order_relaxed); }
     
     TrackInfo current_track() const override { return {"Vanilla Radio", "In-game Audio", "", ""}; }
-    PlaybackState playback_state() const noexcept override { return state_; }
+    PlaybackState playback_state() const noexcept override {
+        return state_.load(std::memory_order_relaxed);
+    }
     AuthState auth_state() const noexcept override { return AuthState::none_required; }
     SourceCapabilities capabilities() const noexcept override { return {}; }
 private:
-    PlaybackState state_ = PlaybackState::stopped;
+    std::atomic<PlaybackState> state_{PlaybackState::stopped};
 };
 
 } // namespace fh6::sources

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -159,10 +159,17 @@ void run_bridge(HMODULE self) noexcept {
         auto worker_exe = data_dir / "fh6-radio-worker.exe";
         if (!std::filesystem::exists(worker_exe))
             worker_exe = dir / "fh6-radio" / "fh6-radio-worker.exe";
+        
+        // inherit the flag
+        SetEnvironmentVariableW(L"RUST_LOG", L"librespot_playback::player=debug,librespot_metadata=trace");
+        
         if (worker.start(worker_exe))
             log::info("[bridge] worker process started");
         else
             log::warn("[bridge] worker process unavailable -- falling back to direct spawn");
+    
+        // clear the flag
+        SetEnvironmentVariableW(L"RUST_LOG", nullptr);
     }
 
     // Register/unregister sources to match the enabled flags. Called at
@@ -207,7 +214,7 @@ void run_bridge(HMODULE self) noexcept {
         }
         if (c.spotify.enabled && !mgr.find("spotify")) {
             auto src = std::make_unique<sources::SpotifySource>(anchor_spotify(c.spotify, data_dir),
-                                                                c.general.ffmpeg_path);
+                                                                c.general.ffmpeg_path, &worker);
             if (src->initialize()) mgr.register_source(std::move(src));
         } else if (!c.spotify.enabled && mgr.find("spotify")) {
             mgr.unregister_source("spotify");

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -17,6 +17,7 @@
 #include "fh6/sources/spotify_source.hpp"
 #include "fh6/worker/worker_client.hpp"
 #include "fh6/sources/online_radio_source.hpp"
+#include "fh6/sources/vanilla_radio_source.hpp"
 
 #include <windows.h>
 #include <array>
@@ -218,6 +219,12 @@ void run_bridge(HMODULE self) noexcept {
             if (src->initialize()) mgr.register_source(std::move(src));
         } else if (!c.spotify.enabled && mgr.find("spotify")) {
             mgr.unregister_source("spotify");
+        }
+        if (c.vanilla_radio.enabled && !mgr.find("vanilla_radio")) {
+            auto src = std::make_unique<sources::VanillaRadioSource>();
+            if (src->initialize()) mgr.register_source(std::move(src));
+        } else if (!c.vanilla_radio.enabled && mgr.find("vanilla_radio")) {
+            mgr.unregister_source("vanilla_radio");
         }
     };
 

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -161,16 +161,25 @@ void run_bridge(HMODULE self) noexcept {
         if (!std::filesystem::exists(worker_exe))
             worker_exe = dir / "fh6-radio" / "fh6-radio-worker.exe";
         
-        // inherit the flag
-        SetEnvironmentVariableW(L"RUST_LOG", L"librespot_playback::player=debug,librespot_metadata=trace");
+        // Temporarily override RUST_LOG for worker launch, then restore prior value.
+        DWORD rust_log_len = GetEnvironmentVariableW(L"RUST_LOG", nullptr, 0);
+        std::wstring prev_rust_log;
+        const bool had_rust_log = rust_log_len > 0;
+        if (had_rust_log) {
+            prev_rust_log.resize(rust_log_len - 1); // exclude null terminator
+            GetEnvironmentVariableW(L"RUST_LOG", prev_rust_log.data(), rust_log_len);
+        }
+        SetEnvironmentVariableW(
+            L"RUST_LOG",
+            L"librespot_playback::player=debug,librespot_metadata=trace");
         
         if (worker.start(worker_exe))
             log::info("[bridge] worker process started");
         else
             log::warn("[bridge] worker process unavailable -- falling back to direct spawn");
     
-        // clear the flag
-        SetEnvironmentVariableW(L"RUST_LOG", nullptr);
+        if (had_rust_log) SetEnvironmentVariableW(L"RUST_LOG", prev_rust_log.c_str());
+        else SetEnvironmentVariableW(L"RUST_LOG", nullptr);
     }
 
     // Register/unregister sources to match the enabled flags. Called at

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -163,6 +163,10 @@ Config load_config(const std::filesystem::path& path) {
     cfg.external_audio.media_session_id =
         pick<std::string>(ea, "media_session_id", cfg.external_audio.media_session_id);
 
+
+    const auto& vr = section(root, "vanilla_radio");
+    cfg.vanilla_radio.enabled = pick<bool>(vr, "enabled", cfg.vanilla_radio.enabled);
+
     const auto& au = section(root, "audio");
     cfg.audio.output_gain =
         static_cast<float>(pick<double>(au, "output_gain", cfg.audio.output_gain));
@@ -345,6 +349,9 @@ void save_config(const std::filesystem::path& path, const Config& cfg) {
     e.kv("enabled", cfg.external_audio.enabled);
     e.kv("endpoint_id", cfg.external_audio.endpoint_id);
     e.kv("media_session_id", cfg.external_audio.media_session_id);
+
+    e.header("vanilla_radio");
+    e.kv("enabled", cfg.vanilla_radio.enabled);
 
     e.header("spotify");
     e.kv("enabled", cfg.spotify.enabled);

--- a/src/fmod/dsp_control_loop.cpp
+++ b/src/fmod/dsp_control_loop.cpp
@@ -80,6 +80,13 @@ void ControlLoop::run(const std::stop_token& tok) {
         bridge_.retarget_if_needed();
         bridge_.manager().pump_once();
 
+        auto* active_src = bridge_.manager().active();
+        if (active_src && active_src->name() == "vanilla_radio") {
+            bridge_.set_mode(DSPMode::passthrough);
+        } else {
+            bridge_.set_mode(DSPMode::pcm);
+        }
+
         // Skip refreshing while the station is silenced (pause menu, rewind):
         // the HUD isn't shown, and freezing the value lets the dedup in
         // MetadataInjector swallow the resume so the game doesn't re-pop its

--- a/src/fmod/dsp_control_loop.cpp
+++ b/src/fmod/dsp_control_loop.cpp
@@ -320,7 +320,7 @@ void ControlLoop::push_metadata() noexcept {
 
     // if using vanilla radio, let the game handle its own native metadata
     // reset the injector cache so that when we swap to a custom source,
-    // it will ovrewrite whatever native metadata the game wrote in the meantime
+    // it will overwrite whatever native metadata the game wrote in the meantime
     if (a->name() == "vanilla_radio") {
         meta_.reset_cache();
         return;

--- a/src/fmod/dsp_control_loop.cpp
+++ b/src/fmod/dsp_control_loop.cpp
@@ -93,7 +93,16 @@ void ControlLoop::run(const std::stop_token& tok) {
         // now-playing banner on every pause/rewind.
         if (++meta_tick >= kMetaEveryNTicks) {
             meta_tick = 0;
-            if (radio_audible_) push_metadata();
+            if (radio_audible_) {
+                // re-poll the discovery cache to grab the freshest SampleProperties body
+                // the game often reallocates this object entirely when native stations change
+                auto disc = discover_radio_instances(img_);
+                if (const RadioInstance* current = select_instance(disc)) {
+                    meta_.set_target(current->sample_props_body);
+                }
+                
+                push_metadata();
+            }
         }
 
         // Staleness watchdog: while a source is actively producing audio,
@@ -308,6 +317,15 @@ void ControlLoop::push_metadata() noexcept {
         meta_.update("FH6 Universal Radio", "Idle");
         return;
     }
+
+    // if using vanilla radio, let the game handle its own native metadata
+    // reset the injector cache so that when we swap to a custom source,
+    // it will ovrewrite whatever native metadata the game wrote in the meantime
+    if (a->name() == "vanilla_radio") {
+        meta_.reset_cache();
+        return;
+    }
+
     TrackInfo info;
     try {
         info = a->current_track();

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -204,6 +204,10 @@ json config_to_json(const Config& c) {
                   return arr;
               }()}
          }},
+        {"vanilla_radio",
+         json{
+             {"enabled", c.vanilla_radio.enabled},
+         }},
         {"audio",
          json{
              {"output_gain", c.audio.output_gain},
@@ -333,6 +337,9 @@ void apply_patch(Config& c, const json& j) {
         } else if (c.online_radio.default_station_index >= c.online_radio.stations.size()) {
             c.online_radio.default_station_index = 0; // or last valid index
         }
+    }
+    if (auto it = j.find("vanilla_radio"); it != j.end()) {
+        c.vanilla_radio.enabled = pull(*it, "enabled", c.vanilla_radio.enabled);
     }
     if (auto it = j.find("audio"); it != j.end()) {
         c.audio.output_gain = pull(*it, "output_gain", c.audio.output_gain);

--- a/src/sources/external_audio_source.cpp
+++ b/src/sources/external_audio_source.cpp
@@ -543,21 +543,47 @@ void ExternalAudioSource::on_radio_audible(bool audible) {
 void ExternalAudioSource::set_media_transport(bool play) {
     if (media_active_.exchange(play) == play) return;
     const auto session = configured_media_session();
-    if (play) {
-        external_audio_media_session_play(session);
-    } else {
-        external_audio_media_session_pause(session);
-    }
+    
+    // dispatch to a background thread so the FMOD DSP control loop never blocks
+    std::thread([session, play]() {
+        // initialize COM for this new background thread
+        HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+        
+        if (play) {
+            external_audio_media_session_play(session);
+        } else {
+            external_audio_media_session_pause(session);
+        }
+        
+        // cleanup COM
+        if (SUCCEEDED(hr)) {
+            CoUninitialize();
+        }
+    }).detach();
 }
 
 void ExternalAudioSource::next() { (void)skip_next(); }
 
 void ExternalAudioSource::previous() {
-    (void)external_audio_media_session_previous(configured_media_session());
+    position_ms_.store(0, std::memory_order_release);
+    const auto session = configured_media_session();
+    std::thread([session]() {
+        HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+        external_audio_media_session_previous(session);
+        if (SUCCEEDED(hr)) CoUninitialize();
+    }).detach();
 }
 
 bool ExternalAudioSource::skip_next() {
-    return external_audio_media_session_next(configured_media_session());
+    position_ms_.store(0, std::memory_order_release);
+    const auto session = configured_media_session();
+    std::thread([session]() {
+        HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+        external_audio_media_session_next(session);
+        if (SUCCEEDED(hr)) CoUninitialize();
+    }).detach();
+
+    return true; 
 }
 
 void ExternalAudioSource::pump(RingBuffer& ring) {
@@ -603,36 +629,12 @@ void ExternalAudioSource::pump(RingBuffer& ring) {
 }
 
 TrackInfo ExternalAudioSource::current_track() const {
-    const auto fallback_position = position_ms_.load(std::memory_order_acquire);
-    const auto selected_session  = configured_media_session();
-    if (auto t = external_audio_media_session_track(selected_session, fallback_position)) {
-        if (t->album.empty()) t->album = "External Audio";
-
-        const std::string key = t->title + '\x1f' + t->artist;
-        bool need_fetch;
-        {
-            std::scoped_lock lk{meta_mu_};
-            need_fetch = (key != art_key_);
-        }
-        std::optional<ArtworkImage> fetched;
-        if (need_fetch) fetched = external_audio_media_session_thumbnail(selected_session);
-
-        std::scoped_lock lk{meta_mu_};
-        if (need_fetch) {
-            art_key_ = key;
-            art_     = fetched ? std::move(*fetched) : ArtworkImage{};
-        }
-        if (!art_.bytes.empty())
-            t->artwork_url = "/api/artwork?v=" + std::to_string(std::hash<std::string>{}(key));
-        return *t;
-    }
-
     std::scoped_lock lk{meta_mu_};
-    TrackInfo t;
-    t.title       = "External Audio";
-    t.artist      = device_name_.empty() ? "No media session metadata" : device_name_;
-    t.album       = "External Audio";
-    t.position_ms = fallback_position;
+    TrackInfo t = cached_track_;
+    
+    // override the cached position_ms with the live position_ms_ 
+    // so the progress bar in the UI remains smooth between polls
+    t.position_ms = position_ms_.load(std::memory_order_acquire);
     return t;
 }
 
@@ -818,7 +820,66 @@ void ExternalAudioSource::capture_loop() noexcept {
     Resampler resampler;
     resampler.fmt = input;
 
+    // force an immediate poll on the first loop iteration
+    auto last_meta_poll = std::chrono::steady_clock::now() - std::chrono::seconds(10);
+
     while (!had_error && !stop_requested_.load(std::memory_order_acquire)) {
+        auto now = std::chrono::steady_clock::now();
+        if (now - last_meta_poll >= std::chrono::seconds(1)) {
+            last_meta_poll = now;
+            
+            const auto selected_session = configured_media_session();
+            TrackInfo next_track;
+            
+            if (auto t = external_audio_media_session_track(selected_session, position_ms_.load(std::memory_order_acquire))) {
+                next_track = std::move(*t);
+                if (next_track.album.empty()) next_track.album = "External Audio";
+                
+                const std::string key = next_track.title + '\x1f' + next_track.artist;
+                
+                bool track_changed = false;
+                {
+                    std::scoped_lock lk{meta_mu_};
+                    track_changed = (key != art_key_);
+                }
+                
+                if (track_changed) {
+                    position_ms_.store(0, std::memory_order_release);
+                    next_track.position_ms = 0;
+                    
+                    auto fetched = external_audio_media_session_thumbnail(selected_session);
+                    std::scoped_lock lk{meta_mu_};
+                    art_key_ = key;
+                    art_ = fetched ? std::move(*fetched) : ArtworkImage{};
+                } else {
+                    const uint64_t smooth_time = position_ms_.load(std::memory_order_acquire);
+                    const uint64_t smtc_time = next_track.position_ms;
+                    
+                    // calculate absolute difference
+                    const uint64_t diff = (smooth_time > smtc_time) 
+                        ? (smooth_time - smtc_time) 
+                        : (smtc_time - smooth_time);
+
+                    if (diff > 4000) {
+                        position_ms_.store(smtc_time, std::memory_order_release);
+                    }
+                }
+                
+                std::scoped_lock lk{meta_mu_};
+                if (!art_.bytes.empty()) {
+                    next_track.artwork_url = "/api/artwork?v=" + std::to_string(std::hash<std::string>{}(key));
+                }
+                cached_track_ = next_track;
+            } else {
+                std::scoped_lock lk{meta_mu_};
+                next_track.title = "External Audio";
+                next_track.artist = device_name_.empty() ? "No media session metadata" : device_name_;
+                next_track.album = "External Audio";
+                next_track.position_ms = position_ms_.load(std::memory_order_acquire);
+                cached_track_ = next_track;
+            }
+        }
+
         UINT32 next_packet_frames = 0;
         hr                        = capture->GetNextPacketSize(&next_packet_frames);
         if (FAILED(hr)) {

--- a/ui/dist/js/schema.js
+++ b/ui/dist/js/schema.js
@@ -6,6 +6,7 @@ export const SOURCE_SECTIONS = [
   ["jellyfin", "Jellyfin"],
   ["external_audio", "External Audio"],
   ["spotify", "Spotify Connect"],
+  ["vanilla_radio", "Vanilla Radio"],
 ];
 
 // [field, label, type, ...args]. type: checkbox | text | number | select | bands.
@@ -72,6 +73,13 @@ export const SCHEMA = [
       ["default_station_index", "Default station", "station-select"],
       // Stations, favourites and discovery live in the dedicated Online Radio
       // card on the dashboard (render/onlineRadio.js).
+    ],
+  ],
+  [
+    "vanilla_radio",
+    "Vanilla Radio",
+    [
+      ["enabled", "Enabled", "checkbox"],
     ],
   ],
   ["audio", "Audio", [["output_gain", "Output gain", "number", 0, 1, 0.01]]],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Vanilla Radio mode: a passthrough option for in-game original radio stations (disabled by default; requires streamer mode off)

* **Configuration**
  * New vanilla radio configuration section with enable/disable toggle

* **Improvements**
  * Enhanced external audio source handling with improved metadata polling and media transport control performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->