### PR TITLE
feat(ytm): Add queue management and track selection

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -38,9 +38,9 @@ shuffle            = true
 
 # you can add as many stations as you want below. name + url are required; the
 # rest are filled in automatically when you save a station from the dashboard
-[[youtube_music.stations]]
-name = "My Playlist"
-url = ""
+#[[youtube_music.stations]]
+#name = "My Playlist"
+#url = ""
 
 [jellyfin]
 enabled            = false

--- a/config.example.toml
+++ b/config.example.toml
@@ -33,8 +33,14 @@ repeat    = "all"                      # "all" | "one" | "off"
 enabled            = false
 cookies_path       = ''                # optional Netscape cookies.txt
 yt_dlp_path        = ''                # blank = auto-download to fh6-radio/bin (else `yt-dlp` on PATH)
-default_playlist   = ""
+active_station     = ""     # which station is currently active
 shuffle            = true
+
+# you can add as many stations as you want below. name + url are required; the
+# rest are filled in automatically when you save a station from the dashboard
+[[youtube_music.stations]]
+name = "My Playlist"
+url = ""
 
 [jellyfin]
 enabled            = false
@@ -44,7 +50,6 @@ user_id            = ''                # the ID of the user to track playback ag
 default_playlist   = ''                # jellyfin playlist ID goes here
 use_favorites      = false             # set to true to play your favorites instead of a playlist
 shuffle            = true              # true or false
-
 
 [external_audio]
 # Off by default. Enable from the dashboard Settings drawer before using External Audio.
@@ -64,12 +69,6 @@ cache_dir          = 'spotify_cache'   # folder to save the Spotify Connect auth
 enabled               = true
 default_station_index = 0 # index of radio station in list (0 refers to start of the list)
 
-# when selected as the active source, this puts the DSP into passthrough mode
-# it bypasses the mod's custom audio injection, allowing the game's original radio stations to play normally
-# requires streamer mode off
-[vanilla_radio]
-enabled               = false
-
 # you can add as many stations as you want below. name + url are required; the
 # rest are filled in automatically when you save a station from the dashboard's
 # Discover tab (radio-browser.info) and are optional when adding by hand.
@@ -83,6 +82,12 @@ enabled               = false
 #bitrate  = 0  # kbps
 #uuid     = "" # radio-browser station id
 #favorite = false
+
+# when selected as the active source, this puts the DSP into passthrough mode
+# it bypasses the mod's custom audio injection, allowing the game's original radio stations to play normally
+# requires streamer mode off
+[vanilla_radio]
+enabled               = false
 
 [audio]
 output_gain = 1.0

--- a/include/fh6/config.hpp
+++ b/include/fh6/config.hpp
@@ -47,11 +47,17 @@ struct LocalFilesConfig {
                                                "aac", "wma",  "aiff", "aif", "m3u", "m3u8"};
 };
 
+struct YouTubeStation {
+    std::string name;
+    std::string url;
+};
+
 struct YouTubeMusicConfig {
     bool enabled = false;
     std::filesystem::path cookies_path;
     std::filesystem::path yt_dlp_path; // empty = look up on PATH
-    std::string default_playlist;
+    std::vector<YouTubeStation> stations;
+    std::string active_station; // station name; empty/unknown => first station
     bool shuffle = true;
 };
 

--- a/include/fh6/http/http_server.hpp
+++ b/include/fh6/http/http_server.hpp
@@ -25,7 +25,21 @@ namespace fh6::http {
 //   POST /api/source/switch               body {"source":"name"}
 //   POST /api/source/<name>/{play,pause,stop,next,previous}
 //
-//   POST /api/source/youtube_music/cast   body {"url":"..."}
+//   POST /api/source/youtube_music/shuffle  body {"shuffle":true|false}
+//   GET  /api/source/youtube_music/stations
+//   PUT  /api/source/youtube_music/stations body {"stations":[...],"active_station":"..."}
+//   POST /api/source/youtube_music/activate body {"name":"..."}
+//   GET  /api/source/youtube_music/queue
+//   POST /api/source/youtube_music/play     body {"index":N}
+//
+//   POST /api/source/online_radio/cast      body {"url":"...", ...}
+//
+//   POST /api/source/jellyfin/cast          body {"playlist_id":"..."}
+//
+//   GET  /api/external_audio/devices
+//   PUT  /api/external_audio/config
+//
+//   POST /api/source/local_files/rescan
 //
 //   POST /api/fs/browse                   body {"path":"..."}; "" => drive list
 //   GET  /api/source/local_files/stations stations + active_station + track_count

--- a/include/fh6/http/http_server.hpp
+++ b/include/fh6/http/http_server.hpp
@@ -25,6 +25,7 @@ namespace fh6::http {
 //   POST /api/source/switch               body {"source":"name"}
 //   POST /api/source/<name>/{play,pause,stop,next,previous}
 //
+//   POST /api/source/youtube_music/cast     body {"url":"..."}
 //   POST /api/source/youtube_music/shuffle  body {"shuffle":true|false}
 //   GET  /api/source/youtube_music/stations
 //   PUT  /api/source/youtube_music/stations body {"stations":[...],"active_station":"..."}

--- a/include/fh6/sources/youtube_music_source.hpp
+++ b/include/fh6/sources/youtube_music_source.hpp
@@ -48,6 +48,26 @@ public:
     void set_yt_dlp_path(std::filesystem::path p);
     void set_playback_options(const PlaybackConfig& opts) override;
 
+    void set_config(YouTubeMusicConfig cfg);
+    void set_active_station(std::string name);
+
+    std::size_t station_count() const noexcept;
+    std::string active_station_name() const;
+
+    struct QueueEntry {
+        std::size_t index;
+        std::string url;
+        std::string title;
+        std::string artist;
+    };
+    struct QueueSnapshot {
+        std::size_t cursor;
+        std::vector<QueueEntry> entries;
+    };
+
+    QueueSnapshot queue_snapshot() const;
+    bool jump_to(std::size_t index);
+
     TrackInfo current_track() const override;
     PlaybackState playback_state() const noexcept override {
         return state_.load(std::memory_order_acquire);
@@ -78,9 +98,16 @@ private:
     std::unique_ptr<Pipe> pipe_;
     std::unique_ptr<Pipe> prefetch_; // pre-spawned next-track pipeline (or null)
 
+    const YouTubeStation* active_station_locked() const noexcept;
+
     mutable std::mutex mu_;
     std::string target_url_;
-    std::vector<std::string> queue_; // canonical watch URLs in playback order
+    struct InternalQueueEntry {
+        std::string url;
+        std::string title;
+        std::string artist;
+    };
+    std::vector<InternalQueueEntry> queue_; // canonical watch URLs in playback order
     std::size_t queue_idx_ = 0;
     std::string queue_built_for_; // value of target_url_ when queue_ was resolved
     std::atomic<uint64_t> position_ms_{0};

--- a/include/fh6/sources/youtube_music_source.hpp
+++ b/include/fh6/sources/youtube_music_source.hpp
@@ -76,7 +76,10 @@ public:
     std::string auth_instructions() const override;
     SourceCapabilities capabilities() const noexcept override { return {false, true, true}; }
 
-    bool shuffle() const noexcept { return cfg_.shuffle; }
+    bool shuffle() const {
+        std::scoped_lock lk{mu_};
+        return cfg_.shuffle;
+    }
 
 private:
     struct Pipe;

--- a/include/fh6/worker/worker_client.hpp
+++ b/include/fh6/worker/worker_client.hpp
@@ -24,7 +24,8 @@ public:
     WorkerClient& operator=(const WorkerClient&) = delete;
 
     /// Launch the worker process and connect to its control pipe.
-    bool start(const std::filesystem::path& worker_exe);
+    bool start(const std::filesystem::path& worker_exe, 
+                   const std::vector<std::pair<std::wstring, std::wstring>>& env_overrides = {});
 
     /// Send shutdown and wait for the worker to exit.
     void stop();

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -284,9 +284,10 @@ void run_bridge(HMODULE self) noexcept {
             }
         }
         if (auto* yt = dynamic_cast<sources::YouTubeMusicSource*>(mgr.find("youtube_music"))) {
-            yt->set_shuffle(c.youtube_music.shuffle);
             yt->set_ffmpeg_path(c.general.ffmpeg_path);
+            yt->set_config(c.youtube_music); 
             yt->set_yt_dlp_path(c.youtube_music.yt_dlp_path);
+            yt->set_shuffle(c.youtube_music.shuffle);
         }
         if (auto* jf = dynamic_cast<sources::JellyfinSource*>(mgr.find("jellyfin"))) {
             jf->set_ffmpeg_path(c.general.ffmpeg_path);

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -161,25 +161,11 @@ void run_bridge(HMODULE self) noexcept {
         if (!std::filesystem::exists(worker_exe))
             worker_exe = dir / "fh6-radio" / "fh6-radio-worker.exe";
         
-        // Temporarily override RUST_LOG for worker launch, then restore prior value.
-        DWORD rust_log_len = GetEnvironmentVariableW(L"RUST_LOG", nullptr, 0);
-        std::wstring prev_rust_log;
-        const bool had_rust_log = rust_log_len > 0;
-        if (had_rust_log) {
-            prev_rust_log.resize(rust_log_len - 1); // exclude null terminator
-            GetEnvironmentVariableW(L"RUST_LOG", prev_rust_log.data(), rust_log_len);
-        }
-        SetEnvironmentVariableW(
-            L"RUST_LOG",
-            L"librespot_playback::player=debug,librespot_metadata=trace");
-        
-        if (worker.start(worker_exe))
+        if (worker.start(worker_exe, {{L"RUST_LOG", L"librespot_playback::player=debug,librespot_metadata=trace"}})) {
             log::info("[bridge] worker process started");
-        else
+        } else {
             log::warn("[bridge] worker process unavailable -- falling back to direct spawn");
-    
-        if (had_rust_log) SetEnvironmentVariableW(L"RUST_LOG", prev_rust_log.c_str());
-        else SetEnvironmentVariableW(L"RUST_LOG", nullptr);
+        }
     }
 
     // Register/unregister sources to match the enabled flags. Called at

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -115,8 +115,30 @@ Config load_config(const std::filesystem::path& path) {
     cfg.youtube_music.enabled          = pick<bool>(ym, "enabled", cfg.youtube_music.enabled);
     cfg.youtube_music.cookies_path     = pick_path(ym, "cookies_path");
     cfg.youtube_music.yt_dlp_path      = pick_path(ym, "yt_dlp_path");
-    cfg.youtube_music.default_playlist = pick<std::string>(ym, "default_playlist", "");
+    cfg.youtube_music.active_station   = pick<std::string>(ym, "active_station", "");
     cfg.youtube_music.shuffle          = pick<bool>(ym, "shuffle", cfg.youtube_music.shuffle);
+
+    try {
+        if (ym.contains("stations")) {
+            for (const auto& st : toml::find<std::vector<toml::value>>(ym, "stations")) {
+                YouTubeStation s;
+                s.name = pick<std::string>(st, "name", "");
+                s.url  = pick<std::string>(st, "url", "");
+                cfg.youtube_music.stations.push_back(std::move(s));
+            }
+        }
+    } catch (...) {}
+
+    // fallback to migrate old configs that still use default_playlist
+    if (cfg.youtube_music.stations.empty()) {
+        auto dp = pick<std::string>(ym, "default_playlist", "");
+        if (!dp.empty()) {
+            cfg.youtube_music.stations.push_back({"My Playlist", dp});
+        }
+    }
+    if (cfg.youtube_music.active_station.empty() && !cfg.youtube_music.stations.empty()) {
+        cfg.youtube_music.active_station = cfg.youtube_music.stations.front().name;
+    }
 
     const auto& sp             = section(root, "spotify");
     cfg.spotify.enabled        = pick<bool>(sp, "enabled", cfg.spotify.enabled);
@@ -333,8 +355,13 @@ void save_config(const std::filesystem::path& path, const Config& cfg) {
     e.kv("enabled", cfg.youtube_music.enabled);
     e.kv_path("cookies_path", cfg.youtube_music.cookies_path);
     e.kv_path("yt_dlp_path", cfg.youtube_music.yt_dlp_path);
-    e.kv("default_playlist", cfg.youtube_music.default_playlist);
+    e.kv("active_station", cfg.youtube_music.active_station);
     e.kv("shuffle", cfg.youtube_music.shuffle);
+    for (const auto& st : cfg.youtube_music.stations) {
+        e.array_header("youtube_music.stations");
+        e.kv("name", st.name);
+        e.kv("url", st.url);
+    }
 
     e.header("jellyfin");
     e.kv("enabled", cfg.jellyfin.enabled);

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -106,8 +106,15 @@ json source_to_json(IAudioSource* s) {
         j["details"]["repeat"]         = lf->active_repeat();
         j["details"]["index_version"]  = lf->index_version();
     }
-    if (auto* yt = dynamic_cast<sources::YouTubeMusicSource*>(s))
+    if (auto* yt = dynamic_cast<sources::YouTubeMusicSource*>(s)) {
         j["details"]["shuffle"] = yt->shuffle();
+        j["details"]["station_count"] = yt->station_count();
+        j["details"]["active_station"] = yt->active_station_name();
+
+        auto snap = yt->queue_snapshot();
+        j["details"]["queue_size"] = snap.entries.size();
+        j["details"]["queue_cursor"] = snap.cursor;
+    }
     if (auto* rd = dynamic_cast<sources::OnlineRadioSource*>(s))
         j["details"]["song_history"] = rd->song_history();
     return j;
@@ -137,6 +144,23 @@ json stations_to_json(const std::vector<LocalStation>& v) {
     return a;
 }
 
+json yt_station_to_json(const YouTubeStation& s) {
+    return json{{"name", s.name}, {"url", s.url}};
+}
+
+json yt_stations_to_json(const std::vector<YouTubeStation>& v) {
+    json a = json::array();
+    for (const auto& s : v) a.push_back(yt_station_to_json(s));
+    return a;
+}
+
+YouTubeStation yt_station_from_json(const json& j) {
+    return YouTubeStation{
+        j.value("name", ""),
+        j.value("url", "")
+    };
+}
+
 json config_to_json(const Config& c) {
     return json{
         {"general",
@@ -159,7 +183,8 @@ json config_to_json(const Config& c) {
              {"enabled", c.youtube_music.enabled},
              {"cookies_path", path_s(c.youtube_music.cookies_path)},
              {"yt_dlp_path", path_s(c.youtube_music.yt_dlp_path)},
-             {"default_playlist", c.youtube_music.default_playlist},
+             {"active_station", c.youtube_music.active_station},
+             {"stations", yt_stations_to_json(c.youtube_music.stations)},
              {"shuffle", c.youtube_music.shuffle},
          }},
         {"jellyfin",
@@ -288,8 +313,12 @@ void apply_patch(Config& c, const json& j) {
         c.youtube_music.enabled      = pull(*it, "enabled", c.youtube_music.enabled);
         c.youtube_music.cookies_path = pull_path(*it, "cookies_path", c.youtube_music.cookies_path);
         c.youtube_music.yt_dlp_path  = pull_path(*it, "yt_dlp_path", c.youtube_music.yt_dlp_path);
-        c.youtube_music.default_playlist =
-            pull(*it, "default_playlist", c.youtube_music.default_playlist);
+        c.youtube_music.active_station = pull(*it, "active_station", c.youtube_music.active_station);
+        if (auto sts = it->find("stations"); sts != it->end() && sts->is_array()) {
+            std::vector<YouTubeStation> parsed;
+            for (const auto& st : *sts) parsed.push_back(yt_station_from_json(st));
+            c.youtube_music.stations = std::move(parsed);
+        }
         c.youtube_music.shuffle = pull(*it, "shuffle", c.youtube_music.shuffle);
     }
     if (auto it = j.find("jellyfin"); it != j.end()) {
@@ -802,24 +831,68 @@ struct HttpServer::Impl {
                            {"endpoint_id", snap.external_audio.endpoint_id},
                            {"media_session_id", snap.external_audio.media_session_id}});
         }
-        if (m == "POST" && p == "/api/source/youtube_music/cast") {
-            auto* yt = find_typed<sources::YouTubeMusicSource>("youtube_music");
-            if (!yt) return fail(404, "youtube_music not registered");
-            auto url              = json::parse(req.body).at("url").get<std::string>();
-            const bool was_active = (mgr.active() == yt);
-            yt->set_target(std::move(url));
-            yt->stop();
-            if (was_active) mgr.ring().drain();
-            yt->play();
-            mgr.switch_to("youtube_music");
-            return ok();
-        }
         if (m == "POST" && p == "/api/source/youtube_music/shuffle") {
             auto* yt = find_typed<sources::YouTubeMusicSource>("youtube_music");
             if (!yt) return fail(404, "youtube_music not registered");
             auto shuffle = json::parse(req.body).at("shuffle").get<bool>();
             yt->set_shuffle(shuffle);
             store.patch([shuffle](Config& c) { c.youtube_music.shuffle = shuffle; });
+            return ok();
+        }
+        if (m == "GET" && p == "/api/source/youtube_music/stations") {
+            auto snap = store.snapshot();
+            return ok(json{
+                {"stations", yt_stations_to_json(snap.youtube_music.stations)},
+                {"active_station", snap.youtube_music.active_station}
+            });
+        }
+        if (m == "PUT" && p == "/api/source/youtube_music/stations") {
+            auto j = json::parse(req.body);
+            store.patch([&](Config& c) {
+                if (auto sts = j.find("stations"); sts != j.end() && sts->is_array()) {
+                    std::vector<YouTubeStation> parsed;
+                    for (const auto& st : *sts) parsed.push_back(yt_station_from_json(st));
+                    c.youtube_music.stations = std::move(parsed);
+                }
+                if (auto a = j.find("active_station"); a != j.end() && a->is_string())
+                    c.youtube_music.active_station = a->get<std::string>();
+            });
+            auto* yt = find_typed<sources::YouTubeMusicSource>("youtube_music");
+            if (yt) yt->set_config(store.snapshot().youtube_music);
+            return ok();
+        }
+        if (m == "POST" && p == "/api/source/youtube_music/activate") {
+            auto* yt = find_typed<sources::YouTubeMusicSource>("youtube_music");
+            if (!yt) return fail(404, "youtube_music not registered");
+            auto name             = json::parse(req.body).value("name", std::string{});
+            const bool was_active = (mgr.active() == yt);
+            store.patch([&](Config& c) { c.youtube_music.active_station = name; });
+            yt->set_active_station(name);
+            if (was_active) mgr.ring().drain();
+            yt->play();
+            mgr.switch_to("youtube_music");
+            return ok();
+        }
+        if (m == "GET" && p == "/api/source/youtube_music/queue") {
+            auto* yt = find_typed<sources::YouTubeMusicSource>("youtube_music");
+            if (!yt) return fail(404, "youtube_music not registered");
+            auto snap   = yt->queue_snapshot();
+            json tracks = json::array();
+            for (const auto& e : snap.entries) {
+                tracks.push_back(
+                    json{{"index", e.index}, {"title", e.title}, {"artist", e.artist}, {"url", e.url}});
+            }
+            return ok(json{{"cursor", snap.cursor}, {"tracks", tracks}});
+        }
+
+        if (m == "POST" && p == "/api/source/youtube_music/play") {
+            auto* yt = find_typed<sources::YouTubeMusicSource>("youtube_music");
+            if (!yt) return fail(404, "youtube_music not registered");
+            auto idx              = json::parse(req.body).value("index", std::size_t{0});
+            const bool was_active = (mgr.active() == yt);
+            if (!yt->jump_to(idx)) return fail(400, "index out of range");
+            if (was_active) mgr.ring().drain();
+            mgr.switch_to("youtube_music");
             return ok();
         }
         if (m == "POST" && p == "/api/source/jellyfin/cast") {

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -755,7 +755,7 @@ struct HttpServer::Impl {
         if (m == "POST" && p == "/api/source/local_files/play" && !req.body.empty()) {
             auto* lf = find_typed<sources::LocalFileSource>("local_files");
             if (!lf) return fail(404, "local_files not registered");
-            auto idx              = json::parse(req.body).value("index", std::size_t{0});
+            auto idx              = json::parse(req.body).at("index").get<std::size_t>();
             const bool was_active = (mgr.active() == lf);
             if (!lf->jump_to(idx)) return fail(400, "index out of range");
             if (was_active) mgr.ring().drain();
@@ -835,6 +835,7 @@ struct HttpServer::Impl {
             auto* yt = find_typed<sources::YouTubeMusicSource>("youtube_music");
             if (!yt) return fail(404, "youtube_music not registered");
             auto url              = json::parse(req.body).at("url").get<std::string>();
+            if (url.empty()) return fail(400, "url required");
             const bool was_active = (mgr.active() == yt);
             yt->stop();
             yt->set_target(std::move(url));
@@ -900,7 +901,7 @@ struct HttpServer::Impl {
         if (m == "POST" && p == "/api/source/youtube_music/play" && !req.body.empty()) {
             auto* yt = find_typed<sources::YouTubeMusicSource>("youtube_music");
             if (!yt) return fail(404, "youtube_music not registered");
-            auto idx              = json::parse(req.body).value("index", std::size_t{0});
+            auto idx              = json::parse(req.body).at("index").get<std::size_t>();
             const bool was_active = (mgr.active() == yt);
             if (!yt->jump_to(idx)) return fail(400, "index out of range");
             if (was_active) mgr.ring().drain();

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -752,7 +752,7 @@ struct HttpServer::Impl {
             mgr.switch_to("local_files");
             return ok(json{{"track_count", lf->track_count()}});
         }
-        if (m == "POST" && p == "/api/source/local_files/play") {
+        if (m == "POST" && p == "/api/source/local_files/play" && !req.body.empty()) {
             auto* lf = find_typed<sources::LocalFileSource>("local_files");
             if (!lf) return fail(404, "local_files not registered");
             auto idx              = json::parse(req.body).value("index", std::size_t{0});
@@ -831,6 +831,18 @@ struct HttpServer::Impl {
                            {"endpoint_id", snap.external_audio.endpoint_id},
                            {"media_session_id", snap.external_audio.media_session_id}});
         }
+        if (m == "POST" && p == "/api/source/youtube_music/cast") {
+            auto* yt = find_typed<sources::YouTubeMusicSource>("youtube_music");
+            if (!yt) return fail(404, "youtube_music not registered");
+            auto url              = json::parse(req.body).at("url").get<std::string>();
+            const bool was_active = (mgr.active() == yt);
+            yt->stop();
+            yt->set_target(std::move(url));
+            if (was_active) mgr.ring().drain();
+            yt->play();
+            mgr.switch_to("youtube_music");
+            return ok();
+        }
         if (m == "POST" && p == "/api/source/youtube_music/shuffle") {
             auto* yt = find_typed<sources::YouTubeMusicSource>("youtube_music");
             if (!yt) return fail(404, "youtube_music not registered");
@@ -885,7 +897,7 @@ struct HttpServer::Impl {
             return ok(json{{"cursor", snap.cursor}, {"tracks", tracks}});
         }
 
-        if (m == "POST" && p == "/api/source/youtube_music/play") {
+        if (m == "POST" && p == "/api/source/youtube_music/play" && !req.body.empty()) {
             auto* yt = find_typed<sources::YouTubeMusicSource>("youtube_music");
             if (!yt) return fail(404, "youtube_music not registered");
             auto idx              = json::parse(req.body).value("index", std::size_t{0});

--- a/src/sources/youtube_music_source.cpp
+++ b/src/sources/youtube_music_source.cpp
@@ -91,7 +91,6 @@ const YouTubeStation* YouTubeMusicSource::active_station_locked() const noexcept
 }
 
 void YouTubeMusicSource::set_config(YouTubeMusicConfig cfg) {
-    bool rescan = false;
     {
         std::scoped_lock lk{mu_};
         const auto* old_st = active_station_locked();
@@ -108,15 +107,12 @@ void YouTubeMusicSource::set_config(YouTubeMusicConfig cfg) {
         std::string new_url = new_st ? new_st->url : "";
         
         if (old_url != new_url && target_url_.empty()) {
-            rescan = true;
+            discard_prefetch_locked();
+            stop_pipe_locked();
+            queue_.clear();
+            queue_idx_ = 0;
+            queue_built_for_.clear();
         }
-    }
-    if (rescan) {
-        std::scoped_lock lk{mu_};
-        queue_.clear();
-        queue_idx_ = 0;
-        queue_built_for_.clear();
-        discard_prefetch_locked();
     }
 }
 
@@ -125,10 +121,11 @@ void YouTubeMusicSource::set_active_station(std::string name) {
     if (cfg_.active_station == name && target_url_.empty()) return;
     cfg_.active_station = std::move(name);
     target_url_.clear(); // clear temporary cast target
+    discard_prefetch_locked();
+    stop_pipe_locked();
     queue_.clear();
     queue_idx_ = 0;
     queue_built_for_.clear();
-    discard_prefetch_locked();
 }
 
 std::size_t YouTubeMusicSource::station_count() const noexcept {
@@ -306,17 +303,13 @@ void YouTubeMusicSource::resolve_queue_locked() {
         while (!line.empty() && (line.back() == '\r' || line.back() == ' ' || line.back() == '\t'))
             line.pop_back();
         if (!line.empty() && line != "NA") {
-            auto tab = line.find('\t');
-            if (!line.empty() && line != "NA") {
-            auto tab = line.find('\t');
-            if (tab != std::string::npos) {
-                std::string id = line.substr(0, tab);
-                std::string title = line.substr(tab + 1);
+            const auto tab = line.find('\t');
+            const std::string id = tab == std::string::npos ? line : line.substr(0, tab);
+            if (!id.empty() && id != "NA") {
+                const std::string title =
+                    tab == std::string::npos ? std::string{} : line.substr(tab + 1);
                 queue_.push_back({watch_url_for_id(id), title, ""});
-            } else {
-                queue_.push_back({watch_url_for_id(line), "", ""});
             }
-        }
         }
         pos = (nl == std::string::npos) ? raw.size() : nl + 1;
     }

--- a/src/sources/youtube_music_source.cpp
+++ b/src/sources/youtube_music_source.cpp
@@ -83,12 +83,73 @@ YouTubeMusicSource::YouTubeMusicSource(YouTubeMusicConfig cfg, std::filesystem::
 
 YouTubeMusicSource::~YouTubeMusicSource() { stop_pipe_locked(); }
 
+const YouTubeStation* YouTubeMusicSource::active_station_locked() const noexcept {
+    if (cfg_.stations.empty()) return nullptr;
+    for (const auto& s : cfg_.stations)
+        if (s.name == cfg_.active_station) return &s;
+    return &cfg_.stations.front();
+}
+
+void YouTubeMusicSource::set_config(YouTubeMusicConfig cfg) {
+    bool rescan = false;
+    {
+        std::scoped_lock lk{mu_};
+        const auto* old_st = active_station_locked();
+        std::string old_url = old_st ? old_st->url : "";
+        
+        // preserve resolved path
+        if (cfg.yt_dlp_path.empty() && !cfg_.yt_dlp_path.empty()) {
+            cfg.yt_dlp_path = cfg_.yt_dlp_path;
+        }
+
+        cfg_ = std::move(cfg);
+        
+        const auto* new_st = active_station_locked();
+        std::string new_url = new_st ? new_st->url : "";
+        
+        if (old_url != new_url && target_url_.empty()) {
+            rescan = true;
+        }
+    }
+    if (rescan) {
+        std::scoped_lock lk{mu_};
+        queue_.clear();
+        queue_idx_ = 0;
+        queue_built_for_.clear();
+        discard_prefetch_locked();
+    }
+}
+
+void YouTubeMusicSource::set_active_station(std::string name) {
+    std::scoped_lock lk{mu_};
+    if (cfg_.active_station == name && target_url_.empty()) return;
+    cfg_.active_station = std::move(name);
+    target_url_.clear(); // clear temporary cast target
+    queue_.clear();
+    queue_idx_ = 0;
+    queue_built_for_.clear();
+    discard_prefetch_locked();
+}
+
+std::size_t YouTubeMusicSource::station_count() const noexcept {
+    std::scoped_lock lk{mu_};
+    return cfg_.stations.size();
+}
+
+std::string YouTubeMusicSource::active_station_name() const {
+    std::scoped_lock lk{mu_};
+    const YouTubeStation* st = active_station_locked();
+    return st ? st->name : std::string{};
+}
+
 bool YouTubeMusicSource::initialize() {
     if (!cfg_.enabled) return false;
-    if (!cfg_.default_playlist.empty()) {
-        std::scoped_lock lk{mu_};
-        target_url_ = cfg_.default_playlist;
+
+    std::scoped_lock lk{mu_};
+    if (cfg_.active_station.empty() && !cfg_.stations.empty()) {
+        cfg_.active_station = cfg_.stations.front().name;
     }
+
     auth_ = cfg_.cookies_path.empty() ? AuthState::none_required : AuthState::authenticated;
     return true;
 }
@@ -125,7 +186,14 @@ void YouTubeMusicSource::set_shuffle(bool shuffle) {
     // The next-queue-index URL is about to change; any prefetched pipeline
     // would now be playing the wrong track.
     discard_prefetch_locked();
-    if (!queue_.empty() && queue_built_for_ == target_url_) {
+
+    std::string effective_url = target_url_;
+    if (effective_url.empty()) {
+        const auto* st = active_station_locked();
+        if (st) effective_url = st->url;
+    }
+
+    if (!queue_.empty() && queue_built_for_ == effective_url) {
         // Re-shuffle or re-sort the remaining queue (preserve current track)
         if (shuffle) {
             static thread_local std::mt19937 rng{std::random_device{}()};
@@ -137,37 +205,68 @@ void YouTubeMusicSource::set_shuffle(bool shuffle) {
             // Re-sort the remaining queue (by URL, which is roughly chronological for playlists)
             auto start = queue_.begin() + static_cast<std::ptrdiff_t>(queue_idx_ + 1);
             if (start < queue_.end()) {
-                std::sort(start, queue_.end());
+                std::sort(start, queue_.end(), [](const auto& a, const auto& b) { 
+                    return a.url < b.url; 
+                });
             }
         }
     }
 }
 
+YouTubeMusicSource::QueueSnapshot YouTubeMusicSource::queue_snapshot() const {
+    std::scoped_lock lk{mu_};
+    QueueSnapshot snap;
+    snap.cursor = queue_idx_;
+    snap.entries.reserve(queue_.size());
+    for (std::size_t i = 0; i < queue_.size(); ++i) {
+        snap.entries.push_back({i, queue_[i].url, queue_[i].title, queue_[i].artist});
+    }
+    return snap;
+}
+
+bool YouTubeMusicSource::jump_to(std::size_t index) {
+    std::scoped_lock lk{mu_};
+    if (index >= queue_.size()) return false;
+    consecutive_failed_ = 0;
+    queue_idx_ = index;
+    if (!promote_prefetch_locked(queue_idx_)) start_pipe_locked();
+    if (pipe_) state_.store(PlaybackState::playing, std::memory_order_release);
+    return true;
+}
+
 void YouTubeMusicSource::resolve_queue_locked() {
-    if (target_url_.empty()) {
+    std::string effective_url = target_url_;
+    if (effective_url.empty()) {
+        const auto* st = active_station_locked();
+        if (st) effective_url = st->url;
+    }
+
+    if (effective_url.empty()) {
         queue_.clear();
         queue_idx_ = 0;
         queue_built_for_.clear();
         return;
     }
-    if (queue_built_for_ == target_url_ && !queue_.empty()) return;
+
+    if (queue_built_for_ == effective_url && !queue_.empty()) return;
 
     queue_.clear();
     queue_idx_ = 0;
 
-    if (!is_playlist_url(target_url_)) {
-        queue_.push_back(target_url_);
-        queue_built_for_ = target_url_;
+    if (!is_playlist_url(effective_url)) {
+        queue_.push_back({effective_url, ""});
+        queue_built_for_ = effective_url;
         return;
     }
 
     // Playlist URL: enumerate IDs via --flat-playlist.
     const auto yt  = cfg_.yt_dlp_path.empty() ? L"yt-dlp" : cfg_.yt_dlp_path.wstring();
     std::wstring cmd = quote(yt) + L" --no-warnings --flat-playlist --skip-download "
-                                   L"--print \"%(id)s\" ";
+                                   L"--encoding UTF-8 "
+                                   L"--print \"%(id)s\t%(title)s\" ";
     if (!cfg_.cookies_path.empty())
         cmd += L"--cookies " + quote(cfg_.cookies_path.wstring()) + L" ";
-    cmd += L"-- " + quote(widen(target_url_));
+    cmd += L"-- " + quote(widen(effective_url));
 
     // Prefer the worker (no fork of the game process); fall back to a direct
     // spawn when it's absent or returns nothing.
@@ -206,7 +305,19 @@ void YouTubeMusicSource::resolve_queue_locked() {
         auto line = raw.substr(pos, end - pos);
         while (!line.empty() && (line.back() == '\r' || line.back() == ' ' || line.back() == '\t'))
             line.pop_back();
-        if (!line.empty() && line != "NA") queue_.push_back(watch_url_for_id(line));
+        if (!line.empty() && line != "NA") {
+            auto tab = line.find('\t');
+            if (!line.empty() && line != "NA") {
+            auto tab = line.find('\t');
+            if (tab != std::string::npos) {
+                std::string id = line.substr(0, tab);
+                std::string title = line.substr(tab + 1);
+                queue_.push_back({watch_url_for_id(id), title, ""});
+            } else {
+                queue_.push_back({watch_url_for_id(line), "", ""});
+            }
+        }
+        }
         pos = (nl == std::string::npos) ? raw.size() : nl + 1;
     }
 
@@ -215,13 +326,13 @@ void YouTubeMusicSource::resolve_queue_locked() {
         std::shuffle(queue_.begin(), queue_.end(), rng);
     }
 
-    queue_built_for_ = target_url_;
-    if (queue_.empty() && is_playlist_url(target_url_)) {
+    queue_built_for_ = effective_url;
+    if (queue_.empty() && is_playlist_url(effective_url)) {
         log::warn("[yt] resolved 0 tracks from {} -- check {} for yt-dlp errors "
                   "(private/deleted/geo-blocked playlist?)",
-                  target_url_, stderr_log_path().string());
+                  effective_url, stderr_log_path().string());
     } else {
-        log::info("[yt] resolved {} track(s) from {}", queue_.size(), target_url_);
+        log::info("[yt] resolved {} track(s) from {}", queue_.size(), effective_url);
     }
 }
 
@@ -366,7 +477,7 @@ void YouTubeMusicSource::start_pipe_locked() {
     if (queue_.empty()) return;
     if (queue_idx_ >= queue_.size()) queue_idx_ = 0;
 
-    pipe_ = spawn_pipe_locked(queue_[queue_idx_], queue_idx_);
+    pipe_ = spawn_pipe_locked(queue_[queue_idx_].url, queue_idx_);
     if (!pipe_) return;
     position_ms_.store(0, std::memory_order_release);
     state_.store(PlaybackState::buffering, std::memory_order_release);
@@ -406,7 +517,7 @@ void YouTubeMusicSource::maybe_spawn_prefetch_locked() {
     if (pipe_->bytes_written < kViableBytes) return;
 
     const std::size_t idx = next_queue_idx_locked();
-    prefetch_             = spawn_pipe_locked(queue_[idx], idx);
+    prefetch_             = spawn_pipe_locked(queue_[idx].url, idx);
 }
 
 void YouTubeMusicSource::stop_pipe_locked() {
@@ -451,6 +562,7 @@ void YouTubeMusicSource::stop() {
     std::scoped_lock lk{mu_};
     discard_prefetch_locked();
     stop_pipe_locked();
+    target_url_.clear(); // allow falling back to active station next play
 }
 
 void YouTubeMusicSource::next() {

--- a/src/worker/worker_client.cpp
+++ b/src/worker/worker_client.cpp
@@ -41,25 +41,32 @@ std::vector<wchar_t> build_environment_block(const std::vector<std::pair<std::ws
     std::map<std::wstring, std::wstring, WStringCmpI> env_map;
 
     // fetch current process environment
-    if (LPWCH curr_env = GetEnvironmentStringsW()) {
-        for (LPWCH p = curr_env; *p; ) {
-            std::wstring entry(p);
-            p += entry.length() + 1;
+    LPWCH curr_env = GetEnvironmentStringsW();
+    if (!curr_env) return {};
+    
+    for (LPWCH p = curr_env; *p; ) {
+        std::wstring entry(p);
+        p += entry.length() + 1;
 
-            if (entry.empty()) continue;
+        if (entry.empty()) continue;
 
-            // start searching for '=' after index 0 to correctly parse variables
-            size_t pos = entry.find(L'=', entry[0] == L'=' ? 1 : 0);
-            
-            if (pos != std::wstring::npos) {
-                env_map[entry.substr(0, pos)] = entry.substr(pos + 1);
-            }
+        // start searching for '=' after index 0 to correctly parse variables
+        size_t pos = entry.find(L'=', entry[0] == L'=' ? 1 : 0);
+        
+        if (pos != std::wstring::npos) {
+            env_map[entry.substr(0, pos)] = entry.substr(pos + 1);
         }
-        FreeEnvironmentStringsW(curr_env);
     }
+    FreeEnvironmentStringsW(curr_env);
 
     // apply overrides
     for (const auto& kv : overrides) {
+        if (kv.first.empty() || kv.first.find(L'=') != std::wstring::npos ||
+            kv.first.find(L'\0') != std::wstring::npos ||
+            kv.second.find(L'\0') != std::wstring::npos) {
+            log::warn("[worker] ignoring invalid environment override");
+            continue;
+        }
         env_map[kv.first] = kv.second;
     }
 
@@ -131,6 +138,11 @@ bool WorkerClient::start(const std::filesystem::path& worker_exe,
 
     // build the custom environment block
     std::vector<wchar_t> env_block = build_environment_block(env_overrides);
+    if (env_block.size() <= 2) {
+        log::error("[worker] failed to read inherited environment");
+        token_.clear();
+        return false;
+    }
 
     STARTUPINFOW si{};
     si.cb = sizeof(si);

--- a/src/worker/worker_client.cpp
+++ b/src/worker/worker_client.cpp
@@ -46,10 +46,11 @@ std::vector<wchar_t> build_environment_block(const std::vector<std::pair<std::ws
             std::wstring entry(p);
             p += entry.length() + 1;
 
-            // skip hidden drive-letter variables that start with '='
-            if (entry.empty() || entry[0] == L'=') continue;
+            if (entry.empty()) continue;
 
-            size_t pos = entry.find(L'=');
+            // start searching for '=' after index 0 to correctly parse variables
+            size_t pos = entry.find(L'=', entry[0] == L'=' ? 1 : 0);
+            
             if (pos != std::wstring::npos) {
                 env_map[entry.substr(0, pos)] = entry.substr(pos + 1);
             }

--- a/src/worker/worker_client.cpp
+++ b/src/worker/worker_client.cpp
@@ -4,7 +4,7 @@
 #include "fh6/subprocess.hpp"
 
 #include <nlohmann/json.hpp>
-
+#include <map>
 #include <bcrypt.h>
 
 namespace fh6::worker {
@@ -27,6 +27,50 @@ std::wstring make_session_token() {
         out += hex[b & 0x0F];
     }
     return out;
+}
+
+
+// helper to construct a custom environment block for CreateProcessW
+std::vector<wchar_t> build_environment_block(const std::vector<std::pair<std::wstring, std::wstring>>& overrides) {
+    // case-insensitive map for Windows environment variables
+    struct WStringCmpI {
+        bool operator()(const std::wstring& a, const std::wstring& b) const {
+            return _wcsicmp(a.c_str(), b.c_str()) < 0;
+        }
+    };
+    std::map<std::wstring, std::wstring, WStringCmpI> env_map;
+
+    // fetch current process environment
+    if (LPWCH curr_env = GetEnvironmentStringsW()) {
+        for (LPWCH p = curr_env; *p; ) {
+            std::wstring entry(p);
+            p += entry.length() + 1;
+
+            // skip hidden drive-letter variables that start with '='
+            if (entry.empty() || entry[0] == L'=') continue;
+
+            size_t pos = entry.find(L'=');
+            if (pos != std::wstring::npos) {
+                env_map[entry.substr(0, pos)] = entry.substr(pos + 1);
+            }
+        }
+        FreeEnvironmentStringsW(curr_env);
+    }
+
+    // apply overrides
+    for (const auto& kv : overrides) {
+        env_map[kv.first] = kv.second;
+    }
+
+    // flatten map into a contiguous buffer of null-terminated strings
+    std::vector<wchar_t> block;
+    for (const auto& kv : env_map) {
+        std::wstring entry = kv.first + L"=" + kv.second;
+        block.insert(block.end(), entry.begin(), entry.end());
+        block.push_back(L'\0');
+    }
+    block.push_back(L'\0'); // final terminator
+    return block;
 }
 
 // Block until an instance of `name` is available, or the deadline passes.
@@ -62,7 +106,8 @@ HANDLE connect_to_stream(const std::wstring& pipe_name) {
 
 WorkerClient::~WorkerClient() { stop(); }
 
-bool WorkerClient::start(const std::filesystem::path& worker_exe) {
+bool WorkerClient::start(const std::filesystem::path& worker_exe, 
+                         const std::vector<std::pair<std::wstring, std::wstring>>& env_overrides) {
     std::scoped_lock lk{mu_};
     if (process_) return true; // already started
 
@@ -82,10 +127,18 @@ bool WorkerClient::start(const std::filesystem::path& worker_exe) {
     // taking its children with it -- if the game ever dies without a clean stop.
     std::wstring cmd = subprocess::quote(worker_exe.wstring()) + L" " + token_ + L" " +
                        std::to_wstring(GetCurrentProcessId());
+
+    // build the custom environment block
+    std::vector<wchar_t> env_block = build_environment_block(env_overrides);
+
     STARTUPINFOW si{};
     si.cb = sizeof(si);
     PROCESS_INFORMATION pi{};
-    if (!CreateProcessW(nullptr, cmd.data(), nullptr, nullptr, FALSE, CREATE_NO_WINDOW, nullptr,
+
+    // add CREATE_UNICODE_ENVIRONMENT to the creation flags
+    DWORD flags = CREATE_NO_WINDOW | CREATE_UNICODE_ENVIRONMENT;
+    
+    if (!CreateProcessW(nullptr, cmd.data(), nullptr, nullptr, FALSE, flags, env_block.data(),
                         subprocess::safe_spawn_cwd(), &si, &pi)) {
         log::error("[worker] failed to launch worker (err {})", GetLastError());
         token_.clear();

--- a/src/worker/worker_main.cpp
+++ b/src/worker/worker_main.cpp
@@ -379,7 +379,7 @@ void serve_connection(HANDLE pipe) {
         } catch (const std::exception& e) {
             resp = {{"ok", false}, {"error", e.what()}};
         }
-        ipc_send(pipe, resp.dump());
+        ipc_send(pipe, resp.dump(-1, ' ', false, json::error_handler_t::replace));
     }
     FlushFileBuffers(pipe);
     DisconnectNamedPipe(pipe);

--- a/ui/dist/index.html
+++ b/ui/dist/index.html
@@ -42,24 +42,6 @@
         <div class="sources" id="sources"></div>
       </section>
 
-      <section class="card" id="yt-cast-card" hidden>
-        <h2>Cast to YouTube Music</h2>
-        <p class="muted">
-          Paste any YouTube or YouTube Music URL (single video or playlist). The radio switches
-          source and starts streaming immediately.
-        </p>
-        <form id="yt-cast" class="row">
-          <input
-            type="text"
-            id="yt-url"
-            placeholder="https://music.youtube.com/playlist?list=&hellip;"
-            autocomplete="off"
-          />
-          <button type="submit" class="btn filled">Cast</button>
-          <button type="button" id="yt-shuffle" class="icon-btn" aria-label="Shuffle playlist" aria-pressed="false"></button>
-        </form>
-      </section>
-
       <section class="card" id="jf-cast-card" hidden>
         <h2>Play Jellyfin Playlist</h2>
         <p class="muted">

--- a/ui/dist/js/api.js
+++ b/ui/dist/js/api.js
@@ -18,11 +18,21 @@ export const api = {
   reloadConfig: () => request("/api/config/reload", { method: "POST" }),
   switchSource: source => request("/api/source/switch", { method: "POST", body: { source } }),
   transport: (source, action) => request(`/api/source/${source}/${action}`, { method: "POST" }),
-  castYoutube: url => request("/api/source/youtube_music/cast", { method: "POST", body: { url } }),
   castOnlineRadio: (url, opts = {}) =>
     request("/api/source/online_radio/cast", { method: "POST", body: { url, ...opts } }),
   shuffleYoutube: shuffle =>
     request("/api/source/youtube_music/shuffle", { method: "POST", body: { shuffle } }),
+  getYoutubeStations: () => request("/api/source/youtube_music/stations"),
+  putYoutubeStations: (stations, activeStation) =>
+    request("/api/source/youtube_music/stations", {
+      method: "PUT",
+      body: { stations, active_station: activeStation },
+    }),
+  activateYoutubeStation: name =>
+    request("/api/source/youtube_music/activate", { method: "POST", body: { name } }),
+  getYoutubeQueue: () => request("/api/source/youtube_music/queue"),
+  playYoutubeIndex: index =>
+    request("/api/source/youtube_music/play", { method: "POST", body: { index } }),
   castJellyfin: playlistId =>
     request("/api/source/jellyfin/cast", { method: "POST", body: { playlist_id: playlistId } }),
   setGain: gain => request("/api/options", { method: "POST", body: { output_gain: gain } }),

--- a/ui/dist/js/api.js
+++ b/ui/dist/js/api.js
@@ -20,6 +20,7 @@ export const api = {
   transport: (source, action) => request(`/api/source/${source}/${action}`, { method: "POST" }),
   castOnlineRadio: (url, opts = {}) =>
     request("/api/source/online_radio/cast", { method: "POST", body: { url, ...opts } }),
+  castYoutube: url => request("/api/source/youtube_music/cast", { method: "POST", body: { url } }),
   shuffleYoutube: shuffle =>
     request("/api/source/youtube_music/shuffle", { method: "POST", body: { shuffle } }),
   getYoutubeStations: () => request("/api/source/youtube_music/stations"),

--- a/ui/dist/js/main.js
+++ b/ui/dist/js/main.js
@@ -12,6 +12,7 @@ import { createDeps } from "./render/deps.js";
 import { createExternalAudio } from "./render/externalAudio.js";
 import { createLocalFiles } from "./render/localFiles.js";
 import { createOnlineRadio } from "./render/onlineRadio.js";
+import { createYoutubeMusic } from "./render/youtubeMusic.js";
 
 let state = null;
 let cfg = null;
@@ -32,9 +33,7 @@ const refs = {
   sources: $("#sources"),
   sourceCard: $("#source-card"),
   outputCard: $("#output-card"),
-  ytCard: $("#yt-cast-card"),
   jfCard: $("#jf-cast-card"),
-  ytShuffle: $("#yt-shuffle"),
   drawer: $("#drawer"),
   scrim: $("#scrim"),
   form: $("#settings-form"),
@@ -45,7 +44,6 @@ $("#open-settings").innerHTML = icons.gear;
 $("#close-settings").innerHTML = icons.close;
 $("#t-prev").innerHTML = icons.prev;
 $("#t-next").innerHTML = icons.next;
-$("#yt-shuffle").innerHTML = icons.shuffle;
 
 const mainEl = $("main");
 
@@ -80,6 +78,16 @@ const localFiles = createLocalFiles(mainEl, {
 });
 
 const onlineRadio = createOnlineRadio(mainEl, {
+  getState: () => state,
+  getConfig: () => cfg,
+  onSaved: async () => {
+    cfg = await api.getConfig().catch(() => cfg);
+    state = await api.getState().catch(() => state);
+    render();
+  },
+});
+
+const youtubeMusic = createYoutubeMusic(mainEl, {
   getState: () => state,
   getConfig: () => cfg,
   onSaved: async () => {
@@ -142,6 +150,7 @@ function render() {
   externalAudio.render();
   localFiles.render();
   onlineRadio.render();
+  youtubeMusic.render();
 
   refs.sourceCard.hidden = false;
   refs.outputCard.hidden = !state.sources?.active;
@@ -149,41 +158,12 @@ function render() {
   const available = state.sources?.available || [];
   const active = state.sources?.active;
   // Source-specific cards only show while that source is on air.
-  refs.ytCard.hidden = active !== "youtube_music";
   refs.jfCard.hidden = active !== "jellyfin";
-  const shuffleOn = !!available.find(s => s.name === "youtube_music")?.details?.shuffle;
-  refs.ytShuffle.classList.toggle("toggled", shuffleOn);
-  refs.ytShuffle.setAttribute("aria-pressed", String(shuffleOn));
 }
 
 $("#t-play").addEventListener("click", () => transport("play"));
 $("#t-next").addEventListener("click", () => transport("next"));
 $("#t-prev").addEventListener("click", () => transport("previous"));
-
-$("#yt-cast").addEventListener("submit", async e => {
-  e.preventDefault();
-  const url = $("#yt-url").value.trim();
-  if (!url) return;
-  try {
-    await api.castYoutube(url);
-    $("#yt-url").value = "";
-    toast("Casting…");
-  } catch (err) {
-    toast(err.message, true);
-  }
-});
-
-$("#yt-shuffle").addEventListener("click", async () => {
-  const yt = state?.sources?.available?.find(s => s.name === "youtube_music");
-  if (!yt) return;
-  const shuffle = !yt.details?.shuffle;
-  try {
-    await api.shuffleYoutube(shuffle);
-    toast(shuffle ? "Shuffle on" : "Shuffle off");
-  } catch (err) {
-    toast(err.message, true);
-  }
-});
 
 $("#jf-cast").addEventListener("submit", async e => {
   e.preventDefault();
@@ -221,6 +201,7 @@ $("#save-config").addEventListener("click", async () => {
     externalAudio.invalidate();
     localFiles.invalidate();
     onlineRadio.invalidate();
+    youtubeMusic.invalidate();
     state = await api.getState().catch(() => state);
     render();
     toast("Saved");
@@ -236,6 +217,7 @@ $("#reload-config").addEventListener("click", async () => {
     externalAudio.invalidate();
     localFiles.invalidate();
     onlineRadio.invalidate();
+    youtubeMusic.invalidate();
     renderSettings(refs.form, cfg);
     render();
     toast("Reloaded from disk");

--- a/ui/dist/js/render/youtubeMusic.js
+++ b/ui/dist/js/render/youtubeMusic.js
@@ -1,0 +1,246 @@
+import { api } from "../api.js";
+import { $, el } from "../dom.js";
+import { toast } from "../toast.js";
+import { icons } from "../icons.js";
+
+function newStation(name) {
+  return { name, url: "" };
+}
+
+const fold = s => (s || "").normalize("NFD").replace(/\p{Diacritic}/gu, "").toLowerCase();
+
+export function createYoutubeMusic(main, ctx) {
+  let stations = [];
+  let activeStation = "";
+  let selected = 0;
+  let loaded = false;
+  let queue = { cursor: 0, tracks: [] };
+  let search = "";
+
+  const stationSelect = el("select", { id: "yt-station", "aria-label": "Station preset" });
+  const onAirBtn = el("button", { type: "button", class: "btn filled" }, "Set on air");
+  const newBtn = el("button", { type: "button", class: "btn ghost" }, "New");
+  const renameBtn = el("button", { type: "button", class: "btn ghost" }, "Rename");
+  const deleteBtn = el("button", { type: "button", class: "btn ghost" }, "Delete");
+
+  const urlInput = el("input", { type: "text", class: "lf-path-input", placeholder: "https://music.youtube.com/playlist?list=...", autocomplete: "off" });
+  const saveBtn = el("button", { type: "button", class: "btn filled" }, "Save");
+
+  const queueCount = el("span", { class: "muted" });
+  const searchInput = el("input", { type: "text", placeholder: "Search the playlist…", autocomplete: "off" });
+  const shuffleBtn = el("button", { type: "button", class: "icon-btn", "aria-label": "Toggle Shuffle", html: icons.shuffle });
+  const trackList = el("ul", { class: "lf-tracklist" });
+
+  const card = el("section", { class: "card", id: "youtube-music-card", hidden: true }, [
+    el("h2", {}, "YouTube Music"),
+    el("div", { class: "yt-stationbar row" }, [stationSelect, onAirBtn]),
+    el("div", { class: "row yt-stationtools", style: "margin-bottom: 1.5rem;" }, [newBtn, renameBtn, deleteBtn]),
+    el("div", { class: "lf-editor" }, [
+      el("label", { class: "field-label" }, "Playlist or Video URL"),
+      urlInput,
+      el("div", { class: "row lf-editor-foot" }, [saveBtn]),
+    ]),
+    el("div", { class: "lf-queue" }, [
+      el("div", { class: "lf-queue-head row" }, [
+        el("label", { class: "field-label" }, "Queue"),
+        queueCount,
+        shuffleBtn,
+      ]),
+      searchInput,
+      trackList,
+    ]),
+  ]);
+
+  const sourcesCard = $("#sources", main)?.closest(".card");
+  if (sourcesCard) sourcesCard.insertAdjacentElement("afterend", card);
+  else main.append(card);
+
+  const cur = () => stations[selected];
+
+  async function load(force = false) {
+    if (loaded && !force) return;
+    try {
+      const r = await api.getYoutubeStations();
+      stations = Array.isArray(r.stations) && r.stations.length ? r.stations : [newStation("My Playlist")];
+      activeStation = r.active_station || stations[0].name;
+      selected = Math.max(0, stations.findIndex(s => s.name === activeStation));
+      loaded = true;
+    } catch {
+      return;
+    }
+    renderEditor();
+    loadQueue();
+  }
+
+  async function loadQueue() {
+    try {
+      queue = await api.getYoutubeQueue();
+    } catch {
+      queue = { cursor: 0, tracks: [] };
+    }
+    renderQueue();
+  }
+
+  function renderStations() {
+    stationSelect.replaceChildren(
+      ...stations.map((s, i) =>
+        el("option", { value: String(i), selected: i === selected },
+          s.name + (s.name === activeStation ? "  • on air" : "")),
+      ),
+    );
+    deleteBtn.disabled = stations.length <= 1;
+    onAirBtn.disabled = cur()?.name === activeStation;
+    onAirBtn.textContent = cur()?.name === activeStation ? "On air" : "Set on air";
+  }
+
+  function renderEditor() {
+    if (!cur()) return;
+    renderStations();
+    urlInput.value = cur().url || "";
+  }
+
+  function renderQueue() {
+    const terms = fold(search).split(/\s+/).filter(Boolean);
+    const rows = (queue.tracks || []).filter(t => {
+      if (!terms.length) return true;
+      const hay = fold(`${t.title || ""} ${t.url || ""}`); 
+      return terms.every(w => hay.includes(w));
+    });
+    queueCount.textContent = `${queue.tracks?.length || 0} tracks`;
+    trackList.replaceChildren(
+      ...rows.map(t => {
+        const titleText = t.title || t.url.split("v=")[1] || t.url;
+        const li = el("li", { class: "lf-track" + (t.index === queue.cursor ? " current" : "") }, [
+          el("div", { class: "lf-track-main" }, [
+            el("span", { class: "lf-track-title" }, titleText),
+          ]),
+          t.url ? el("span", { class: "lf-track-folder muted" }, t.url.split("v=")[1] || t.url) : null,
+        ]);
+        li.addEventListener("click", async () => {
+          try {
+            await api.playYoutubeIndex(t.index);
+            queue.cursor = t.index;
+            renderQueue();
+          } catch (e) {
+            toast(e.message, true);
+          }
+        });
+        return li;
+      }),
+    );
+    if (!rows.length) {
+      trackList.append(el("li", { class: "muted" }, terms.length ? "No matches." : "Queue is empty."));
+    }
+  }
+
+  // --- events ---
+  stationSelect.addEventListener("change", () => {
+    selected = parseInt(stationSelect.value, 10) || 0;
+    renderEditor();
+  });
+  
+  newBtn.addEventListener("click", () => {
+    let name = "New Playlist";
+    let n = 2;
+    while (stations.some(s => s.name === name)) name = `New Playlist ${n++}`;
+    stations.push(newStation(name));
+    selected = stations.length - 1;
+    renderEditor();
+  });
+  
+  renameBtn.addEventListener("click", () => {
+    const s = cur();
+    const name = window.prompt("Station name", s.name)?.trim();
+    if (!name || name === s.name) return;
+    if (stations.some(x => x !== s && x.name === name)) return toast("A station with that name exists", true);
+    if (s.name === activeStation) activeStation = name;
+    s.name = name;
+    renderEditor();
+  });
+  
+  deleteBtn.addEventListener("click", () => {
+    if (stations.length <= 1) return;
+    const wasActive = cur().name === activeStation;
+    stations.splice(selected, 1);
+    selected = Math.min(selected, stations.length - 1);
+    if (wasActive) activeStation = stations[0].name;
+    renderEditor();
+  });
+
+  urlInput.addEventListener("input", () => {
+    if (cur()) cur().url = urlInput.value.trim();
+  });
+
+  searchInput.addEventListener("input", () => {
+    search = searchInput.value;
+    renderQueue();
+  });
+
+  saveBtn.addEventListener("click", async () => {
+    try {
+      await api.putYoutubeStations(stations, activeStation);
+      toast("Saved YouTube Music stations");
+      await ctx.onSaved?.();
+      loadQueue();
+    } catch (e) {
+      toast(e.message, true);
+    }
+  });
+
+  shuffleBtn.addEventListener("click", async () => {
+    const isShuffled = shuffleBtn.classList.contains("toggled");
+    try {
+        await api.shuffleYoutube(!isShuffled);
+        toast(!isShuffled ? "Shuffle on" : "Shuffle off");
+        await ctx.onSaved?.(); // force state refresh
+        loadQueue();
+    } catch (err) {
+        toast(err.message, true);
+    }
+  });
+
+  onAirBtn.addEventListener("click", async () => {
+    const name = cur().name;
+    try {
+      await api.putYoutubeStations(stations, name); 
+      await api.activateYoutubeStation(name); 
+      activeStation = name;
+      renderStations();
+      toast(`On air: ${name}`);
+      await ctx.onSaved?.();
+      loadQueue();
+    } catch (e) {
+      toast(e.message, true);
+    }
+  });
+
+  let lastQueueSize = -1;
+  let lastQueueCursor = -1;
+
+  function render() {
+    const state = ctx.getState();
+    const isActive = state?.sources?.active === "youtube_music";
+    card.hidden = !isActive;
+    if (!isActive) return;
+    load();
+
+    const ytDetails = state?.sources?.available?.find(s => s.name === "youtube_music")?.details;
+    const shuffleOn = !!ytDetails?.shuffle;
+    shuffleBtn.classList.toggle("toggled", shuffleOn);
+    shuffleBtn.setAttribute("aria-pressed", String(shuffleOn));
+
+    // refetch the queue if the track count changes (rescan/activate) or cursor moves
+    const qs = ytDetails?.queue_size ?? -1;
+    const qc = ytDetails?.queue_cursor ?? -1;
+    if (loaded && (qs !== lastQueueSize || qc !== lastQueueCursor)) {
+      lastQueueSize = qs;
+      lastQueueCursor = qc;
+      loadQueue();
+    }
+  }
+
+  return {
+    render,
+    invalidate: () => { loaded = false; },
+  };
+}

--- a/ui/dist/js/render/youtubeMusic.js
+++ b/ui/dist/js/render/youtubeMusic.js
@@ -204,6 +204,10 @@ export function createYoutubeMusic(main, ctx) {
     try {
       await api.putYoutubeStations(stations, name); 
       await api.activateYoutubeStation(name); 
+
+      await api.switchSource("youtube_music");
+      await api.transport("youtube_music", "play");
+
       activeStation = name;
       renderStations();
       toast(`On air: ${name}`);

--- a/ui/dist/js/render/youtubeMusic.js
+++ b/ui/dist/js/render/youtubeMusic.js
@@ -24,6 +24,7 @@ export function createYoutubeMusic(main, ctx) {
   const deleteBtn = el("button", { type: "button", class: "btn ghost" }, "Delete");
 
   const urlInput = el("input", { type: "text", class: "lf-path-input", placeholder: "https://music.youtube.com/playlist?list=...", autocomplete: "off" });
+  const castBtn = el("button", { type: "button", class: "btn ghost" }, "Cast");
   const saveBtn = el("button", { type: "button", class: "btn filled" }, "Save");
 
   const queueCount = el("span", { class: "muted" });
@@ -38,7 +39,7 @@ export function createYoutubeMusic(main, ctx) {
     el("div", { class: "lf-editor" }, [
       el("label", { class: "field-label" }, "Playlist or Video URL"),
       urlInput,
-      el("div", { class: "row lf-editor-foot" }, [saveBtn]),
+      el("div", { class: "row lf-editor-foot" }, [castBtn, saveBtn]),
     ]),
     el("div", { class: "lf-queue" }, [
       el("div", { class: "lf-queue-head row" }, [
@@ -167,16 +168,13 @@ export function createYoutubeMusic(main, ctx) {
     renderEditor();
   });
 
-  urlInput.addEventListener("input", () => {
-    if (cur()) cur().url = urlInput.value.trim();
-  });
-
   searchInput.addEventListener("input", () => {
     search = searchInput.value;
     renderQueue();
   });
 
   saveBtn.addEventListener("click", async () => {
+    if (cur()) cur().url = urlInput.value.trim();
     try {
       await api.putYoutubeStations(stations, activeStation);
       toast("Saved YouTube Music stations");
@@ -184,6 +182,27 @@ export function createYoutubeMusic(main, ctx) {
       loadQueue();
     } catch (e) {
       toast(e.message, true);
+    }
+  });
+
+  castBtn.addEventListener("click", async () => {
+    const url = urlInput.value.trim();
+    if (!url) return;
+
+    urlInput.disabled = true;
+    castBtn.disabled = true;
+    
+    try {
+      await api.castYoutube(url);
+      toast("Casting to YouTube Music...");
+      urlInput.value = "";
+      await ctx.onSaved?.();
+      loadQueue();
+    } catch (e) {
+      toast(e.message, true);
+    } finally {
+      urlInput.disabled = false;
+      castBtn.disabled = false;
     }
   });
 

--- a/ui/dist/js/schema.js
+++ b/ui/dist/js/schema.js
@@ -38,7 +38,6 @@ export const SCHEMA = [
       ["enabled", "Enabled", "checkbox"],
       ["cookies_path", "cookies.txt (optional)", "text"],
       ["yt_dlp_path", "yt-dlp path (optional)", "text"],
-      ["default_playlist", "Default playlist URL", "text"],
       ["shuffle", "Shuffle", "checkbox"],
     ],
   ],

--- a/ui/dist/styles.css
+++ b/ui/dist/styles.css
@@ -1057,6 +1057,12 @@ output {
   border-top: 1px solid var(--line);
 }
 
+.lf-path-input {
+    width: 100%;
+    padding: 0.75rem;
+    box-sizing: border-box;
+}
+
 .lf-roots {
   display: flex;
   flex-direction: column;
@@ -1197,6 +1203,17 @@ output {
   cursor: pointer;
 }
 
+.lf-track-main {
+    display: flex;
+    gap: 0.5rem;
+    align-items: baseline;
+}
+
+.lf-track-artist {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
 .lf-track:hover {
   background: var(--surface-raise);
 }
@@ -1283,6 +1300,12 @@ output {
 .lf-modal-foot {
   margin-top: var(--spacing-12);
   justify-content: flex-end;
+}
+
+/* Youtube Music */
+.yt-stationtools {
+    margin-top: 1rem;
+    gap: 0.5rem;
 }
 
 /* Online Radio. */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * YouTube Music now supports multiple named stations with an active station selector.
  * Added queue inspection (size/cursor/entries) and “play from index” support.
  * Expanded the YouTube Music HTTP API for stations, activation, queue viewing, and indexed playback.

* **Improvements**
  * Configuration migration: legacy playlist settings auto-convert to the new stations format.
  * Worker startup can now apply custom environment overrides.
  * YouTube Music API responses now include more station/queue details.

* **Documentation**
  * Updated the example configuration template to reflect the new stations/active station settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->