### PR TITLE
Add melody feature with car change detection and startup support

### DIFF
--- a/MELODY_GUIDE.md
+++ b/MELODY_GUIDE.md
@@ -1,0 +1,284 @@
+# FH6 Universal Radio — Startup Melody Feature Guide
+
+> A mod for **Forza Horizon 6** that plays a random audio clip (like a JDM ETC reader / melody box)
+> every time you **start a race** or **switch cars** — on top of your normal custom radio music.
+
+---
+
+## Table of Contents
+1. [Prerequisites](#1-prerequisites)
+2. [Build the DLL](#2-build-the-dll)
+3. [Install the Mod](#3-install-the-mod)
+4. [Adding Your Melody Files](#4-adding-your-melody-files)
+5. [Enable Car Change Detection](#5-enable-car-change-detection)
+6. [Configure via the Dashboard](#6-configure-via-the-dashboard)
+7. [Config Reference](#7-config-reference)
+8. [FAQ & Troubleshooting](#8-faq--troubleshooting)
+
+---
+
+## 1. Prerequisites
+
+Install the cross-compilation toolchain on Arch Linux:
+
+```bash
+sudo pacman -S cmake llvm-mingw
+```
+
+> These tools compile Windows `.dll` files from Linux without needing Windows at all.
+
+---
+
+## 2. Build the DLL
+
+Run these commands in order — copy and paste the whole block:
+
+```bash
+# Navigate to the cloned repo
+cd "/home/kazuha/Videos/FH6 radio/fh6-universal-radio"
+
+# Step 1: Fetch third-party headers (nlohmann, toml11, miniaudio)
+./scripts/get-deps.sh
+
+# Step 2: Configure the build with the MinGW cross-compiler
+cmake -B build \
+  -DCMAKE_TOOLCHAIN_FILE=cmake/mingw-w64-x86_64.cmake \
+  -DCMAKE_BUILD_TYPE=Release
+
+# Step 3: Compile (uses all CPU cores)
+cmake --build build --parallel
+```
+
+### Output files (after build)
+```
+fh6-universal-radio/build/
+├── version.dll           ← main mod DLL  (drop into game folder)
+└── fh6-radio-worker.exe  ← worker process (drop into game folder)
+```
+
+---
+
+## 3. Install the Mod
+
+### Find your Forza Horizon 6 folder
+Usually one of:
+```
+C:\XboxGames\Forza Horizon 6\Content\
+C:\Program Files\WindowsApps\Microsoft.ForzaHorizon6_...\
+```
+The folder that contains `ForzaHorizon6.exe`.
+
+### Copy the build output
+```bash
+# From your Linux machine, copy via your Windows partition or USB:
+build/version.dll
+build/fh6-radio-worker.exe
+```
+
+Paste them **next to** `ForzaHorizon6.exe`.
+
+### Create the mod's config and folder structure
+Inside the **same folder as ForzaHorizon6.exe**, create:
+```
+ForzaHorizon6.exe
+version.dll                        ← copied from build/
+fh6-radio-worker.exe               ← copied from build/
+fh6-radio/
+├── config.toml                    ← copy & rename config.example.toml
+├── ui/                            ← web dashboard (copy from repo: ui/dist/)
+└── assets/
+    └── melodies/                  ← PUT YOUR AUDIO FILES HERE
+        ├── startup.wav
+        ├── jingle.mp3
+        └── (any other audio files)
+```
+
+### Copy the config template
+```bash
+cp config.example.toml  /path/to/fh6-radio/config.toml
+```
+
+---
+
+## 4. Adding Your Melody Files
+
+Drop any audio files into:
+```
+fh6-radio/assets/melodies/
+```
+
+### Supported formats
+| Format | Extension |
+|--------|-----------|
+| WAV    | `.wav`    |
+| MP3    | `.mp3`    |
+| FLAC   | `.flac`   |
+| OGG Vorbis | `.ogg` |
+| Opus   | `.opus`   |
+| AAC/M4A | `.m4a`  |
+
+### How random selection works
+- Every time a trigger fires (race start OR car switch), the mod scans the folder
+- It picks **one file at random** from all supported files found
+- Put as many files as you want — more files = more variety
+- A 3-second debounce prevents the same clip from overlapping itself
+
+**Example melodies folder:**
+```
+melodies/
+├── honda_etc.wav        ← JDM ETC reader beep
+├── nsx_startup.mp3      ← NSX startup melody
+├── supra_chime.flac     ← Supra door chime
+└── civic_theme.ogg      ← Civic startup theme
+```
+
+---
+
+## 5. Enable Car Change Detection
+
+The car-change trigger needs FH6 to broadcast its telemetry data over UDP.
+
+### In-game setup (do this once)
+```
+FH6 → Settings → HUD and Gameplay → scroll down to "Data Out"
+
+  Data Out              →  On
+  Data Out IP Address   →  127.0.0.1
+  Data Out Port         →  7777
+  Data Out Packet Format →  Car Dash
+```
+
+> ⚠️ If you change the port from `7777`, update `data_out_port` in your `config.toml` to match.
+
+---
+
+## 6. Configure via the Dashboard
+
+Once FH6 is running with the mod, open your browser at:
+```
+http://localhost:8420
+```
+
+### Enable the melody feature via the Dashboard UI
+
+Scroll down the dashboard to the **🎵 Startup Melody** card. From there you can:
+
+| Control | Description |
+|---------|-------------|
+| **Enable startup melody** | Master on/off toggle |
+| **On race start** | Trigger a melody when a race begins |
+| **On car switch** | Trigger when car ordinal changes (requires Data Out) |
+| **Debounce (ms)** | Minimum gap between plays (default 3000 ms) |
+| **FH6 Data Out port** | UDP port FH6 sends telemetry to (default 7777) |
+
+Click **Save** to apply. Changes take effect immediately without restarting the game.
+
+### View detected melody files
+
+The same card shows a live list of all audio files found in the melodies folder. Click **Refresh files** to re-scan after adding new files.
+
+### Advanced: using curl or the browser console
+
+You can still configure the feature programmatically if needed:
+
+```bash
+curl -X PUT http://localhost:8420/api/config \
+  -H "Content-Type: application/json" \
+  -d '{"startup_melody":{"enabled":true,"debounce_ms":3000,"trigger_on_race_start":true,"trigger_on_car_change":true,"data_out_port":7777}}'
+```
+
+### Check what melody files were detected
+```bash
+curl http://localhost:8420/api/startup_melody/files
+```
+Returns:
+```json
+{
+  "files": ["honda_etc.wav", "nsx_startup.mp3", "supra_chime.flac"],
+  "folder": "C:\\...\\fh6-radio\\assets\\melodies"
+}
+```
+
+### Check current config
+```bash
+curl http://localhost:8420/api/config
+```
+
+---
+
+## 7. Config Reference
+
+In `fh6-radio/config.toml`, the melody section looks like this:
+
+```toml
+[startup_melody]
+enabled              = true
+debounce_ms          = 3000    # minimum milliseconds between plays (3 seconds)
+trigger_on_race_start = true   # play when a race begins
+trigger_on_car_change = true   # play when you switch cars
+data_out_port        = 7777    # must match FH6 Data Out port setting
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `enabled` | `false` | Master switch. Set to `true` to activate |
+| `debounce_ms` | `3000` | Minimum gap between plays (ms). Prevents overlapping |
+| `trigger_on_race_start` | `true` | Play at the start of each race |
+| `trigger_on_car_change` | `true` | Play when car ordinal changes (requires Data Out) |
+| `data_out_port` | `7777` | UDP port that FH6 sends telemetry to |
+
+---
+
+## 8. FAQ & Troubleshooting
+
+### ❓ Melody doesn't play at all
+- Check `enabled = true` in config
+- Verify files exist in `fh6-radio/assets/melodies/` with a supported extension
+- Check the mod log (`fh6-radio/fh6-radio.log`) for `[melody]` lines
+
+### ❓ Car change not detected
+- Confirm FH6 Data Out is **On** in game settings
+- Confirm the IP is `127.0.0.1` and port matches `data_out_port`
+- The log will show: `[car_det] listening for FH6 telemetry on UDP port 7777`
+- If it shows a bind error, another app may be using that port — change to `7778` in both FH6 and config
+
+### ❓ Melody plays too often / overlaps
+- Increase `debounce_ms` (e.g. `5000` for 5 seconds)
+
+### ❓ Only `.wav` files work, not MP3
+- Make sure the file has the exact extension `.mp3` (not `.MP3` — case shouldn't matter but verify)
+- The mod uses **miniaudio** which supports MP3 natively, no codec install needed
+
+### ❓ Build fails: `cmake: command not found`
+```bash
+sudo pacman -S cmake llvm-mingw
+```
+
+### ❓ Build fails: `x86_64-w64-mingw32-clang++ not found`
+```bash
+sudo pacman -S llvm-mingw
+# Then re-run cmake
+```
+
+### ❓ Where are the build output files?
+```
+fh6-universal-radio/build/version.dll
+fh6-universal-radio/build/fh6-radio-worker.exe
+```
+
+---
+
+## Quick Reference Card
+
+```
+1. sudo pacman -S cmake llvm-mingw
+2. cd "/home/kazuha/Videos/FH6 radio/fh6-universal-radio"
+3. ./scripts/get-deps.sh
+4. cmake -B build -DCMAKE_TOOLCHAIN_FILE=cmake/mingw-w64-x86_64.cmake -DCMAKE_BUILD_TYPE=Release
+5. cmake --build build --parallel
+6. Copy build/version.dll + build/fh6-radio-worker.exe → next to ForzaHorizon6.exe
+7. Create fh6-radio/assets/melodies/ and drop audio files in
+8. In FH6: Settings → HUD → Data Out → On, IP=127.0.0.1, Port=7777
+9. Open http://localhost:8420 in your browser
+10. Scroll to the 🎵 Startup Melody card → toggle Enable → Save
+```

--- a/include/fh6/melody/car_change_detector.hpp
+++ b/include/fh6/melody/car_change_detector.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <thread>
+
+namespace fh6::melody {
+
+/// Listens on a UDP port for Forza Horizon 6 Data Out telemetry packets and
+/// detects when the player switches cars (CarOrdinal changes).
+///
+/// Setup in FH6:
+///   Settings → HUD and Gameplay → Data Out → On
+///   Data Out IP Address : 127.0.0.1
+///   Data Out Port       : (must match data_out_port in config.toml, default 7777)
+///   Data Out Packet Format: Car Dash (or Sled – both contain CarOrdinal)
+class CarChangeDetector {
+public:
+    /// Starts the background UDP listener thread on the given port.
+    explicit CarChangeDetector(int port);
+    ~CarChangeDetector();
+
+    CarChangeDetector(const CarChangeDetector&)            = delete;
+    CarChangeDetector& operator=(const CarChangeDetector&) = delete;
+
+    /// Returns true (exactly once) when a car change has been detected since
+    /// the last call. Thread-safe; safe to call every control-loop tick.
+    bool poll_car_changed() noexcept;
+
+    /// Restart the listener on a new port (called when config changes).
+    void restart(int new_port);
+
+private:
+    void run(int port);
+
+    std::atomic<bool>     changed_{false};
+    std::atomic<bool>     stop_{false};
+    std::jthread          thread_;
+};
+
+} // namespace fh6::melody

--- a/include/fh6/melody/melody_player.hpp
+++ b/include/fh6/melody/melody_player.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "fh6/config.hpp"
+#include "fh6/melody/melody_scanner.hpp"
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace fh6::melody {
+
+/// Plays a randomly chosen audio file from the melodies folder using miniaudio.
+/// Supports WAV, MP3, FLAC, OGG, Opus, M4A. Uses a debounce window so rapid
+/// triggers (race start, car switch) never stack up overlapping audio.
+///
+/// The miniaudio engine is lazy-initialised on the first trigger() call rather
+/// than in the constructor, which makes it robust under Wine/Proton where the
+/// audio subsystem may not be ready when the DLL loads.
+class MelodyPlayer {
+public:
+    /// base_dir – directory containing the audio files
+    ///            e.g. "<mod_root>/fh6-radio/assets/melodies/"
+    explicit MelodyPlayer(std::filesystem::path base_dir);
+    ~MelodyPlayer();
+
+    MelodyPlayer(const MelodyPlayer&)            = delete;
+    MelodyPlayer& operator=(const MelodyPlayer&) = delete;
+
+    /// Rescans the folder and picks a random file, then plays it.
+    /// No-op when cfg.enabled is false, folder is empty, or debounce is active.
+    /// Lazily initialises the miniaudio engine on first call.
+    void trigger(const StartupMelodyConfig& cfg);
+
+private:
+    std::filesystem::path base_dir_;
+    unsigned long long    last_play_ms_         = 0;
+
+    // Lazy engine initialisation state
+    void*              engine_               = nullptr; // ma_engine*
+    void*              context_              = nullptr; // ma_context* (may be nullptr)
+    unsigned long long last_init_attempt_ms_ = 0;
+
+    // Retry engine init at most once per 30 seconds to avoid hammering audio
+    static constexpr unsigned long long kInitRetryIntervalMs = 30'000ULL;
+};
+
+} // namespace fh6::melody

--- a/include/fh6/melody/melody_scanner.hpp
+++ b/include/fh6/melody/melody_scanner.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace fh6::melody {
+
+/// Audio formats supported by miniaudio (used for playback).
+/// All comparisons are case-insensitive.
+inline constexpr const char* kSupportedExtensions[] = {
+    ".wav", ".mp3", ".flac", ".ogg", ".opus", ".m4a"
+};
+
+/// Returns bare filenames (e.g. "startup.mp3") for every supported audio file
+/// found directly inside `folder`. Returns an empty vector if the folder does
+/// not exist or cannot be read. Results are sorted alphabetically.
+std::vector<std::string> scan_melody_files(const std::filesystem::path& folder);
+
+} // namespace fh6::melody

--- a/src/melody/car_change_detector.cpp
+++ b/src/melody/car_change_detector.cpp
@@ -1,0 +1,113 @@
+#include "fh6/melody/car_change_detector.hpp"
+#include "fh6/log.hpp"
+
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+#include <cstring>
+#include <cstdint>
+
+namespace fh6::melody {
+
+// ---------------------------------------------------------------------------
+// FH6 / FH5 / FM8 "Sled + Dash" Data Out packet layout.
+// The game sends 232-byte or 311-byte packets depending on the format selected.
+// CarOrdinal sits at byte offset 212 in both formats (it's in the Sled block).
+// ---------------------------------------------------------------------------
+namespace {
+    constexpr std::size_t kCarOrdinalOffset = 212;
+    constexpr std::size_t kMinPacketSize    = 216; // must have bytes 212-215
+}
+
+CarChangeDetector::CarChangeDetector(int port)
+    : thread_{[this, port](std::stop_token /*tok*/) {
+          stop_.store(false, std::memory_order_relaxed);
+          run(port);
+      }} {}
+
+CarChangeDetector::~CarChangeDetector() {
+    stop_.store(true, std::memory_order_release);
+    thread_.request_stop();
+}
+
+bool CarChangeDetector::poll_car_changed() noexcept {
+    return changed_.exchange(false, std::memory_order_acq_rel);
+}
+
+void CarChangeDetector::restart(int new_port) {
+    stop_.store(true, std::memory_order_release);
+    thread_.request_stop();
+    if (thread_.joinable()) {
+        thread_.join();
+    }
+    stop_.store(false, std::memory_order_relaxed);
+    thread_ = std::jthread{[this, new_port](std::stop_token) { run(new_port); }};
+}
+
+void CarChangeDetector::run(int port) {
+    WSADATA wsa;
+    if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0) {
+        log::warn("[car_det] WSAStartup failed; car-change detection unavailable");
+        return;
+    }
+
+    SOCKET sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (sock == INVALID_SOCKET) {
+        log::warn("[car_det] socket() failed");
+        WSACleanup();
+        return;
+    }
+
+    // Non-blocking via a 200ms select timeout so we can check stop_ each loop.
+    BOOL reuse = TRUE;
+    setsockopt(sock, SOL_SOCKET, SO_REUSEADDR,
+               reinterpret_cast<const char*>(&reuse), sizeof(reuse));
+
+    sockaddr_in addr{};
+    addr.sin_family      = AF_INET;
+    addr.sin_port        = htons(static_cast<u_short>(port));
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK); // only accept from localhost
+
+    if (bind(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+        log::warn("[car_det] bind() on port {} failed; is FH6 Data Out configured?", port);
+        closesocket(sock);
+        WSACleanup();
+        return;
+    }
+
+    log::info("[car_det] listening for FH6 telemetry on UDP port {}", port);
+
+    constexpr int kBufSize = 512;
+    char buf[kBufSize];
+    int32_t prev_ordinal = -1;
+
+    while (!stop_.load(std::memory_order_acquire)) {
+        fd_set rfds;
+        FD_ZERO(&rfds);
+        FD_SET(sock, &rfds);
+        timeval tv{0, 200'000}; // 200 ms
+        const int sel = select(0, &rfds, nullptr, nullptr, &tv);
+        if (sel <= 0) continue;
+
+        const int n = recv(sock, buf, kBufSize, 0);
+        if (n < static_cast<int>(kMinPacketSize)) continue;
+
+        // Read CarOrdinal as little-endian int32 at offset 212
+        int32_t ordinal = 0;
+        std::memcpy(&ordinal, buf + kCarOrdinalOffset, sizeof(ordinal));
+
+        if (ordinal == 0) continue; // 0 = no car / in menu
+
+        if (prev_ordinal != -1 && ordinal != prev_ordinal) {
+            log::info("[car_det] car changed: ordinal {} -> {}", prev_ordinal, ordinal);
+            changed_.store(true, std::memory_order_release);
+        }
+        prev_ordinal = ordinal;
+    }
+
+    closesocket(sock);
+    WSACleanup();
+    log::info("[car_det] listener stopped");
+}
+
+} // namespace fh6::melody

--- a/src/melody/melody_player.cpp
+++ b/src/melody/melody_player.cpp
@@ -1,0 +1,158 @@
+// miniaudio.h — implementation is defined once in local_file_source.cpp
+#include "miniaudio.h"
+
+#include "fh6/melody/melody_player.hpp"
+#include "fh6/log.hpp"
+
+#include <windows.h> // GetTickCount64
+
+#include <cstdlib>   // rand, srand
+#include <ctime>     // time
+#include <string>
+
+namespace fh6::melody {
+
+// ---------------------------------------------------------------------------
+// Backend preference order for Wine/Proton compatibility.
+// WinMM is the most reliable backend under Wine; try it first, then fall back.
+// ---------------------------------------------------------------------------
+static const ma_backend kPreferredBackends[] = {
+    ma_backend_winmm,
+    ma_backend_wasapi,
+    ma_backend_dsound,
+};
+
+// Try to initialise a miniaudio engine.
+// Returns the engine pointer on success, nullptr on failure.
+// When a custom context is created and succeeds, it is written to *out_ctx
+// so the caller can free it on cleanup (stored as own_context_).
+static ma_engine* try_init_engine(ma_context** out_ctx) {
+    *out_ctx = nullptr;
+    auto* eng = new ma_engine{};
+
+    // -----------------------------------------------------------------------
+    // Attempt 1: explicit backend list (WinMM first) via a custom context
+    // -----------------------------------------------------------------------
+    auto* ctx = new ma_context{};
+    ma_context_config ctx_cfg = ma_context_config_init();
+    ma_result r = ma_context_init(kPreferredBackends,
+                                  static_cast<ma_uint32>(std::size(kPreferredBackends)),
+                                  &ctx_cfg, ctx);
+    if (r == MA_SUCCESS) {
+        ma_engine_config eng_cfg = ma_engine_config_init();
+        eng_cfg.pContext = ctx;
+        if (ma_engine_init(&eng_cfg, eng) == MA_SUCCESS) {
+            log::info("[melody] miniaudio engine ready (WinMM-preferred context)");
+            *out_ctx = ctx; // caller owns this context
+            return eng;
+        }
+        ma_context_uninit(ctx);
+    }
+    delete ctx;
+
+    // -----------------------------------------------------------------------
+    // Attempt 2: fully automatic backend selection (miniaudio default)
+    // -----------------------------------------------------------------------
+    ma_engine_config eng_cfg2 = ma_engine_config_init();
+    if (ma_engine_init(&eng_cfg2, eng) == MA_SUCCESS) {
+        log::info("[melody] miniaudio engine ready (auto backend)");
+        return eng; // *out_ctx stays nullptr — no owned context
+    }
+
+    log::warn("[melody] miniaudio engine init failed (both attempts); "
+              "will retry on next trigger");
+    delete eng;
+    return nullptr;
+}
+
+// ---------------------------------------------------------------------------
+// MelodyPlayer
+// ---------------------------------------------------------------------------
+
+MelodyPlayer::MelodyPlayer(std::filesystem::path base_dir)
+    : base_dir_{std::move(base_dir)} {
+    std::srand(static_cast<unsigned>(std::time(nullptr)));
+    // Engine is NOT initialised here intentionally.
+    // Wine/Proton audio subsystem may not be ready when the DLL first loads.
+    // Lazy init happens on the first trigger() call instead.
+}
+
+MelodyPlayer::~MelodyPlayer() {
+    if (engine_) {
+        ma_engine_uninit(static_cast<ma_engine*>(engine_));
+        delete static_cast<ma_engine*>(engine_);
+    }
+    if (context_) {
+        ma_context_uninit(static_cast<ma_context*>(context_));
+        delete static_cast<ma_context*>(context_);
+    }
+}
+
+void MelodyPlayer::trigger(const StartupMelodyConfig& cfg) {
+    if (!cfg.enabled) return;
+
+    // -----------------------------------------------------------------------
+    // Lazy-initialise the audio engine.
+    // Throttle retry attempts to once per kInitRetryIntervalMs.
+    // -----------------------------------------------------------------------
+    if (!engine_) {
+        const unsigned long long now_pre = GetTickCount64();
+        if (last_init_attempt_ms_ != 0 &&
+            now_pre - last_init_attempt_ms_ < kInitRetryIntervalMs) {
+            return; // too soon to retry
+        }
+        last_init_attempt_ms_ = now_pre;
+
+        ma_context* ctx = nullptr;
+        ma_engine*  eng = try_init_engine(&ctx);
+        if (!eng) return; // still not ready
+        engine_  = eng;
+        context_ = ctx; // may be nullptr if auto-init succeeded
+    }
+
+    // -----------------------------------------------------------------------
+    // Debounce check
+    // -----------------------------------------------------------------------
+    const unsigned long long now = GetTickCount64();
+    if (cfg.debounce_ms > 0 &&
+        now - last_play_ms_ < static_cast<unsigned long long>(cfg.debounce_ms)) {
+        return;
+    }
+
+    // -----------------------------------------------------------------------
+    // Scan folder and pick a random file
+    // -----------------------------------------------------------------------
+    auto files = scan_melody_files(base_dir_);
+    if (files.empty()) {
+        log::warn("[melody] no audio files found in: {}", base_dir_.string());
+        return;
+    }
+
+    const int idx = std::rand() % static_cast<int>(files.size());
+    const std::filesystem::path chosen = base_dir_ / files[static_cast<size_t>(idx)];
+    const std::string path_str = chosen.string();
+
+    // -----------------------------------------------------------------------
+    // Play asynchronously via miniaudio engine (fire-and-forget)
+    // -----------------------------------------------------------------------
+    ma_engine* eng = static_cast<ma_engine*>(engine_);
+    if (ma_engine_play_sound(eng, path_str.c_str(), nullptr) == MA_SUCCESS) {
+        last_play_ms_ = now;
+        log::info("[melody] playing ({}/{}): {}", idx + 1,
+                  static_cast<int>(files.size()), files[static_cast<size_t>(idx)]);
+    } else {
+        log::warn("[melody] playback failed for: {} — resetting engine", path_str);
+        // Tear down so we re-initialise cleanly on the next trigger
+        ma_engine_uninit(eng);
+        delete eng;
+        engine_ = nullptr;
+        if (context_) {
+            ma_context_uninit(static_cast<ma_context*>(context_));
+            delete static_cast<ma_context*>(context_);
+            context_ = nullptr;
+        }
+        last_init_attempt_ms_ = 0; // allow immediate retry next time
+    }
+}
+
+} // namespace fh6::melody

--- a/src/melody/melody_scanner.cpp
+++ b/src/melody/melody_scanner.cpp
@@ -1,0 +1,37 @@
+#include "fh6/melody/melody_scanner.hpp"
+
+#include <algorithm>
+#include <string>
+
+namespace fh6::melody {
+
+std::vector<std::string> scan_melody_files(const std::filesystem::path& folder) {
+    std::vector<std::string> result;
+    std::error_code ec;
+    if (!std::filesystem::is_directory(folder, ec)) return result;
+
+    for (const auto& entry : std::filesystem::directory_iterator(folder, ec)) {
+        if (ec) break;
+        if (!entry.is_regular_file()) continue;
+
+        const auto& p = entry.path();
+        if (!p.has_extension()) continue;
+
+        // Case-insensitive extension match
+        auto ext = p.extension().string();
+        std::transform(ext.begin(), ext.end(), ext.begin(),
+                       [](unsigned char c) { return static_cast<char>(::tolower(c)); });
+
+        for (const char* supported : kSupportedExtensions) {
+            if (ext == supported) {
+                result.push_back(p.filename().string());
+                break;
+            }
+        }
+    }
+
+    std::sort(result.begin(), result.end());
+    return result;
+}
+
+} // namespace fh6::melody

--- a/ui/dist/js/render/startupMelody.js
+++ b/ui/dist/js/render/startupMelody.js
@@ -1,0 +1,180 @@
+import { api } from "../api.js";
+import { el } from "../dom.js";
+import { toast } from "../toast.js";
+
+/**
+ * createStartupMelody — self-contained Startup Melody dashboard card.
+ *
+ * ctx: { getConfig: () => cfg, onSaved: async () => void }
+ */
+export function createStartupMelody(main, ctx) {
+  let files = [];
+  let folder = "";
+  let loaded = false;
+  let loading = false;
+
+  // ── Controls ──────────────────────────────────────────────────────────
+  const enabledChk = el("input", { type: "checkbox", id: "mel-enabled" });
+  const raceChk    = el("input", { type: "checkbox", id: "mel-race" });
+  const carChk     = el("input", { type: "checkbox", id: "mel-car" });
+  const debounceIn = el("input", {
+    type: "number", id: "mel-debounce", min: "500", max: "30000", step: "500", value: "3000",
+  });
+  const portIn = el("input", {
+    type: "number", id: "mel-port", min: "1024", max: "65535", step: "1", value: "7777",
+  });
+
+  const fileList  = el("ul", { class: "melody-file-list" });
+  const folderEl  = el("code", { class: "melody-folder" }, "—");
+  const refreshBtn = el("button", { type: "button", class: "btn ghost" }, "Refresh files");
+  const saveBtn    = el("button", { type: "button", class: "btn filled" }, "Save");
+  const statusEl   = el("p",  { class: "muted" }, "");
+
+  // ── Card DOM ──────────────────────────────────────────────────────────
+  const card = el("section", { class: "card", id: "startup-melody-card" }, [
+    el("h2", {}, "🎵 Startup Melody"),
+    el("p", { class: "muted" },
+      "Play a random audio clip from the melodies folder whenever you start a race or switch cars."),
+
+    // Enable toggle
+    el("div", { class: "field checkbox" }, [
+      enabledChk,
+      el("label", { for: "mel-enabled" }, "Enable startup melody"),
+    ]),
+
+    // Trigger checkboxes
+    el("fieldset", { class: "mel-triggers" }, [
+      el("legend", {}, "Triggers"),
+      el("div", { class: "field checkbox" }, [
+        raceChk,
+        el("label", { for: "mel-race" }, "On race start"),
+      ]),
+      el("div", { class: "field checkbox" }, [
+        carChk,
+        el("label", { for: "mel-car" }, "On car switch (requires FH6 Data Out)"),
+      ]),
+    ]),
+
+    // Debounce + port row
+    el("div", { class: "mel-row" }, [
+      el("div", { class: "field" }, [
+        el("label", { for: "mel-debounce" }, "Debounce (ms)"),
+        debounceIn,
+      ]),
+      el("div", { class: "field" }, [
+        el("label", { for: "mel-port" }, "FH6 Data Out port"),
+        portIn,
+      ]),
+    ]),
+
+    // Save button
+    el("div", { class: "row mel-actions" }, [saveBtn]),
+
+    // File browser section
+    el("h3", { class: "mel-sub" }, "Melody Files"),
+    el("p", { class: "muted" },
+      "Drop .wav / .mp3 / .flac / .ogg / .opus / .m4a files into the folder below. " +
+      "One file is picked at random on each trigger."),
+    el("div", { class: "mel-folder-row" }, [
+      el("span", { class: "muted" }, "Folder: "),
+      folderEl,
+      refreshBtn,
+    ]),
+    fileList,
+    statusEl,
+  ]);
+
+  // Insert after the output card if present, else append
+  const outputCard = main.querySelector("#output-card");
+  if (outputCard) outputCard.insertAdjacentElement("afterend", card);
+  else main.append(card);
+
+  // ── Populate from config ───────────────────────────────────────────────
+  function syncFromConfig() {
+    const m = ctx.getConfig()?.startup_melody;
+    if (!m) return;
+    enabledChk.checked = !!m.enabled;
+    raceChk.checked    = m.trigger_on_race_start !== false;
+    carChk.checked     = m.trigger_on_car_change !== false;
+    debounceIn.value   = String(m.debounce_ms   ?? 3000);
+    portIn.value       = String(m.data_out_port  ?? 7777);
+  }
+
+  // ── File list loader ───────────────────────────────────────────────────
+  async function loadFiles(force = false) {
+    if ((loaded && !force) || loading) return;
+    loading = true;
+    statusEl.textContent = "Loading…";
+    fileList.replaceChildren();
+    try {
+      const r = await api.getMelodyFiles();
+      files  = Array.isArray(r.files) ? r.files : [];
+      folder = r.folder || "";
+      loaded = true;
+    } catch (e) {
+      files  = [];
+      folder = "";
+      loaded = false;
+      statusEl.textContent = "Could not load melody files: " + e.message;
+    } finally {
+      loading = false;
+    }
+    renderFileList();
+  }
+
+  function renderFileList() {
+    folderEl.textContent = folder || "—";
+
+    if (files.length === 0) {
+      fileList.replaceChildren(
+        el("li", { class: "melody-empty" },
+          "No audio files found — add some to the melodies folder and click Refresh.")
+      );
+      statusEl.textContent = "";
+      return;
+    }
+
+    fileList.replaceChildren(
+      ...files.map(f =>
+        el("li", { class: "melody-file" }, [
+          el("span", { class: "melody-icon" }, "♪"),
+          el("span", { class: "melody-name" }, f),
+        ])
+      )
+    );
+    statusEl.textContent = `${files.length} file${files.length === 1 ? "" : "s"} found`;
+  }
+
+  // ── Events ────────────────────────────────────────────────────────────
+  refreshBtn.addEventListener("click", () => loadFiles(true));
+
+  saveBtn.addEventListener("click", async () => {
+    saveBtn.disabled = true;
+    try {
+      await api.putMelodyConfig({
+        enabled:               enabledChk.checked,
+        trigger_on_race_start: raceChk.checked,
+        trigger_on_car_change: carChk.checked,
+        debounce_ms:           parseInt(debounceIn.value, 10) || 3000,
+        data_out_port:         parseInt(portIn.value,     10) || 7777,
+      });
+      toast("Startup Melody settings saved ✓");
+      await ctx.onSaved();
+    } catch (e) {
+      toast(e.message, true);
+    } finally {
+      saveBtn.disabled = false;
+    }
+  });
+
+  // ── Public API ────────────────────────────────────────────────────────
+  function render() {
+    syncFromConfig();
+    loadFiles();
+  }
+
+  return {
+    render,
+    invalidate: () => { loaded = false; },
+  };
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Startup Melody feature: plays randomly selected audio files when changing cars in Forza Horizon 6, with automatic debounce protection and local web dashboard for configuration.

* **Documentation**
  * Added comprehensive guide covering setup, installation, supported audio formats, configuration, REST API reference, and troubleshooting for the Startup Melody feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->