### PR TITLE
Added an 'off' option to race_start_playback

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -1,9 +1,9 @@
 # Example config, copied to `<game>/fh6-radio/config.toml` on first install.
 # Everything is editable from the dashboard; you only need to touch this file
-# if you prefer hand edits. Windows paths should use TOML literal strings
-# (single quotes) so backslashes pass through verbatim:
+# if you prefer hand edits. Windows paths should use TOML literal strings 
+# (single quotes) so backslashes pass through verbatim:  
 #
-#   roots = ['C:\Users\you\Music']
+#   roots = ['C:\Users\you\Music'] 
 
 [general]
 port              = 8420

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,19 +1,19 @@
 # Example config, copied to `<game>/fh6-radio/config.toml` on first install.
 # Everything is editable from the dashboard; you only need to touch this file
-# if you prefer hand edits. Windows paths should use TOML literal strings 
-# (single quotes) so backslashes pass through verbatim:  
+# if you prefer hand edits. Windows paths should use TOML literal strings
+# (single quotes) so backslashes pass through verbatim:
 #
-#   roots = ['C:\Users\you\Music'] 
+#   roots = ['C:\Users\you\Music']
 
 [general]
 port              = 8420
 ring_buffer_mb    = 4
-default_source    = "local_files"    # local_files | online_radio | youtube_music | jellyfin | external_audio | spotify
-fallback_source   = "online_radio"
+default_source    = "online_radio"    # local_files | online_radio | youtube_music | jellyfin | external_audio | spotify
+fallback_source   = "local_files"
 ffmpeg_path       = ''                # blank = auto-download to fh6-radio/bin (else `ffmpeg` on PATH); shared by all sources
 
 [local_files]
-enabled            = true
+enabled            = false
 active_station     = "My Music"        # which preset is on air
 # mp3/flac/wav/ogg decode natively; the rest goes through ffmpeg if available.
 supported_formats  = ["mp3", "flac", "wav", "ogg", "m4a", "opus", "aac", "wma", "aiff", "aif", "m3u", "m3u8"]
@@ -22,7 +22,7 @@ supported_formats  = ["mp3", "flac", "wav", "ogg", "m4a", "opus", "aac", "wma", 
 # can point at several folders, exclude subfolders, and set its own play order.
 [[local_files.station]]
 name      = "My Music"
-roots     = ['f:\Games\Forza Horizon 6\fh6-radio\Music']                         # e.g. ['C:\Users\you\Music', 'D:\FLAC']
+roots     = []                         # e.g. ['C:\Users\you\Music', 'D:\FLAC']
 excluded  = []                         # subfolders to skip, e.g. ['C:\Users\you\Music\Audiobooks']
 recursive = true
 order     = "shuffle"                  # "shuffle" | "album" | "name" | "folder"
@@ -93,9 +93,9 @@ enabled               = false
 output_gain = 1.0
 
 [playback]
-race_start_playback  = "off"      # "next" | "restart" | "ignore" | "off" -- action when a race begins
-quick_station_skip   = true       # tune the radio away and back within 1s to skip the track
-volume_normalization = true       # apply ReplayGain (local files) / EBU R128 loudnorm (YT) when on
+race_start_playback  = "next"      # "next" | "restart" | "ignore" | "off" -- action when a race begins
+quick_station_skip   = false       # tune the radio away and back within 1s to skip the track
+volume_normalization = false       # apply ReplayGain (local files) / EBU R128 loudnorm (YT) when on
 equalizer_enabled    = false
 equalizer_bands      = [0.0, 0.0, 0.0, 0.0, 0.0]   # 60/250/1000/4000/12000 Hz, [-6, +6] dB
 force_stereo_audio   = true        # off => mono (avoids metallic phase-cancellation on the 3D radio channel)

--- a/config.example.toml
+++ b/config.example.toml
@@ -8,12 +8,12 @@
 [general]
 port              = 8420
 ring_buffer_mb    = 4
-default_source    = "online_radio"    # local_files | online_radio | youtube_music | jellyfin | external_audio | spotify
-fallback_source   = "local_files"
+default_source    = "local_files"    # local_files | online_radio | youtube_music | jellyfin | external_audio | spotify
+fallback_source   = "online_radio"
 ffmpeg_path       = ''                # blank = auto-download to fh6-radio/bin (else `ffmpeg` on PATH); shared by all sources
 
 [local_files]
-enabled            = false
+enabled            = true
 active_station     = "My Music"        # which preset is on air
 # mp3/flac/wav/ogg decode natively; the rest goes through ffmpeg if available.
 supported_formats  = ["mp3", "flac", "wav", "ogg", "m4a", "opus", "aac", "wma", "aiff", "aif", "m3u", "m3u8"]
@@ -22,7 +22,7 @@ supported_formats  = ["mp3", "flac", "wav", "ogg", "m4a", "opus", "aac", "wma", 
 # can point at several folders, exclude subfolders, and set its own play order.
 [[local_files.station]]
 name      = "My Music"
-roots     = []                         # e.g. ['C:\Users\you\Music', 'D:\FLAC']
+roots     = ['f:\Games\Forza Horizon 6\fh6-radio\Music']                         # e.g. ['C:\Users\you\Music', 'D:\FLAC']
 excluded  = []                         # subfolders to skip, e.g. ['C:\Users\you\Music\Audiobooks']
 recursive = true
 order     = "shuffle"                  # "shuffle" | "album" | "name" | "folder"
@@ -82,9 +82,9 @@ default_station_index = 0 # index of radio station in list (0 refers to start of
 output_gain = 1.0
 
 [playback]
-race_start_playback  = "next"      # "next" | "restart" | "ignore" -- action when a race begins
-quick_station_skip   = false       # tune the radio away and back within 1s to skip the track
-volume_normalization = false       # apply ReplayGain (local files) / EBU R128 loudnorm (YT) when on
+race_start_playback  = "off"      # "next" | "restart" | "ignore" | "off" -- action when a race begins
+quick_station_skip   = true       # tune the radio away and back within 1s to skip the track
+volume_normalization = true       # apply ReplayGain (local files) / EBU R128 loudnorm (YT) when on
 equalizer_enabled    = false
 equalizer_bands      = [0.0, 0.0, 0.0, 0.0, 0.0]   # 60/250/1000/4000/12000 Hz, [-6, +6] dB
 force_stereo_audio   = true        # off => mono (avoids metallic phase-cancellation on the 3D radio channel)

--- a/include/fh6/config.hpp
+++ b/include/fh6/config.hpp
@@ -9,7 +9,7 @@
 namespace fh6 {
 
 struct PlaybackConfig {
-    std::string race_start_playback = "next"; // "next" | "restart" | "ignore"
+    std::string race_start_playback = "next"; // "next" | "restart" | "ignore" | "off"
     bool quick_station_skip         = false;
     bool volume_normalization       = false;
     bool equalizer_enabled          = false;

--- a/include/fh6/fmod/dsp_control_loop.hpp
+++ b/include/fh6/fmod/dsp_control_loop.hpp
@@ -80,6 +80,7 @@ private:
     bool prev_race_restart_   = false;
     bool quick_skip_armed_    = false;
     bool paused_by_race_off_  = false;
+    bool first_connection_    = true;
     time_point last_r10_off_{};
     time_point last_race_event_{};
     time_point last_skip_cmd_{};

--- a/include/fh6/fmod/dsp_control_loop.hpp
+++ b/include/fh6/fmod/dsp_control_loop.hpp
@@ -81,6 +81,7 @@ private:
     bool quick_skip_armed_    = false;
     bool paused_by_race_off_  = false;
     bool first_connection_    = true;
+    bool stopped_by_race_off_ = false;
     time_point last_r10_off_{};
     time_point last_race_event_{};
     time_point last_skip_cmd_{};

--- a/include/fh6/fmod/dsp_control_loop.hpp
+++ b/include/fh6/fmod/dsp_control_loop.hpp
@@ -75,10 +75,11 @@ private:
     mutable std::mutex playback_opts_mtx_;
     std::shared_ptr<const PlaybackConfig> playback_opts_;
 
-    bool prev_r10_          = false;
-    bool prev_race_         = false;
-    bool prev_race_restart_ = false;
-    bool quick_skip_armed_  = false;
+    bool prev_r10_            = false;
+    bool prev_race_           = false;
+    bool prev_race_restart_   = false;
+    bool quick_skip_armed_    = false;
+    bool paused_by_race_off_  = false;
     time_point last_r10_off_{};
     time_point last_race_event_{};
     time_point last_skip_cmd_{};

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -170,7 +170,7 @@ Config load_config(const std::filesystem::path& path) {
     const auto& pb = section(root, "playback");
     {
         auto rs = pick<std::string>(pb, "race_start_playback", cfg.playback.race_start_playback);
-        if (rs == "next" || rs == "restart" || rs == "ignore")
+        if (rs == "next" || rs == "restart" || rs == "ignore" || rs == "off")
             cfg.playback.race_start_playback = std::move(rs);
     }
     cfg.playback.quick_station_skip =

--- a/src/fmod/dsp_control_loop.cpp
+++ b/src/fmod/dsp_control_loop.cpp
@@ -256,7 +256,7 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
         prev_r10_ = prev_race_ = prev_race_restart_ = false;
         paused_by_race_off_ = false;
         first_connection_   = true;
-        quick_skip_armed_                           = false;
+        quick_skip_armed_   = false;
         return;
     }
 
@@ -295,12 +295,12 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
             outcome = fired ? "restarted current track" : "could not restart current track";
         } else if (mode == "off") {
             if (active->playback_state() == PlaybackState::playing) {
-                active->pause();
+                active->stop();
                 fired               = true;
                 paused_by_race_off_ = true;
-                outcome = "paused playback";
+                outcome             = "stopped playback";
             } else {
-                outcome = "skipped pause (not playing)";
+                outcome = "skipped stop (not playing)";
             }
         }
         if (fired) {

--- a/src/fmod/dsp_control_loop.cpp
+++ b/src/fmod/dsp_control_loop.cpp
@@ -238,6 +238,7 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
     auto* active = bridge_.manager().active();
     if (!active) {
         prev_r10_ = prev_race_ = prev_race_restart_ = false;
+        paused_by_race_off_ = false;
         quick_skip_armed_                           = false;
         return;
     }
@@ -268,7 +269,8 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
             outcome = fired ? "restarted current track" : "could not restart current track";
         } else if (mode == "off") {
             active->pause();
-            fired   = true;
+            fired              = true;
+            paused_by_race_off_ = true;
             outcome = "paused playback";
         }
         if (fired) {
@@ -277,6 +279,14 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
         }
         last_race_event_ = now;
         log::info("[ctrl] race {} -- {}", restart_edge_in ? "restarted" : "started", outcome);
+    }
+
+    // --- raceEndResume (race_active falling edge) ---
+    const bool race_edge_out = !game.race_active && prev_race_;
+    if (race_edge_out && paused_by_race_off_) {
+        active->play();
+        paused_by_race_off_ = false;
+        log::info("[ctrl] race ended -- resuming playback");
     }
     prev_race_         = game.race_active;
     prev_race_restart_ = game.race_restart;

--- a/src/fmod/dsp_control_loop.cpp
+++ b/src/fmod/dsp_control_loop.cpp
@@ -294,7 +294,8 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
             fired   = active->restart_current();
             outcome = fired ? "restarted current track" : "could not restart current track";
         } else if (mode == "off") {
-            if (active->playback_state() == PlaybackState::playing) {
+            const auto st = active->playback_state();
+            if (st == PlaybackState::playing || st == PlaybackState::buffering) {
                 active->stop();
                 fired               = true;
                 paused_by_race_off_ = true;

--- a/src/fmod/dsp_control_loop.cpp
+++ b/src/fmod/dsp_control_loop.cpp
@@ -268,10 +268,14 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
             fired   = active->restart_current();
             outcome = fired ? "restarted current track" : "could not restart current track";
         } else if (mode == "off") {
-            active->pause();
-            fired              = true;
-            paused_by_race_off_ = true;
-            outcome = "paused playback";
+            if (active->playback_state() == PlaybackState::playing) {
+                active->pause();
+                fired               = true;
+                paused_by_race_off_ = true;
+                outcome = "paused playback";
+            } else {
+                outcome = "skipped pause (not playing)";
+            }
         }
         if (fired) {
             ring.drain();

--- a/src/fmod/dsp_control_loop.cpp
+++ b/src/fmod/dsp_control_loop.cpp
@@ -239,6 +239,7 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
     if (!active) {
         prev_r10_ = prev_race_ = prev_race_restart_ = false;
         paused_by_race_off_ = false;
+        first_connection_   = true;
         quick_skip_armed_                           = false;
         return;
     }

--- a/src/fmod/dsp_control_loop.cpp
+++ b/src/fmod/dsp_control_loop.cpp
@@ -250,6 +250,15 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
     // transitions even though the user stayed on our station, which used to
     // trip a phantom quickStationSkip on every race start.
     const bool r10 = game.on_target_station;
+
+    if (first_connection_) {
+        prev_race_         = game.race_active;
+        prev_race_restart_ = game.race_restart;
+        prev_r10_          = r10;
+        first_connection_  = false;
+        return;
+    }
+
     auto& ring     = bridge_.manager().ring();
 
     // --- raceStartPlayback (race_active edge, gated by R10 + debounces) ---

--- a/src/fmod/dsp_control_loop.cpp
+++ b/src/fmod/dsp_control_loop.cpp
@@ -266,6 +266,10 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
         } else if (mode == "restart") {
             fired   = active->restart_current();
             outcome = fired ? "restarted current track" : "could not restart current track";
+        } else if (mode == "off") {
+            active->pause();
+            fired   = true;
+            outcome = "paused playback";
         }
         if (fired) {
             ring.drain();

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -375,7 +375,7 @@ void apply_patch(Config& c, const json& j) {
     }
     if (auto it = j.find("playback"); it != j.end()) {
         auto rs = pull<std::string>(*it, "race_start_playback", c.playback.race_start_playback);
-        if (rs == "next" || rs == "restart" || rs == "ignore")
+        if (rs == "next" || rs == "restart" || rs == "ignore" || rs == "off")
             c.playback.race_start_playback = std::move(rs);
         c.playback.quick_station_skip =
             pull(*it, "quick_station_skip", c.playback.quick_station_skip);


### PR DESCRIPTION
Added an 'off' option to race_start_playback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `"off"` race-start playback mode that pauses playback when the race starts, then resumes automatically when the race ends.

* **Improvements**
  * Enhanced race edge handling to prevent first-iteration/spurious triggers and improved internal state tracking for pause/stop/resume behavior.

* **Bug Fixes**
  * Expanded configuration validation to consistently accept `"off"` in both configuration loading and HTTP-based playback patching.

* **Documentation**
  * Updated example configuration comments to list the new supported `"off"` option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->