### PR TITLE
feat: Add hotkey logic (play/pause, skip, source), settings backup support and Jellyfin queue management and track selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,18 @@ An open-source radio mod for **Forza Horizon 6**. Adds a new in-game radio stati
 
 - **Local files**: build named **stations** from one or more folders, exclude subfolders you don't want, and pick a play order (shuffle / albums / name / folder) with repeat modes and a searchable queue. MP3 / FLAC / WAV / OGG / M4A / AAC / OPUS / WMA / M3U / M3U8 etc.
 - **Online radio**: search a directory of thousands of internet stations by name, genre, or country (via [radio-browser.info](https://www.radio-browser.info)) or paste any stream URL; save favourites with logos and genre/bitrate badges, with live track info.
-- **YouTube Music**: paste any video, playlist, or YT Music URL from the dashboard.
+- **YouTube Music**: paste any video, playlist, or YT Music URL from the dashboard. Tracks are added to a searchable queue, with support for saving playlists as reusable stations.
 - **Spotify Connect**: cast from the Spotify app to an "FH6 Universal Radio" device (requires Spotify Premium).
-- **Jellyfin**: stream playlists from your own Jellyfin server.
+- **Jellyfin**: stream playlists from your own Jellyfin server, view queued tracks, and save playlists as stations for quick access later.
 - **External audio**: capture any Windows app (Deezer, a browser tab...) and pipe it into the radio through a virtual audio cable.
 - **In-game radio integration**: audio is routed through FH6's radio bus, fades with menus and reacts to in-game volume like every other station.
 - **Live dashboard** at `http://localhost:8420`: switch source, transport controls, volume, settings.
-- **Race start action**: on race begin, advance to next track, restart the current one, or leave it alone.
+- **Race start action**: on race begin, advance to next track, restart the current one, turn radio off on race begin, or leave it alone.
 - **Quick station skip**: tune the radio knob away and back within 1s to skip the current track.
 - **Loudness normalization**: For consistent volume across tracks.
 - **5-band equalizer**: 60 Hz / 250 Hz / 1 kHz / 4 kHz / 12 kHz peaking biquads, ±6 dB per band, applied producer-side at 48 kHz before audio hits the game.
+- **Vanilla radio passthrough**: broadcast FH6's built-in radio stations through the mod. Requires **Streamer Mode = Off** while in use.
+- **Media hotkeys**: Play/Pause and Next Track/Source media keys continue to work while FH6 is focused.
 
 ## Install
 
@@ -35,7 +37,9 @@ An open-source radio mod for **Forza Horizon 6**. Adds a new in-game radio stati
 1. Download the latest `fh6-universal-radio.zip` from [Nexus Mods](https://www.nexusmods.com/forzahorizon6/mods/215).
 2. Close FH6.
 3. Extract the ZIP into your Forza Horizon 6 install folder (next to `forzahorizon6.exe`). Overwrite when prompted.
-4. Launch the game. In **Audio settings**, set **Radio DJ = Off** and **Streamer Mode = On**.
+4. Launch the game. In **Audio settings**, set **Radio DJ = Off**.
+   - For custom stations (local files, Spotify, YouTube Music, Jellyfin, etc.), enable **Streamer Mode**.
+   - For **Vanilla Radio passthrough**, disable **Streamer Mode**.
 5. Cycle through radio stations until you land on the new one.
 6. Open <http://localhost:8420> in any browser on the same machine. From another device on the same network, use your PC's local IP (e.g. `http://192.168.1.42:8420`), run `ipconfig` in a Command Prompt to find it.
 
@@ -63,6 +67,14 @@ External Audio is a loopback capture of a Windows playback device, so the app ha
 4. Pick the app as the **Media session** for the in-game title/artist and the next/previous controls.
 
 The app then pauses and resumes with the game radio (menus, radio off) instead of playing on in the background.
+
+### Vanilla Radio
+
+Vanilla Radio passthrough lets listeners hear FH6's built-in radio stations through the mod instead of only custom audio sources.
+
+> ⚠️ Requires **Streamer Mode = Off**. FH6 disables radio playback in Streamer Mode, so vanilla stations cannot be captured while it is enabled.
+
+When Vanilla Radio is active, switching between FH6's built-in stations works normally and the currently selected station is forwarded through the radio system.
 
 ## Uninstall
 
@@ -107,6 +119,8 @@ Requires **CMake** and **llvm-mingw**. On Arch: `sudo pacman -S llvm-mingw cmake
 | Spotify device doesn't appear or won't play | Wait for `librespot` to finish downloading, confirm your phone/PC is on the same network, and that the account is Spotify Premium. |
 | External Audio plays in the background, not through the radio | You're capturing the same device the app plays on. Route the app's output to a **virtual audio cable** and select that cable as the **Capture device** (see [External audio](#external-audio)). |
 | External Audio has clicks / artifacts | Set the virtual cable to **48000 Hz** (2 ch). Other sample rates caused artifacts in testing. |
+| Vanilla Radio produces no audio | Vanilla Radio passthrough requires **Streamer Mode = Off**. Disable Streamer Mode and restart the game if needed. |
+| Media hotkeys don't work | Ensure another application is not intercepting media key events. Play/Pause and Next Source should work while FH6 is focused. |
 
 ## Why this exists
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -94,9 +94,17 @@ output_gain = 1.0
 
 [playback]
 race_start_playback  = "next"      # "next" | "restart" | "ignore" -- action when a race begins
-quick_station_skip   = false       # tune the radio away and back within 1s to skip the track
 volume_normalization = false       # apply ReplayGain (local files) / EBU R128 loudnorm (YT) when on
 equalizer_enabled    = false
 equalizer_bands      = [0.0, 0.0, 0.0, 0.0, 0.0]   # 60/250/1000/4000/12000 Hz, [-6, +6] dB
 force_stereo_audio   = true        # off => mono (avoids metallic phase-cancellation on the 3D radio channel)
 prebuffer_next_track = true        # pre-spawn the next track's pipeline so transitions skip the "(loading)" gap
+
+
+[hotkeys]
+kb_skip       = 0           # keyboard virtual key code to skip track (0 = unbound)
+pad_skip      = 0           # XInput controller button mask to skip track (0 = unbound)
+kb_source     = 0           # keyboard virtual key code to switch sources (0 = unbound)
+pad_source    = 0           # XInput controller button mask to switch sources (0 = unbound)
+kb_playpause  = 0           # keyboard virtual key code to play track (0 = unbound)
+pad_playpause = 0           # XInput controller button mask to play track (0 = unbound)

--- a/include/fh6/config.hpp
+++ b/include/fh6/config.hpp
@@ -71,14 +71,20 @@ struct YouTubeMusicConfig {
     bool shuffle = true;
 };
 
+struct JellyfinStation {
+    std::string name;
+    std::string playlist_id;
+    bool use_favorites = false;
+};
+
 struct JellyfinConfig {
     bool enabled = false;
     std::string server_url;
     std::string api_key;
     std::string user_id;
-    std::string default_playlist;
-    bool use_favorites = false;
-    bool shuffle       = true;
+    std::vector<JellyfinStation> stations;
+    std::string active_station;
+    bool shuffle = true;
 };
 
 struct RadioStation {

--- a/include/fh6/config.hpp
+++ b/include/fh6/config.hpp
@@ -8,9 +8,17 @@
 
 namespace fh6 {
 
+struct HotkeysConfig {
+    int kb_skip = 0;
+    int pad_skip = 0;
+    int kb_source = 0;
+    int pad_source = 0;
+    int kb_playpause = 0;
+    int pad_playpause = 0;
+};
+
 struct PlaybackConfig {
     std::string race_start_playback = "next"; // "next" | "restart" | "ignore"
-    bool quick_station_skip         = false;
     bool volume_normalization       = false;
     bool equalizer_enabled          = false;
     std::array<float, 5> equalizer_bands{}; // 60 / 250 / 1000 / 4000 / 12000 Hz, [-6, +6] dB
@@ -18,6 +26,8 @@ struct PlaybackConfig {
     // Pre-spawn the next track's pipeline so transitions (skip / end-of-track)
     // are instant.
     bool prebuffer_next_track = true;
+
+    HotkeysConfig hotkeys;
 };
 
 struct GeneralConfig {

--- a/include/fh6/fmod/dsp_control_loop.hpp
+++ b/include/fh6/fmod/dsp_control_loop.hpp
@@ -85,6 +85,10 @@ private:
     bool paused_by_race_off_  = false;
     bool first_connection_    = true;
     bool stopped_by_race_off_ = false;
+    int combo_wait_ticks_ = 0;
+    bool pending_skip_ = false;
+    bool pending_src_ = false;
+    bool pending_pp_ = false;
     time_point last_source_cmd_{};
     time_point last_playpause_cmd_{};
     time_point last_r10_off_{};

--- a/include/fh6/fmod/dsp_control_loop.hpp
+++ b/include/fh6/fmod/dsp_control_loop.hpp
@@ -75,13 +75,21 @@ private:
     mutable std::mutex playback_opts_mtx_;
     std::shared_ptr<const PlaybackConfig> playback_opts_;
 
-    bool prev_r10_          = false;
     bool prev_race_         = false;
     bool prev_race_restart_ = false;
+    bool prev_r10_          = false;
+    bool prev_skip_hotkey_ = false;
+    bool prev_source_hotkey_ = false;
+    bool prev_playpause_hotkey_ = false;
     bool quick_skip_armed_  = false;
+    time_point last_source_cmd_{};
+    time_point last_playpause_cmd_{};
     time_point last_r10_off_{};
     time_point last_race_event_{};
     time_point last_skip_cmd_{};
+    bool old_method_src_fired_ = false;
+    bool old_method_pp_fired_  = false;
+    bool old_method_skip_fired_ = false;
 
     std::jthread thread_;
 };

--- a/include/fh6/sources/jellyfin_source.hpp
+++ b/include/fh6/sources/jellyfin_source.hpp
@@ -39,6 +39,7 @@ public:
     std::string_view display_name() const noexcept override { return "Jellyfin"; }
 
     bool initialize() override;
+    bool shuffle() const { std::scoped_lock lk{mu_}; return cfg_.shuffle; }
     void shutdown() noexcept override;
 
     void play() override;
@@ -53,9 +54,28 @@ public:
     void set_config(JellyfinConfig cfg);
     void set_ffmpeg_path(std::filesystem::path p);
 
+    void set_active_station(std::string name);
+    void set_shuffle(bool shuffle);
+    std::size_t station_count() const noexcept;
+    std::string active_station_name() const;
+
+    struct QueueEntry {
+        std::size_t index;
+        std::string title;
+        std::string artist;
+        std::string album;
+    };
+    struct QueueSnapshot {
+        std::size_t cursor;
+        std::vector<QueueEntry> entries;
+    };
+
+    QueueSnapshot queue_snapshot() const;
+    bool jump_to(std::size_t index);
+
     // POST /api/source/jellyfin/cast: swap to a specific playlist id.
     // Returns false if the fetch fails (queue left untouched).
-    bool cast(std::string playlist_id);
+    bool cast(std::string playlist_id, bool use_favorites = false);
 
     void set_playback_options(const PlaybackConfig& opts) override;
 
@@ -80,11 +100,14 @@ private:
     std::size_t next_queue_idx_locked() const noexcept;
     void advance_locked(std::ptrdiff_t step);
 
+    const JellyfinStation* active_station_locked() const noexcept;
+
     JellyfinConfig cfg_;
     std::filesystem::path ffmpeg_path_;
     worker::WorkerClient* worker_;
 
     mutable std::mutex mu_;
+    std::string target_playlist_; // one-off casting
     std::vector<JellyfinTrack> queue_;
     std::size_t current_idx_ = 0;
     std::unique_ptr<Pipe> pipe_;

--- a/include/fh6/sources/jellyfin_source.hpp
+++ b/include/fh6/sources/jellyfin_source.hpp
@@ -23,6 +23,7 @@ struct JellyfinTrack {
     std::string album;
     std::string image_tag; // ImageTags.Primary; empty when the item has no cover
     std::uint64_t duration_ms = 0;
+     std::size_t original_index = 0;
 };
 
 // Resolves a Jellyfin playlist over HTTP, then streams each item through

--- a/include/fh6/sources/youtube_music_source.hpp
+++ b/include/fh6/sources/youtube_music_source.hpp
@@ -109,6 +109,7 @@ private:
         std::string url;
         std::string title;
         std::string artist;
+        std::size_t original_index = 0;
     };
     std::vector<InternalQueueEntry> queue_; // canonical watch URLs in playback order
     std::size_t queue_idx_ = 0;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -152,10 +152,32 @@ Config load_config(const std::filesystem::path& path) {
     cfg.jellyfin.server_url = pick<std::string>(jf, "server_url", cfg.jellyfin.server_url);
     cfg.jellyfin.api_key    = pick<std::string>(jf, "api_key", cfg.jellyfin.api_key);
     cfg.jellyfin.user_id    = pick<std::string>(jf, "user_id", cfg.jellyfin.user_id);
-    cfg.jellyfin.default_playlist =
-        pick<std::string>(jf, "default_playlist", cfg.jellyfin.default_playlist);
-    cfg.jellyfin.use_favorites = pick<bool>(jf, "use_favorites", cfg.jellyfin.use_favorites);
-    cfg.jellyfin.shuffle       = pick<bool>(jf, "shuffle", cfg.jellyfin.shuffle);
+    cfg.jellyfin.active_station = pick<std::string>(jf, "active_station", cfg.jellyfin.active_station);
+    cfg.jellyfin.shuffle    = pick<bool>(jf, "shuffle", cfg.jellyfin.shuffle);
+
+    try {
+        if (jf.contains("stations")) {
+            for (const auto& st : toml::find<std::vector<toml::value>>(jf, "stations")) {
+                JellyfinStation s;
+                s.name          = pick<std::string>(st, "name", "");
+                s.playlist_id   = pick<std::string>(st, "playlist_id", "");
+                s.use_favorites = pick<bool>(st, "use_favorites", false);
+                cfg.jellyfin.stations.push_back(std::move(s));
+            }
+        }
+    } catch (...) {}
+
+    // fallback migration for old configs
+    if (cfg.jellyfin.stations.empty()) {
+        auto dp = pick<std::string>(jf, "default_playlist", "");
+        auto uf = pick<bool>(jf, "use_favorites", false);
+        if (!dp.empty() || uf) {
+            cfg.jellyfin.stations.push_back({"My Playlist", dp, uf});
+        }
+    }
+    if (cfg.jellyfin.active_station.empty() && !cfg.jellyfin.stations.empty()) {
+        cfg.jellyfin.active_station = cfg.jellyfin.stations.front().name;
+    }
 
     const auto& or_sec       = section(root, "online_radio");
     cfg.online_radio.enabled = pick<bool>(or_sec, "enabled", cfg.online_radio.enabled);
@@ -385,9 +407,14 @@ void save_config(const std::filesystem::path& path, const Config& cfg) {
     e.kv("server_url", cfg.jellyfin.server_url);
     e.kv("api_key", cfg.jellyfin.api_key);
     e.kv("user_id", cfg.jellyfin.user_id);
-    e.kv("default_playlist", cfg.jellyfin.default_playlist);
-    e.kv("use_favorites", cfg.jellyfin.use_favorites);
+    e.kv("active_station", cfg.jellyfin.active_station);
     e.kv("shuffle", cfg.jellyfin.shuffle);
+    for (const auto& st : cfg.jellyfin.stations) {
+        e.array_header("jellyfin.stations");
+        e.kv("name", st.name);
+        e.kv("playlist_id", st.playlist_id);
+        e.kv("use_favorites", st.use_favorites);
+    }
 
     e.header("external_audio");
     e.kv("enabled", cfg.external_audio.enabled);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -194,6 +194,8 @@ Config load_config(const std::filesystem::path& path) {
         static_cast<float>(pick<double>(au, "output_gain", cfg.audio.output_gain));
 
     const auto& pb = section(root, "playback");
+    const bool legacy_quick_station_skip =
++        pick<bool>(pb, "quick_station_skip", false);
     {
         auto rs = pick<std::string>(pb, "race_start_playback", cfg.playback.race_start_playback);
         if (rs == "next" || rs == "restart" || rs == "ignore")
@@ -226,6 +228,15 @@ Config load_config(const std::filesystem::path& path) {
     cfg.playback.hotkeys.pad_source = pick<int>(hk, "pad_source", cfg.playback.hotkeys.pad_source);
     cfg.playback.hotkeys.kb_playpause = pick<int>(hk, "kb_playpause", cfg.playback.hotkeys.kb_playpause);
     cfg.playback.hotkeys.pad_playpause = pick<int>(hk, "pad_playpause", cfg.playback.hotkeys.pad_playpause);
+
+    const bool any_hotkey_bound =
+        cfg.playback.hotkeys.kb_skip || cfg.playback.hotkeys.pad_skip ||
+        cfg.playback.hotkeys.kb_source || cfg.playback.hotkeys.pad_source ||
+        cfg.playback.hotkeys.kb_playpause || cfg.playback.hotkeys.pad_playpause;
+    if (legacy_quick_station_skip && !any_hotkey_bound) {
+        cfg.playback.hotkeys.kb_skip = 0x9999; // legacy quick-skip sentinel
+        cfg.playback.hotkeys.pad_skip = 0x9999; // legacy quick-skip sentinel
+    }
 
     return cfg;
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -199,8 +199,6 @@ Config load_config(const std::filesystem::path& path) {
         if (rs == "next" || rs == "restart" || rs == "ignore")
             cfg.playback.race_start_playback = std::move(rs);
     }
-    cfg.playback.quick_station_skip =
-        pick<bool>(pb, "quick_station_skip", cfg.playback.quick_station_skip);
     cfg.playback.volume_normalization =
         pick<bool>(pb, "volume_normalization", cfg.playback.volume_normalization);
     cfg.playback.equalizer_enabled =
@@ -220,6 +218,14 @@ Config load_config(const std::filesystem::path& path) {
             }
         }
     } catch (...) {}
+
+    const auto& hk = section(root, "hotkeys");
+    cfg.playback.hotkeys.kb_skip = pick<int>(hk, "kb_skip", cfg.playback.hotkeys.kb_skip);
+    cfg.playback.hotkeys.pad_skip = pick<int>(hk, "pad_skip", cfg.playback.hotkeys.pad_skip);
+    cfg.playback.hotkeys.kb_source = pick<int>(hk, "kb_source", cfg.playback.hotkeys.kb_source);
+    cfg.playback.hotkeys.pad_source = pick<int>(hk, "pad_source", cfg.playback.hotkeys.pad_source);
+    cfg.playback.hotkeys.kb_playpause = pick<int>(hk, "kb_playpause", cfg.playback.hotkeys.kb_playpause);
+    cfg.playback.hotkeys.pad_playpause = pick<int>(hk, "pad_playpause", cfg.playback.hotkeys.pad_playpause);
 
     return cfg;
 }
@@ -406,12 +412,19 @@ void save_config(const std::filesystem::path& path, const Config& cfg) {
 
     e.header("playback");
     e.kv("race_start_playback", cfg.playback.race_start_playback);
-    e.kv("quick_station_skip", cfg.playback.quick_station_skip);
     e.kv("volume_normalization", cfg.playback.volume_normalization);
     e.kv("equalizer_enabled", cfg.playback.equalizer_enabled);
     e.kv_floats("equalizer_bands", std::span<const float>{cfg.playback.equalizer_bands});
     e.kv("force_stereo_audio", cfg.playback.force_stereo_audio);
     e.kv("prebuffer_next_track", cfg.playback.prebuffer_next_track);
+
+    e.header("hotkeys");
+    e.kv("kb_skip", (int64_t)cfg.playback.hotkeys.kb_skip);
+    e.kv("pad_skip", (int64_t)cfg.playback.hotkeys.pad_skip);
+    e.kv("kb_source", (int64_t)cfg.playback.hotkeys.kb_source);
+    e.kv("pad_source", (int64_t)cfg.playback.hotkeys.pad_source);
+    e.kv("kb_playpause", (int64_t)cfg.playback.hotkeys.kb_playpause);
+    e.kv("pad_playpause", (int64_t)cfg.playback.hotkeys.pad_playpause);
 
     auto tmp  = path;
     tmp      += ".tmp";

--- a/src/fmod/dsp_control_loop.cpp
+++ b/src/fmod/dsp_control_loop.cpp
@@ -7,6 +7,7 @@
 #include "fh6/log.hpp"
 
 #include <chrono>
+#include <bit>
 
 namespace fh6::fmod_bridge {
 
@@ -311,23 +312,18 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
     });
 
     XINPUT_STATE xstate{};
-    bool pad_connected = pXInputGetState && (pXInputGetState(0, &xstate) == ERROR_SUCCESS);
+    const bool has_pad_hotkeys = opts->hotkeys.pad_skip || opts->hotkeys.pad_source || opts->hotkeys.pad_playpause;
+    bool pad_connected = has_pad_hotkeys && pXInputGetState && (pXInputGetState(0, &xstate) == ERROR_SUCCESS);
 
-    // helpers to resolve overlap conflicts
-    auto count_bits = [](DWORD v) {
-        DWORD c = 0;
-        for (; v; v >>= 1) c += v & 1;
-        return c;
-    };
-
+    // helper to resolve overlap conflicts
     auto check_pad = [&](int mask) {
-        return pad_connected && mask && ((xstate.Gamepad.wButtons & mask) == mask);
+        return pad_connected && mask && (mask != 0x9999) && ((xstate.Gamepad.wButtons & mask) == mask);
     };
 
     // check keyboard (direct)
-    bool kb_skip = opts->hotkeys.kb_skip && (GetAsyncKeyState(opts->hotkeys.kb_skip) & 0x8000);
-    bool kb_src  = opts->hotkeys.kb_source && (GetAsyncKeyState(opts->hotkeys.kb_source) & 0x8000);
-    bool kb_pp   = opts->hotkeys.kb_playpause && (GetAsyncKeyState(opts->hotkeys.kb_playpause) & 0x8000);
+    bool kb_skip = opts->hotkeys.kb_skip && (opts->hotkeys.kb_skip != 0x9999) && (GetAsyncKeyState(opts->hotkeys.kb_skip) & 0x8000);
+    bool kb_src  = opts->hotkeys.kb_source && (opts->hotkeys.kb_source != 0x9999) && (GetAsyncKeyState(opts->hotkeys.kb_source) & 0x8000);
+    bool kb_pp   = opts->hotkeys.kb_playpause && (opts->hotkeys.kb_playpause != 0x9999) && (GetAsyncKeyState(opts->hotkeys.kb_playpause) & 0x8000);
 
     // check controller (resolve overlap by complexity)
     bool p_skip = check_pad(opts->hotkeys.pad_skip);
@@ -335,14 +331,14 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
     bool p_pp   = check_pad(opts->hotkeys.pad_playpause);
 
     DWORD max_bits = std::max<DWORD>({
-        p_skip ? count_bits(opts->hotkeys.pad_skip) : 0u,
-        p_src  ? count_bits(opts->hotkeys.pad_source) : 0u,
-        p_pp   ? count_bits(opts->hotkeys.pad_playpause) : 0u
+        p_skip ? static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_skip))) : 0u,
+        p_src  ? static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_source))) : 0u,
+        p_pp   ? static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_playpause))) : 0u
     });
 
-    bool pad_skip_pressed = p_skip && (count_bits(opts->hotkeys.pad_skip) == max_bits);
-    bool pad_src_pressed  = p_src && (count_bits(opts->hotkeys.pad_source) == max_bits);
-    bool pad_pp_pressed   = p_pp && (count_bits(opts->hotkeys.pad_playpause) == max_bits);
+    bool pad_skip_pressed = p_skip && (static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_skip))) == max_bits);
+    bool pad_src_pressed  = p_src && (static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_source))) == max_bits);
+    bool pad_pp_pressed   = p_pp && (static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_playpause))) == max_bits);
 
     bool skip_pressed = kb_skip || pad_skip_pressed;
     bool src_pressed  = kb_src || pad_src_pressed;
@@ -367,8 +363,10 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
     prev_r10_ = r10;
 
     // execute skip track
-    if (((!use_old_skip && skip_pressed && !prev_skip_hotkey_) || old_method_skip_fired_) && (now - last_skip_cmd_ >= kSkipCommandCooldown)) {
-        old_method_skip_fired_ = false;
+    bool trigger_skip = (skip_pressed && !prev_skip_hotkey_) || old_method_skip_fired_;
+    old_method_skip_fired_ = false;
+
+    if (trigger_skip && (now - last_skip_cmd_ >= kSkipCommandCooldown)) {
         if (active->skip_next()) {
             ring.drain();
             last_skip_cmd_ = now;
@@ -377,8 +375,10 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
     }
     
     // execute source switch
-    if (((!use_old_src && src_pressed && !prev_source_hotkey_) || old_method_src_fired_) && (now - last_source_cmd_ >= 250ms)) {
-        old_method_src_fired_ = false;
+    bool trigger_src = (src_pressed && !prev_source_hotkey_) || old_method_src_fired_;
+    old_method_src_fired_ = false;
+
+    if (trigger_src && (now - last_source_cmd_ >= 250ms)) {
         auto sources = bridge_.manager().sources_snapshot();
         if (!sources.empty()) {
             std::size_t next_idx = 0;
@@ -393,8 +393,10 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
     }
 
     // execute play/pause toggle
-    if (((!use_old_pp && pp_pressed && !prev_playpause_hotkey_) || old_method_pp_fired_) && (now - last_playpause_cmd_ >= 250ms)) {
-        old_method_pp_fired_ = false;
+    bool trigger_pp = (pp_pressed && !prev_playpause_hotkey_) || old_method_pp_fired_;
+    old_method_pp_fired_ = false;
+
+    if (trigger_pp && (now - last_playpause_cmd_ >= 250ms)) {
         auto state = active->playback_state();
         if (state == PlaybackState::playing || state == PlaybackState::buffering) {
             active->pause();

--- a/src/fmod/dsp_control_loop.cpp
+++ b/src/fmod/dsp_control_loop.cpp
@@ -1,3 +1,5 @@
+#include <windows.h>
+#include <xinput.h>
 #include "fh6/fmod/dsp_control_loop.hpp"
 #include "fh6/fmod/radio_discovery.hpp"
 #include "fh6/audio_source.hpp"
@@ -254,7 +256,7 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
     auto* active = bridge_.manager().active();
     if (!active) {
         prev_r10_ = prev_race_ = prev_race_restart_ = false;
-        quick_skip_armed_                           = false;
+        quick_skip_armed_ = false;
         return;
     }
 
@@ -293,22 +295,119 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
     prev_race_         = game.race_active;
     prev_race_restart_ = game.race_restart;
 
+    // --- Hotkeys ---
+    // dynamically load XInput
+    typedef DWORD(WINAPI* XInputGetState_t)(DWORD, XINPUT_STATE*);
+    static XInputGetState_t pXInputGetState = nullptr;
+    static bool xinput_tried = false;
+
+    if (!xinput_tried) {
+        HMODULE hXInput = LoadLibraryW(L"xinput1_4.dll");
+        if (!hXInput) hXInput = LoadLibraryW(L"xinput9_1_0.dll");
+        if (!hXInput) hXInput = LoadLibraryW(L"xinput1_3.dll");
+        if (hXInput) pXInputGetState = (XInputGetState_t)GetProcAddress(hXInput, "XInputGetState");
+        xinput_tried = true;
+    }
+
+    XINPUT_STATE xstate{};
+    bool pad_connected = pXInputGetState && (pXInputGetState(0, &xstate) == ERROR_SUCCESS);
+
+    // helpers to resolve overlap conflicts
+    auto count_bits = [](DWORD v) {
+        DWORD c = 0;
+        for (; v; v >>= 1) c += v & 1;
+        return c;
+    };
+
+    auto check_pad = [&](int mask) {
+        return pad_connected && mask && ((xstate.Gamepad.wButtons & mask) == mask);
+    };
+
+    // check keyboard (direct)
+    bool kb_skip = opts->hotkeys.kb_skip && (GetAsyncKeyState(opts->hotkeys.kb_skip) & 0x8000);
+    bool kb_src  = opts->hotkeys.kb_source && (GetAsyncKeyState(opts->hotkeys.kb_source) & 0x8000);
+    bool kb_pp   = opts->hotkeys.kb_playpause && (GetAsyncKeyState(opts->hotkeys.kb_playpause) & 0x8000);
+
+    // check controller (resolve overlap by complexity)
+    bool p_skip = check_pad(opts->hotkeys.pad_skip);
+    bool p_src  = check_pad(opts->hotkeys.pad_source);
+    bool p_pp   = check_pad(opts->hotkeys.pad_playpause);
+
+    DWORD max_bits = std::max<DWORD>({
+        p_skip ? count_bits(opts->hotkeys.pad_skip) : 0u,
+        p_src  ? count_bits(opts->hotkeys.pad_source) : 0u,
+        p_pp   ? count_bits(opts->hotkeys.pad_playpause) : 0u
+    });
+
+    bool pad_skip_pressed = p_skip && (count_bits(opts->hotkeys.pad_skip) == max_bits);
+    bool pad_src_pressed  = p_src && (count_bits(opts->hotkeys.pad_source) == max_bits);
+    bool pad_pp_pressed   = p_pp && (count_bits(opts->hotkeys.pad_playpause) == max_bits);
+
+    bool skip_pressed = kb_skip || pad_skip_pressed;
+    bool src_pressed  = kb_src || pad_src_pressed;
+    bool pp_pressed   = kb_pp || pad_pp_pressed;
+
     // --- quickStationSkip (R10 edge) ---
+    const bool use_old_skip = (opts->hotkeys.kb_skip      == 0x9999 || opts->hotkeys.pad_skip      == 0x9999);
+    const bool use_old_src  = (opts->hotkeys.kb_source    == 0x9999 || opts->hotkeys.pad_source    == 0x9999);
+    const bool use_old_pp   = (opts->hotkeys.kb_playpause == 0x9999 || opts->hotkeys.pad_playpause == 0x9999);
+
     if (prev_r10_ && !r10) {
         last_r10_off_ = now;
-        if (opts->quick_station_skip) quick_skip_armed_ = true;
+        if (use_old_skip || use_old_src || use_old_pp) quick_skip_armed_ = true;
     } else if (!prev_r10_ && r10) {
-        if (quick_skip_armed_ && now - last_r10_off_ <= kQuickSkipWindow &&
-            now - last_skip_cmd_ >= kSkipCommandCooldown) {
-            if (active->skip_next()) {
-                ring.drain();
-                last_skip_cmd_ = now;
-                log::info("[ctrl] quick station return -- advanced to next track");
-            }
+        if (quick_skip_armed_ && now - last_r10_off_ <= kQuickSkipWindow) {
+            if (use_old_skip) old_method_skip_fired_ = true;
+            if (use_old_src)  old_method_src_fired_  = true;
+            if (use_old_pp)   old_method_pp_fired_   = true;
         }
         quick_skip_armed_ = false;
     }
     prev_r10_ = r10;
+
+    // execute skip track
+    if (((!use_old_skip && skip_pressed && !prev_skip_hotkey_) || old_method_skip_fired_) && (now - last_skip_cmd_ >= kSkipCommandCooldown)) {
+        old_method_skip_fired_ = false;
+        if (active->skip_next()) {
+            ring.drain();
+            last_skip_cmd_ = now;
+            log::info("[ctrl] Hotkey triggered: advanced to next track");
+        }
+    }
+    
+    // execute source switch
+    if (((!use_old_src && src_pressed && !prev_source_hotkey_) || old_method_src_fired_) && (now - last_source_cmd_ >= 250ms)) {
+        old_method_src_fired_ = false;
+        auto sources = bridge_.manager().sources_snapshot();
+        if (!sources.empty()) {
+            std::size_t next_idx = 0;
+            for (std::size_t i = 0; i < sources.size(); ++i) {
+                if (sources[i] == active) { next_idx = (i + 1) % sources.size(); break; }
+            }
+            bridge_.manager().switch_to(sources[next_idx]->name());
+            ring.drain();
+            last_source_cmd_ = now;
+            log::info("[ctrl] Hotkey triggered: switched source to {}", sources[next_idx]->name());
+        }
+    }
+
+    // execute play/pause toggle
+    if (((!use_old_pp && pp_pressed && !prev_playpause_hotkey_) || old_method_pp_fired_) && (now - last_playpause_cmd_ >= 250ms)) {
+        old_method_pp_fired_ = false;
+        auto state = active->playback_state();
+        if (state == PlaybackState::playing || state == PlaybackState::buffering) {
+            active->pause();
+            log::info("[ctrl] Hotkey triggered: paused playback");
+        } else {
+            active->play();
+            log::info("[ctrl] Hotkey triggered: resumed playback");
+        }
+        last_playpause_cmd_ = now;
+    }
+
+    prev_skip_hotkey_ = skip_pressed;
+    prev_source_hotkey_ = src_pressed;
+    prev_playpause_hotkey_ = pp_pressed;
 }
 
 void ControlLoop::push_metadata() noexcept {

--- a/src/fmod/dsp_control_loop.cpp
+++ b/src/fmod/dsp_control_loop.cpp
@@ -391,10 +391,51 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
     }
     prev_r10_ = r10;
 
-    // execute skip track
-    bool trigger_skip = (skip_pressed && !prev_skip_hotkey_) || old_method_skip_fired_;
-    old_method_skip_fired_ = false;
+    // check for rising edges (button just pressed)
+    bool skip_edge = skip_pressed && !prev_skip_hotkey_;
+    bool src_edge  = src_pressed && !prev_source_hotkey_;
+    bool pp_edge   = pp_pressed && !prev_playpause_hotkey_;
 
+    // buffer
+    if (skip_edge) pending_skip_ = true;
+    if (src_edge)  pending_src_ = true;
+    if (pp_edge)   pending_pp_ = true;
+
+    bool trigger_skip = old_method_skip_fired_;
+    bool trigger_src  = old_method_src_fired_;
+    bool trigger_pp   = old_method_pp_fired_;
+    old_method_skip_fired_ = false;
+    old_method_src_fired_  = false;
+    old_method_pp_fired_   = false;
+
+    // track how long buttons have been held to allow combos to form
+    if (skip_pressed || src_pressed || pp_pressed) {
+        if (combo_wait_ticks_ >= 0) {
+            combo_wait_ticks_++;
+        }
+    } else {
+        combo_wait_ticks_ = 0;
+        pending_skip_ = pending_src_ = pending_pp_ = false;
+    }
+
+    // trigger combos immediately, delay single buttons by 3 ticks (~60ms) to prevent overlap
+    if (combo_wait_ticks_ == 3 || (max_bits > 1 && combo_wait_ticks_ > 0)) {
+        if (pending_pp_ && max_bits == static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_playpause)))) {
+            trigger_pp = true;
+        } else if (pending_src_ && max_bits == static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_source)))) {
+            trigger_src = true;
+        } else if (pending_skip_ && max_bits == static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_skip)))) {
+            trigger_skip = true;
+        }
+
+        // clear pending states
+        pending_skip_ = pending_src_ = pending_pp_ = false;
+        
+        // set to a negative number to prevent firing again until buttons are released
+        combo_wait_ticks_ = -9999; 
+    }
+
+    // execute skip track
     if (trigger_skip && (now - last_skip_cmd_ >= kSkipCommandCooldown)) {
         if (active->skip_next()) {
             ring.drain();
@@ -404,9 +445,6 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
     }
     
     // execute source switch
-    bool trigger_src = (src_pressed && !prev_source_hotkey_) || old_method_src_fired_;
-    old_method_src_fired_ = false;
-
     if (trigger_src && (now - last_source_cmd_ >= 250ms)) {
         auto sources = bridge_.manager().sources_snapshot();
         if (!sources.empty()) {
@@ -422,9 +460,6 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
     }
 
     // execute play/pause toggle
-    bool trigger_pp = (pp_pressed && !prev_playpause_hotkey_) || old_method_pp_fired_;
-    old_method_pp_fired_ = false;
-
     if (trigger_pp && (now - last_playpause_cmd_ >= 250ms)) {
         auto state = active->playback_state();
         if (state == PlaybackState::playing || state == PlaybackState::buffering) {

--- a/src/fmod/dsp_control_loop.cpp
+++ b/src/fmod/dsp_control_loop.cpp
@@ -299,15 +299,16 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
     // dynamically load XInput
     typedef DWORD(WINAPI* XInputGetState_t)(DWORD, XINPUT_STATE*);
     static XInputGetState_t pXInputGetState = nullptr;
-    static bool xinput_tried = false;
-
-    if (!xinput_tried) {
+    static std::once_flag xinput_once;
+    std::call_once(xinput_once, [] {
         HMODULE hXInput = LoadLibraryW(L"xinput1_4.dll");
         if (!hXInput) hXInput = LoadLibraryW(L"xinput9_1_0.dll");
         if (!hXInput) hXInput = LoadLibraryW(L"xinput1_3.dll");
-        if (hXInput) pXInputGetState = (XInputGetState_t)GetProcAddress(hXInput, "XInputGetState");
-        xinput_tried = true;
-    }
+        if (hXInput) {
+            pXInputGetState =
+                reinterpret_cast<XInputGetState_t>(GetProcAddress(hXInput, "XInputGetState"));
+        }
+    });
 
     XINPUT_STATE xstate{};
     bool pad_connected = pXInputGetState && (pXInputGetState(0, &xstate) == ERROR_SUCCESS);

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -240,12 +240,20 @@ json config_to_json(const Config& c) {
         {"playback",
          json{
              {"race_start_playback", c.playback.race_start_playback},
-             {"quick_station_skip", c.playback.quick_station_skip},
              {"volume_normalization", c.playback.volume_normalization},
              {"equalizer_enabled", c.playback.equalizer_enabled},
              {"equalizer_bands", c.playback.equalizer_bands},
              {"force_stereo_audio", c.playback.force_stereo_audio},
              {"prebuffer_next_track", c.playback.prebuffer_next_track},
+         }},
+        {"hotkeys",
+         json{
+             {"kb_skip", c.playback.hotkeys.kb_skip},
+             {"pad_skip", c.playback.hotkeys.pad_skip},
+             {"kb_source", c.playback.hotkeys.kb_source},
+             {"pad_source", c.playback.hotkeys.pad_source},
+             {"kb_playpause", c.playback.hotkeys.kb_playpause},
+             {"pad_playpause", c.playback.hotkeys.pad_playpause},
          }},
     };
 }
@@ -377,15 +385,14 @@ void apply_patch(Config& c, const json& j) {
         auto rs = pull<std::string>(*it, "race_start_playback", c.playback.race_start_playback);
         if (rs == "next" || rs == "restart" || rs == "ignore")
             c.playback.race_start_playback = std::move(rs);
-        c.playback.quick_station_skip =
-            pull(*it, "quick_station_skip", c.playback.quick_station_skip);
         c.playback.volume_normalization =
             pull(*it, "volume_normalization", c.playback.volume_normalization);
         c.playback.force_stereo_audio =
             pull(*it, "force_stereo_audio", c.playback.force_stereo_audio);
         c.playback.prebuffer_next_track =
             pull(*it, "prebuffer_next_track", c.playback.prebuffer_next_track);
-        c.playback.equalizer_enabled = pull(*it, "equalizer_enabled", c.playback.equalizer_enabled);
+        c.playback.equalizer_enabled = 
+            pull(*it, "equalizer_enabled", c.playback.equalizer_enabled);
         if (auto bands = it->find("equalizer_bands"); bands != it->end() && bands->is_array()) {
             for (std::size_t i = 0; i < c.playback.equalizer_bands.size() && i < bands->size();
                  ++i) {
@@ -395,6 +402,20 @@ void apply_patch(Config& c, const json& j) {
                 c.playback.equalizer_bands[i] = b;
             }
         }
+    }
+    if (auto it = j.find("hotkeys"); it != j.end()) {
+        c.playback.hotkeys.kb_skip = 
+            pull(*it, "kb_skip", c.playback.hotkeys.kb_skip);
+        c.playback.hotkeys.pad_skip = 
+            pull(*it, "pad_skip", c.playback.hotkeys.pad_skip);
+        c.playback.hotkeys.kb_source = 
+            pull(*it, "kb_source", c.playback.hotkeys.kb_source);
+        c.playback.hotkeys.pad_source = 
+            pull(*it, "pad_source", c.playback.hotkeys.pad_source);
+        c.playback.hotkeys.kb_playpause = 
+            pull(*it, "kb_playpause", c.playback.hotkeys.kb_playpause);
+        c.playback.hotkeys.pad_playpause = 
+            pull(*it, "pad_playpause", c.playback.hotkeys.pad_playpause);
     }
 }
 

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -115,6 +115,15 @@ json source_to_json(IAudioSource* s) {
         j["details"]["queue_size"] = snap.entries.size();
         j["details"]["queue_cursor"] = snap.cursor;
     }
+    if (auto* jf = dynamic_cast<sources::JellyfinSource*>(s)) {
+        j["details"]["shuffle"] = jf->shuffle();
+        j["details"]["station_count"] = jf->station_count();
+        j["details"]["active_station"] = jf->active_station_name();
+
+        auto snap = jf->queue_snapshot();
+        j["details"]["queue_size"] = snap.entries.size();
+        j["details"]["queue_cursor"] = snap.cursor;
+    }
     if (auto* rd = dynamic_cast<sources::OnlineRadioSource*>(s))
         j["details"]["song_history"] = rd->song_history();
     return j;
@@ -161,6 +170,28 @@ YouTubeStation yt_station_from_json(const json& j) {
     };
 }
 
+json jf_station_to_json(const JellyfinStation& s) {
+    return json{
+        {"name", s.name},
+        {"playlist_id", s.playlist_id},
+        {"use_favorites", s.use_favorites}
+    };
+}
+
+json jf_stations_to_json(const std::vector<JellyfinStation>& v) {
+    json a = json::array();
+    for (const auto& s : v) a.push_back(jf_station_to_json(s));
+    return a;
+}
+
+JellyfinStation jf_station_from_json(const json& j) {
+    return JellyfinStation{
+        j.value("name", ""),
+        j.value("playlist_id", ""),
+        j.value("use_favorites", false)
+    };
+}
+
 json config_to_json(const Config& c) {
     return json{
         {"general",
@@ -193,8 +224,8 @@ json config_to_json(const Config& c) {
              {"server_url", c.jellyfin.server_url},
              {"api_key", c.jellyfin.api_key},
              {"user_id", c.jellyfin.user_id},
-             {"default_playlist", c.jellyfin.default_playlist},
-             {"use_favorites", c.jellyfin.use_favorites},
+             {"active_station", c.jellyfin.active_station},
+             {"stations", jf_stations_to_json(c.jellyfin.stations)},
              {"shuffle", c.jellyfin.shuffle},
          }},
         {"external_audio",
@@ -334,9 +365,13 @@ void apply_patch(Config& c, const json& j) {
         c.jellyfin.server_url       = pull(*it, "server_url", c.jellyfin.server_url);
         c.jellyfin.api_key          = pull(*it, "api_key", c.jellyfin.api_key);
         c.jellyfin.user_id          = pull(*it, "user_id", c.jellyfin.user_id);
-        c.jellyfin.default_playlist = pull(*it, "default_playlist", c.jellyfin.default_playlist);
-        c.jellyfin.use_favorites    = pull(*it, "use_favorites", c.jellyfin.use_favorites);
+        c.jellyfin.active_station   = pull(*it, "active_station", c.jellyfin.active_station);
         c.jellyfin.shuffle          = pull(*it, "shuffle", c.jellyfin.shuffle);
+        if (auto sts = it->find("stations"); sts != it->end() && sts->is_array()) {
+            std::vector<JellyfinStation> parsed;
+            for (const auto& st : *sts) parsed.push_back(jf_station_from_json(st));
+            c.jellyfin.stations = std::move(parsed);
+        }
     }
     if (auto it = j.find("external_audio"); it != j.end()) {
         c.external_audio.enabled     = pull(*it, "enabled", c.external_audio.enabled);
@@ -932,10 +967,75 @@ struct HttpServer::Impl {
         if (m == "POST" && p == "/api/source/jellyfin/cast") {
             auto* jf = find_typed<sources::JellyfinSource>("jellyfin");
             if (!jf) return fail(404, "jellyfin not registered");
-            auto playlist_id = json::parse(req.body).value("playlist_id", std::string{});
-            if (playlist_id.empty()) return fail(400, "playlist_id required");
+            auto body = json::parse(req.body);
+            auto playlist_id = body.value("playlist_id", std::string{});
+            auto use_favorites = body.value("use_favorites", false);
+            if (playlist_id.empty() && !use_favorites) return fail(400, "playlist_id or use_favorites required");
             const bool was_active = (mgr.active() == jf);
-            if (!jf->cast(std::move(playlist_id))) return fail(502, "jellyfin fetch failed");
+            if (!jf->cast(std::move(playlist_id), use_favorites)) return fail(502, "jellyfin fetch failed");
+            if (was_active) mgr.ring().drain();
+            mgr.switch_to("jellyfin");
+            return ok();
+        }
+        if (m == "POST" && p == "/api/source/jellyfin/shuffle") {
+            auto* jf = find_typed<sources::JellyfinSource>("jellyfin");
+            if (!jf) return fail(404, "jellyfin not registered");
+            auto shuffle = json::parse(req.body).at("shuffle").get<bool>();
+            jf->set_shuffle(shuffle);
+            store.patch([shuffle](Config& c) { c.jellyfin.shuffle = shuffle; });
+            return ok();
+        }
+        if (m == "GET" && p == "/api/source/jellyfin/stations") {
+            auto snap = store.snapshot();
+            return ok(json{
+                {"stations", jf_stations_to_json(snap.jellyfin.stations)},
+                {"active_station", snap.jellyfin.active_station}
+            });
+        }
+        if (m == "PUT" && p == "/api/source/jellyfin/stations") {
+            auto j = json::parse(req.body);
+            store.patch([&](Config& c) {
+                if (auto sts = j.find("stations"); sts != j.end() && sts->is_array()) {
+                    std::vector<JellyfinStation> parsed;
+                    for (const auto& st : *sts) parsed.push_back(jf_station_from_json(st));
+                    c.jellyfin.stations = std::move(parsed);
+                }
+                if (auto a = j.find("active_station"); a != j.end() && a->is_string())
+                    c.jellyfin.active_station = a->get<std::string>();
+            });
+            if (auto* jf = find_typed<sources::JellyfinSource>("jellyfin"))
+                jf->set_config(store.snapshot().jellyfin);
+            return ok();
+        }
+        if (m == "POST" && p == "/api/source/jellyfin/activate") {
+            auto* jf = find_typed<sources::JellyfinSource>("jellyfin");
+            if (!jf) return fail(404, "jellyfin not registered");
+            auto name = json::parse(req.body).value("name", std::string{});
+            const bool was_active = (mgr.active() == jf);
+            store.patch([&](Config& c) { c.jellyfin.active_station = name; });
+            jf->set_active_station(name);
+            if (was_active) mgr.ring().drain();
+            jf->play();
+            mgr.switch_to("jellyfin");
+            return ok();
+        }
+        if (m == "GET" && p == "/api/source/jellyfin/queue") {
+            auto* jf = find_typed<sources::JellyfinSource>("jellyfin");
+            if (!jf) return fail(404, "jellyfin not registered");
+            auto snap = jf->queue_snapshot();
+            json tracks = json::array();
+            for (const auto& e : snap.entries) {
+                tracks.push_back(
+                    json{{"index", e.index}, {"title", e.title}, {"artist", e.artist}, {"album", e.album}});
+            }
+            return ok(json{{"cursor", snap.cursor}, {"tracks", tracks}});
+        }
+        if (m == "POST" && p == "/api/source/jellyfin/play" && !req.body.empty()) {
+            auto* jf = find_typed<sources::JellyfinSource>("jellyfin");
+            if (!jf) return fail(404, "jellyfin not registered");
+            auto idx = json::parse(req.body).at("index").get<std::size_t>();
+            const bool was_active = (mgr.active() == jf);
+            if (!jf->jump_to(idx)) return fail(400, "index out of range");
             if (was_active) mgr.ring().drain();
             mgr.switch_to("jellyfin");
             return ok();

--- a/src/sources/jellyfin_source.cpp
+++ b/src/sources/jellyfin_source.cpp
@@ -62,6 +62,10 @@ std::optional<std::string> http_get(const JellyfinConfig& cfg, const std::string
 }
 
 std::optional<std::vector<JellyfinTrack>> fetch_tracks(const JellyfinConfig& cfg, const std::string& target_id, bool use_favs) {
+    if (!use_favs && target_id.empty()) {
+        log::warn("[jellyfin] playlist_id required when use_favorites=false");
+        return std::nullopt;
+    }
     std::string path;
     if (use_favs) {
         path = std::format("/Users/{}/Items?Filters=IsFavorite&IncludeItemTypes=Audio&Recursive=true", cfg.user_id);
@@ -397,8 +401,10 @@ void JellyfinSource::set_config(JellyfinConfig cfg) {
     } else if (shuffle_flip) {
         if (cfg_.shuffle) {
             shuffle_range(queue_, current_idx_ + 1); // preserve the currently-playing track
-        } else {
-            auto start = queue_.begin() + static_cast<std::ptrdiff_t>(current_idx_ + 1);
+        } else if (!queue_.empty()) {
+            const std::size_t from =
+                (current_idx_ >= queue_.size()) ? queue_.size() : (current_idx_ + 1);
+            auto start = queue_.begin() + static_cast<std::ptrdiff_t>(from);
             if (start < queue_.end()) {
                 std::sort(start, queue_.end(), [](const auto& a, const auto& b) {
                     return a.original_index < b.original_index;

--- a/src/sources/jellyfin_source.cpp
+++ b/src/sources/jellyfin_source.cpp
@@ -80,6 +80,7 @@ std::optional<std::vector<JellyfinTrack>> fetch_tracks(const JellyfinConfig& cfg
             return std::nullopt;
         }
         out.reserve(items->size());
+        std::size_t og_idx = 0;
         for (const auto& item : *items) {
             JellyfinTrack t;
             t.id = item.value("Id", "");
@@ -97,6 +98,7 @@ std::optional<std::vector<JellyfinTrack>> fetch_tracks(const JellyfinConfig& cfg
                 t.image_tag = it->value("Primary", "");
             if (auto r = item.find("RunTimeTicks"); r != item.end() && r->is_number_unsigned())
                 t.duration_ms = r->get<std::uint64_t>() / 10'000u; // 10000 ticks = 1 ms
+            t.original_index = og_idx++;
             out.push_back(std::move(t));
         }
     } catch (const std::exception& e) {
@@ -392,9 +394,18 @@ void JellyfinSource::set_config(JellyfinConfig cfg) {
             start_pipe_locked();
             if (pipe_) state_.store(PlaybackState::playing, std::memory_order_release);
         }
-    } else if (shuffle_flip && cfg_.shuffle) {
-        shuffle_range(queue_, current_idx_ + 1); // preserve the currently-playing track
-        discard_prefetch_locked();               // next-idx URL just changed
+    } else if (shuffle_flip) {
+        if (cfg_.shuffle) {
+            shuffle_range(queue_, current_idx_ + 1); // preserve the currently-playing track
+        } else {
+            auto start = queue_.begin() + static_cast<std::ptrdiff_t>(current_idx_ + 1);
+            if (start < queue_.end()) {
+                std::sort(start, queue_.end(), [](const auto& a, const auto& b) {
+                    return a.original_index < b.original_index;
+                });
+            }
+        }
+        discard_prefetch_locked(); // next-idx URL just changed
     }
 }
 
@@ -582,7 +593,9 @@ void JellyfinSource::set_shuffle(bool shuffle) {
     } else if (!shuffle && queue_.size() > 1) {
         auto start = queue_.begin() + static_cast<std::ptrdiff_t>(current_idx_ + 1);
         if (start < queue_.end()) {
-            std::sort(start, queue_.end(), [](const auto& a, const auto& b) { return a.id < b.id; });
+            std::sort(start, queue_.end(), [](const auto& a, const auto& b) { 
+                return a.original_index < b.original_index;
+            });
         }
     }
 }

--- a/src/sources/jellyfin_source.cpp
+++ b/src/sources/jellyfin_source.cpp
@@ -34,18 +34,20 @@ constexpr std::uint64_t kPcmBytesPerSec = 48000ull * 2ull * 2ull;
 
 bool config_complete(const JellyfinConfig& c) noexcept {
     return !c.server_url.empty() && !c.api_key.empty() && !c.user_id.empty() &&
-           (!c.default_playlist.empty() || c.use_favorites);
+           (!c.stations.empty());
 }
 
 // Fields that determine which playlist gets fetched. `shuffle` deliberately
 // omitted -- it doesn't require a re-query.
 bool same_query_target(const JellyfinConfig& a, const JellyfinConfig& b) noexcept {
-    if (a.server_url != b.server_url || a.api_key != b.api_key || a.user_id != b.user_id ||
-        a.use_favorites != b.use_favorites)
+    if (a.server_url != b.server_url || a.api_key != b.api_key || a.user_id != b.user_id)
         return false;
-    // default_playlist is irrelevant when both sides fetch favorites.
-    if (a.use_favorites && b.use_favorites) return true;
-    return a.default_playlist == b.default_playlist;
+    auto get_target = [](const JellyfinConfig& c) {
+        for (const auto& s : c.stations) if (s.name == c.active_station) return s;
+        return c.stations.empty() ? JellyfinStation{} : c.stations.front();
+    };
+    auto ta = get_target(a), tb = get_target(b);
+    return ta.playlist_id == tb.playlist_id && ta.use_favorites == tb.use_favorites;
 }
 
 std::optional<std::string> http_get(const JellyfinConfig& cfg, const std::string& path) {
@@ -59,15 +61,12 @@ std::optional<std::string> http_get(const JellyfinConfig& cfg, const std::string
     return net::http_get(cfg.server_url + path, auth);
 }
 
-std::optional<std::vector<JellyfinTrack>> fetch_tracks(const JellyfinConfig& cfg) {
+std::optional<std::vector<JellyfinTrack>> fetch_tracks(const JellyfinConfig& cfg, const std::string& target_id, bool use_favs) {
     std::string path;
-    if (cfg.use_favorites) {
-        path =
-            std::format("/Users/{}/Items?Filters=IsFavorite&IncludeItemTypes=Audio&Recursive=true",
-                        cfg.user_id);
+    if (use_favs) {
+        path = std::format("/Users/{}/Items?Filters=IsFavorite&IncludeItemTypes=Audio&Recursive=true", cfg.user_id);
     } else {
-        path = std::format("/Users/{}/Items?ParentId={}&Filters=IsNotFolder", cfg.user_id,
-                           cfg.default_playlist);
+        path = std::format("/Users/{}/Items?ParentId={}&Filters=IsNotFolder", cfg.user_id, target_id);
     }
     auto body = http_get(cfg, path);
     if (!body) return std::nullopt;
@@ -161,9 +160,16 @@ bool JellyfinSource::initialize() {
     if (!cfg_.enabled) return false;
     if (!config_complete(cfg_)) return true; // tile visible; user can fill fields later
 
+    std::string target_id;
+    bool target_fav = false;
+    if (auto* st = active_station_locked()) {
+        target_id = st->playlist_id;
+        target_fav = st->use_favorites;
+    }
+
     // Construction precedes registration -- no other thread holds a reference
     // yet, so the fetch can run without locking.
-    if (auto tracks = fetch_tracks(cfg_)) {
+    if (auto tracks = fetch_tracks(cfg_, target_id, target_fav)) {
         queue_ = std::move(*tracks);
         if (cfg_.shuffle) shuffle_range(queue_, 0);
     }
@@ -315,9 +321,7 @@ void JellyfinSource::previous() {
     advance_locked(-1);
 }
 
-bool JellyfinSource::cast(std::string playlist_id) {
-    if (playlist_id.empty()) return false;
-
+bool JellyfinSource::cast(std::string playlist_id, bool use_favorites) {
     // Build the fetch config from a fresh cfg_ snapshot + the cast target,
     // then run the HTTP call with no class locks held.
     JellyfinConfig snap;
@@ -325,23 +329,22 @@ bool JellyfinSource::cast(std::string playlist_id) {
         std::scoped_lock lk{mu_};
         snap = cfg_;
     }
-    snap.default_playlist = playlist_id;
-    snap.use_favorites    = false; // cast targets a specific playlist
-    if (!config_complete(snap)) return false;
+    // for casting, only need to ensure the auth fields are filled out
+    if (snap.server_url.empty() || snap.api_key.empty() || snap.user_id.empty()) return false;
 
     std::optional<std::vector<JellyfinTrack>> tracks;
     {
         std::scoped_lock fetch_lk{fetch_serializer()};
-        tracks = fetch_tracks(snap);
+        tracks = fetch_tracks(snap, playlist_id, use_favorites);
     }
     if (!tracks) return false;
 
     std::scoped_lock lk{mu_};
-    cfg_.default_playlist = std::move(playlist_id);
-    queue_                = std::move(*tracks);
-    current_idx_          = 0;
+    target_playlist_ = use_favorites ? "FAVORITES" : playlist_id;
+    queue_ = std::move(*tracks);
+    current_idx_ = 0;
     if (cfg_.shuffle) shuffle_range(queue_, 0);
-    discard_prefetch_locked(); // stale: targets the old playlist
+    discard_prefetch_locked();  // stale: targets the old playlist
     start_pipe_locked();
     if (pipe_) state_.store(PlaybackState::playing, std::memory_order_release);
     return true;
@@ -351,26 +354,38 @@ void JellyfinSource::set_config(JellyfinConfig cfg) {
     // Decide what's actually changing under a brief lock; do the HTTP fetch
     // with no class lock held; then commit under the lock again.
     bool requery, shuffle_flip;
+    std::string target_id;
+    bool target_fav = false;
     {
         std::scoped_lock lk{mu_};
-        requery      = !same_query_target(cfg_, cfg) && config_complete(cfg);
+        requery = !same_query_target(cfg_, cfg) && config_complete(cfg);
         shuffle_flip = cfg_.shuffle != cfg.shuffle;
+        if (requery) {
+            target_playlist_.clear();
+            auto get_target = [](const JellyfinConfig& c) {
+                for (const auto& s : c.stations) if (s.name == c.active_station) return s;
+                return c.stations.empty() ? JellyfinStation{} : c.stations.front();
+            };
+            auto t = get_target(cfg);
+            target_id = t.playlist_id;
+            target_fav = t.use_favorites;
+        }
     }
 
     std::optional<std::vector<JellyfinTrack>> tracks;
     if (requery) {
         std::scoped_lock fetch_lk{fetch_serializer()};
-        tracks = fetch_tracks(cfg);
+        tracks = fetch_tracks(cfg, target_id, target_fav);
     }
 
     std::scoped_lock lk{mu_};
     const bool was_playing = state_.load(std::memory_order_acquire) == PlaybackState::playing;
-    cfg_                   = std::move(cfg);
+    cfg_ = std::move(cfg);
 
     if (tracks) {
         discard_prefetch_locked();
         stop_pipe_locked();
-        queue_       = std::move(*tracks);
+        queue_ = std::move(*tracks);
         current_idx_ = 0;
         if (cfg_.shuffle) shuffle_range(queue_, 0);
         if (was_playing) {
@@ -480,6 +495,96 @@ void JellyfinSource::pump(RingBuffer& ring) {
     }
     update_position();
     maybe_spawn_prefetch_locked();
+}
+
+const JellyfinStation* JellyfinSource::active_station_locked() const noexcept {
+    if (cfg_.stations.empty()) return nullptr;
+    for (const auto& s : cfg_.stations)
+        if (s.name == cfg_.active_station) return &s;
+    return &cfg_.stations.front();
+}
+
+void JellyfinSource::set_active_station(std::string name) {
+    JellyfinConfig snap;
+    std::string target_id;
+    bool target_fav = false;
+    {
+        std::scoped_lock lk{mu_};
+        if (cfg_.active_station == name && target_playlist_.empty()) return;
+        cfg_.active_station = std::move(name);
+        target_playlist_.clear();
+        snap = cfg_;
+        auto* st = active_station_locked();
+        if (st) {
+            target_id = st->playlist_id;
+            target_fav = st->use_favorites;
+        }
+    }
+
+    std::optional<std::vector<JellyfinTrack>> tracks;
+    {
+        std::scoped_lock fetch_lk{fetch_serializer()};
+        tracks = fetch_tracks(snap, target_id, target_fav);
+    }
+
+    std::scoped_lock lk{mu_};
+    discard_prefetch_locked();
+    stop_pipe_locked();
+    if (tracks) {
+        queue_ = std::move(*tracks);
+        current_idx_ = 0;
+        if (cfg_.shuffle) shuffle_range(queue_, 0);
+    } else {
+        queue_.clear();
+        current_idx_ = 0;
+    }
+}
+
+std::size_t JellyfinSource::station_count() const noexcept {
+    std::scoped_lock lk{mu_};
+    return cfg_.stations.size();
+}
+
+std::string JellyfinSource::active_station_name() const {
+    std::scoped_lock lk{mu_};
+    const JellyfinStation* st = active_station_locked();
+    return st ? st->name : std::string{};
+}
+
+JellyfinSource::QueueSnapshot JellyfinSource::queue_snapshot() const {
+    std::scoped_lock lk{mu_};
+    QueueSnapshot snap;
+    snap.cursor = current_idx_;
+    snap.entries.reserve(queue_.size());
+    for (std::size_t i = 0; i < queue_.size(); ++i) {
+        snap.entries.push_back({i, queue_[i].title, queue_[i].artist, queue_[i].album});
+    }
+    return snap;
+}
+
+bool JellyfinSource::jump_to(std::size_t index) {
+    std::scoped_lock lk{mu_};
+    if (index >= queue_.size()) return false;
+    current_idx_ = index;
+    if (!promote_prefetch_locked(current_idx_)) {
+        start_pipe_locked();
+    }
+    if (pipe_) state_.store(PlaybackState::playing, std::memory_order_release);
+    return true;
+}
+
+void JellyfinSource::set_shuffle(bool shuffle) {
+    std::scoped_lock lk{mu_};
+    cfg_.shuffle = shuffle;
+    discard_prefetch_locked();
+    if (shuffle && queue_.size() > 1) {
+        shuffle_range(queue_, current_idx_ + 1);
+    } else if (!shuffle && queue_.size() > 1) {
+        auto start = queue_.begin() + static_cast<std::ptrdiff_t>(current_idx_ + 1);
+        if (start < queue_.end()) {
+            std::sort(start, queue_.end(), [](const auto& a, const auto& b) { return a.id < b.id; });
+        }
+    }
 }
 
 } // namespace fh6::sources

--- a/src/sources/youtube_music_source.cpp
+++ b/src/sources/youtube_music_source.cpp
@@ -259,7 +259,7 @@ void YouTubeMusicSource::resolve_queue_locked() {
 
     // Playlist URL: enumerate IDs via --flat-playlist.
     const auto yt  = cfg_.yt_dlp_path.empty() ? L"yt-dlp" : cfg_.yt_dlp_path.wstring();
-    std::wstring cmd = quote(yt) + L" --no-warnings --flat-playlist --skip-download "
+    std::wstring cmd = quote(yt) + L" --ignore-config --no-warnings --flat-playlist --skip-download "
                                    L"--encoding UTF-8 "
                                    L"--print \"%(id)s\t%(title)s\" ";
     if (!cfg_.cookies_path.empty())
@@ -345,7 +345,8 @@ YouTubeMusicSource::spawn_pipe_locked(std::string_view url, std::size_t for_idx)
     const auto yt = cfg_.yt_dlp_path.empty() ? L"yt-dlp" : cfg_.yt_dlp_path.wstring();
     const auto ff = ffmpeg_path_.empty() ? L"ffmpeg" : ffmpeg_path_.wstring();
 
-    std::wstring yt_cmd = quote(yt) + L" --no-warnings --no-progress "
+    std::wstring yt_cmd = quote(yt) + L" --ignore-config --no-warnings --no-progress "
+                                      L"--no-write-thumbnail "
                                       L"--format bestaudio/best --no-playlist -o - ";
     if (!cfg_.cookies_path.empty())
         yt_cmd += L"--cookies " + quote(cfg_.cookies_path.wstring()) + L" ";
@@ -356,7 +357,8 @@ YouTubeMusicSource::spawn_pipe_locked(std::string_view url, std::size_t for_idx)
         ff_cmd += L"-af loudnorm=I=-14:TP=-2:LRA=11 ";
     ff_cmd += L"-acodec pcm_s16le -ar 48000 -ac 2 pipe:1";
 
-    std::wstring tl_cmd = quote(yt) + L" --skip-download --no-warnings --no-playlist "
+    std::wstring tl_cmd = quote(yt) + L" --ignore-config --skip-download --no-warnings --no-playlist "
+                                      L"--no-write-thumbnail "
                                       L"--encoding UTF-8 "
                                       L"--print \"%(title)s\" "
                                       L"--print \"%(uploader)s\" "

--- a/src/sources/youtube_music_source.cpp
+++ b/src/sources/youtube_music_source.cpp
@@ -203,7 +203,7 @@ void YouTubeMusicSource::set_shuffle(bool shuffle) {
             auto start = queue_.begin() + static_cast<std::ptrdiff_t>(queue_idx_ + 1);
             if (start < queue_.end()) {
                 std::sort(start, queue_.end(), [](const auto& a, const auto& b) { 
-                    return a.url < b.url; 
+                    return a.original_index < b.original_index;
                 });
             }
         }
@@ -251,7 +251,8 @@ void YouTubeMusicSource::resolve_queue_locked() {
     queue_idx_ = 0;
 
     if (!is_playlist_url(effective_url)) {
-        queue_.push_back({effective_url, ""});
+        // add a 0 at the end for the original_index
+        queue_.push_back({effective_url, "", "", 0}); 
         queue_built_for_ = effective_url;
         return;
     }
@@ -296,6 +297,7 @@ void YouTubeMusicSource::resolve_queue_locked() {
         raw = drain_to_eof(rd);
         CloseHandle(rd); CloseHandle(proc); CloseHandle(job);
     }
+    std::size_t og_idx = 0;
     for (std::size_t pos = 0; pos < raw.size();) {
         auto nl   = raw.find('\n', pos);
         auto end  = (nl == std::string::npos) ? raw.size() : nl;
@@ -308,7 +310,9 @@ void YouTubeMusicSource::resolve_queue_locked() {
             if (!id.empty() && id != "NA") {
                 const std::string title =
                     tab == std::string::npos ? std::string{} : line.substr(tab + 1);
-                queue_.push_back({watch_url_for_id(id), title, ""});
+                
+                // add og_idx++ to the end of the push_back
+                queue_.push_back({watch_url_for_id(id), title, "", og_idx++}); 
             }
         }
         pos = (nl == std::string::npos) ? raw.size() : nl + 1;

--- a/ui/dist/index.html
+++ b/ui/dist/index.html
@@ -110,8 +110,16 @@
       </div>
       <form id="settings-form" class="drawer-body"></form>
       <div class="drawer-foot">
-        <button class="btn ghost" id="reload-config" type="button">Reload from disk</button>
-        <button class="btn filled" id="save-config" type="button">Save</button>
+        <div style="display: flex; gap: 8px;">
+          <button class="btn ghost" id="backup-config" type="button" title="Download settings backup">Backup</button>
+          <button class="btn ghost" id="restore-config" type="button" title="Restore settings from file">Restore</button>
+          <input type="file" id="restore-file" accept=".json" style="display: none;" />
+        </div>
+        
+        <div style="display: flex; gap: 8px;">
+          <button class="btn ghost" id="reload-config" type="button" title="Reload from disk">Reload</button>
+          <button class="btn filled" id="save-config" type="button">Save</button>
+        </div>
       </div>
     </aside>
     <div class="scrim" id="scrim" hidden></div>

--- a/ui/dist/index.html
+++ b/ui/dist/index.html
@@ -42,17 +42,6 @@
         <div class="sources" id="sources"></div>
       </section>
 
-      <section class="card" id="jf-cast-card" hidden>
-        <h2>Play Jellyfin Playlist</h2>
-        <p class="muted">
-          Enter a Jellyfin Playlist ID. The radio switches source and starts streaming immediately.
-        </p>
-        <form id="jf-cast" class="row">
-          <input type="text" id="jf-url" placeholder="Playlist ID" autocomplete="off" />
-          <button type="submit" class="btn filled">Play</button>
-        </form>
-      </section>
-
       <section class="card" id="output-card" hidden>
         <h2>Output</h2>
         <label class="slider">

--- a/ui/dist/js/api.js
+++ b/ui/dist/js/api.js
@@ -34,8 +34,18 @@ export const api = {
   getYoutubeQueue: () => request("/api/source/youtube_music/queue"),
   playYoutubeIndex: index =>
     request("/api/source/youtube_music/play", { method: "POST", body: { index } }),
-  castJellyfin: playlistId =>
-    request("/api/source/jellyfin/cast", { method: "POST", body: { playlist_id: playlistId } }),
+  castJellyfin: (playlistId, useFavorites) => 
+    request("/api/source/jellyfin/cast", { method: "POST", body: { playlist_id: playlistId, use_favorites: useFavorites } }),
+  shuffleJellyfin: shuffle => 
+    request("/api/source/jellyfin/shuffle", { method: "POST", body: { shuffle } }),
+  getJellyfinStations: () => request("/api/source/jellyfin/stations"),
+  putJellyfinStations: (stations, activeStation) => 
+    request("/api/source/jellyfin/stations", { method: "PUT", body: { stations, active_station: activeStation } }),
+  activateJellyfinStation: name => 
+    request("/api/source/jellyfin/activate", { method: "POST", body: { name } }),
+  getJellyfinQueue: () => request("/api/source/jellyfin/queue"),
+  playJellyfinIndex: index => 
+    request("/api/source/jellyfin/play", { method: "POST", body: { index } }),
   setGain: gain => request("/api/options", { method: "POST", body: { output_gain: gain } }),
   getExternalAudio: () => request("/api/external_audio/devices"),
   putExternalAudio: config => request("/api/external_audio/config", { method: "PUT", body: config }),

--- a/ui/dist/js/main.js
+++ b/ui/dist/js/main.js
@@ -13,6 +13,7 @@ import { createExternalAudio } from "./render/externalAudio.js";
 import { createLocalFiles } from "./render/localFiles.js";
 import { createOnlineRadio } from "./render/onlineRadio.js";
 import { createYoutubeMusic } from "./render/youtubeMusic.js";
+import { createJellyfin } from "./render/jellyfin.js";
 
 let state = null;
 let cfg = null;
@@ -33,7 +34,6 @@ const refs = {
   sources: $("#sources"),
   sourceCard: $("#source-card"),
   outputCard: $("#output-card"),
-  jfCard: $("#jf-cast-card"),
   drawer: $("#drawer"),
   scrim: $("#scrim"),
   form: $("#settings-form"),
@@ -97,6 +97,16 @@ const youtubeMusic = createYoutubeMusic(mainEl, {
   },
 });
 
+const jellyfin = createJellyfin(mainEl, {
+  getState: () => state,
+  getConfig: () => cfg,
+  onSaved: async () => {
+    cfg = await api.getConfig().catch(() => cfg);
+    state = await api.getState().catch(() => state);
+    render();
+  },
+});
+
 async function switchSource(name) {
   try {
     await api.switchSource(name);
@@ -151,14 +161,13 @@ function render() {
   localFiles.render();
   onlineRadio.render();
   youtubeMusic.render();
+  jellyfin.render();
 
   refs.sourceCard.hidden = false;
   refs.outputCard.hidden = !state.sources?.active;
 
   const available = state.sources?.available || [];
   const active = state.sources?.active;
-  // Source-specific cards only show while that source is on air.
-  refs.jfCard.hidden = active !== "jellyfin";
 }
 
 // --- BACKUP CONFIGURATION ---
@@ -210,6 +219,7 @@ if (restoreBtn && restoreFile) {
       localFiles.invalidate();
       onlineRadio.invalidate();
       youtubeMusic.invalidate();
+      jellyfin.invalidate();
       renderSettings(refs.form, cfg);
       state = await api.getState().catch(() => state);
       render();
@@ -227,19 +237,6 @@ if (restoreBtn && restoreFile) {
 $("#t-play").addEventListener("click", () => transport("play"));
 $("#t-next").addEventListener("click", () => transport("next"));
 $("#t-prev").addEventListener("click", () => transport("previous"));
-
-$("#jf-cast").addEventListener("submit", async e => {
-  e.preventDefault();
-  const playlistId = $("#jf-url").value.trim();
-  if (!playlistId) return;
-  try {
-    await api.castJellyfin(playlistId);
-    $("#jf-url").value = "";
-    toast("Playing playlist…");
-  } catch (err) {
-    toast(err.message, true);
-  }
-});
 
 $("#open-settings").addEventListener("click", async () => {
   try {
@@ -265,6 +262,7 @@ $("#save-config").addEventListener("click", async () => {
     localFiles.invalidate();
     onlineRadio.invalidate();
     youtubeMusic.invalidate();
+    jellyfin.invalidate();
     state = await api.getState().catch(() => state);
     render();
     toast("Saved");
@@ -281,6 +279,7 @@ $("#reload-config").addEventListener("click", async () => {
     localFiles.invalidate();
     onlineRadio.invalidate();
     youtubeMusic.invalidate();
+    jellyfin.invalidate();
     renderSettings(refs.form, cfg);
     render();
     toast("Reloaded from disk");

--- a/ui/dist/js/main.js
+++ b/ui/dist/js/main.js
@@ -161,6 +161,69 @@ function render() {
   refs.jfCard.hidden = active !== "jellyfin";
 }
 
+// --- BACKUP CONFIGURATION ---
+const backupBtn = document.getElementById("backup-config");
+if (backupBtn) {
+  backupBtn.addEventListener("click", async () => {
+    try {
+      const config = await api.getConfig();
+
+      const blob = new Blob([JSON.stringify(config, null, 2)], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+
+      const dateStr = new Date().toISOString().split("T")[0];
+      a.download = `fh6-radio-settings-${dateStr}.json`;
+
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      
+      toast("Backup downloaded successfully");
+    } catch (err) {
+      console.error("Failed to backup config:", err);
+      toast("Failed to backup settings.", true);
+    }
+  });
+}
+
+// --- RESTORE CONFIGURATION ---
+const restoreBtn = document.getElementById("restore-config");
+const restoreFile = document.getElementById("restore-file");
+
+if (restoreBtn && restoreFile) {
+  restoreBtn.addEventListener("click", () => restoreFile.click());
+
+  restoreFile.addEventListener("change", async (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+
+    try {
+      const text = await file.text();
+      const patch = JSON.parse(text);
+
+      cfg = await api.putConfig(patch);
+
+      externalAudio.invalidate();
+      localFiles.invalidate();
+      onlineRadio.invalidate();
+      youtubeMusic.invalidate();
+      renderSettings(refs.form, cfg);
+      state = await api.getState().catch(() => state);
+      render();
+      
+      toast("Settings restored successfully!");
+    } catch (err) {
+      console.error("Failed to restore config:", err);
+      toast("Failed to restore settings. Invalid JSON file.", true);
+    } finally {
+      e.target.value = ""; 
+    }
+  });
+}
+
 $("#t-play").addEventListener("click", () => transport("play"));
 $("#t-next").addEventListener("click", () => transport("next"));
 $("#t-prev").addEventListener("click", () => transport("previous"));

--- a/ui/dist/js/render/jellyfin.js
+++ b/ui/dist/js/render/jellyfin.js
@@ -1,0 +1,276 @@
+import { api } from "../api.js";
+import { $, el } from "../dom.js";
+import { toast } from "../toast.js";
+import { icons } from "../icons.js";
+
+function newStation(name) {
+  return { name, playlist_id: "", use_favorites: false };
+}
+
+const fold = s => (s || "").normalize("NFD").replace(/\p{Diacritic}/gu, "").toLowerCase();
+
+export function createJellyfin(main, ctx) {
+  let stations = [];
+  let activeStation = "";
+  let selected = 0;
+  let loaded = false;
+  let queue = { cursor: 0, tracks: [] };
+  let search = "";
+
+  const stationSelect = el("select", { id: "jf-station", "aria-label": "Station preset" });
+  const onAirBtn = el("button", { type: "button", class: "btn filled" }, "Set on air");
+  const newBtn = el("button", { type: "button", class: "btn ghost" }, "New");
+  const renameBtn = el("button", { type: "button", class: "btn ghost" }, "Rename");
+  const deleteBtn = el("button", { type: "button", class: "btn ghost" }, "Delete");
+
+  const idInput = el("input", { type: "text", class: "lf-path-input", placeholder: "Playlist ID", autocomplete: "off" });
+  const favCheck = el("input", { type: "checkbox" });
+  const castBtn = el("button", { type: "button", class: "btn ghost" }, "Cast");
+  const saveBtn = el("button", { type: "button", class: "btn filled" }, "Save");
+
+  const queueCount = el("span", { class: "muted" });
+  const searchInput = el("input", { type: "text", placeholder: "Search the playlist…", autocomplete: "off" });
+  const shuffleBtn = el("button", { type: "button", class: "icon-btn", "aria-label": "Toggle Shuffle", html: icons.shuffle });
+  const trackList = el("ul", { class: "lf-tracklist" });
+
+  const card = el("section", { class: "card", id: "jellyfin-card", hidden: true }, [
+    el("h2", {}, "Jellyfin"),
+    el("div", { class: "yt-stationbar row" }, [stationSelect, onAirBtn]),
+    el("div", { class: "row yt-stationtools", style: "margin-bottom: 1.5rem;" }, [newBtn, renameBtn, deleteBtn]),
+    el("div", { class: "lf-editor" }, [
+      el("label", { class: "field-label" }, "Playlist ID"),
+      idInput,
+      el("label", { class: "field-label", style: "display: flex; align-items: center; gap: 0.5rem; margin-top: 0.5rem;" }, [
+        favCheck, "Use Favorites (ignores Playlist ID)"
+      ]),
+      el("div", { class: "row lf-editor-foot", style: "margin-top: 1rem;" }, [castBtn, saveBtn]),
+    ]),
+    el("div", { class: "lf-queue" }, [
+      el("div", { class: "lf-queue-head row" }, [
+        el("label", { class: "field-label" }, "Queue"),
+        queueCount,
+        shuffleBtn,
+      ]),
+      searchInput,
+      trackList,
+    ]),
+  ]);
+
+  const sourcesCard = $("#sources", main)?.closest(".card");
+  if (sourcesCard) sourcesCard.insertAdjacentElement("afterend", card);
+  else main.append(card);
+
+  const cur = () => stations[selected];
+
+  async function load(force = false) {
+    if (loaded && !force) return;
+    try {
+      const r = await api.getJellyfinStations();
+      stations = Array.isArray(r.stations) && r.stations.length ? r.stations : [newStation("My Playlist")];
+      activeStation = r.active_station || stations[0].name;
+      selected = Math.max(0, stations.findIndex(s => s.name === activeStation));
+      loaded = true;
+    } catch {
+      return;
+    }
+    renderEditor();
+    loadQueue();
+  }
+
+  async function loadQueue() {
+    try {
+      queue = await api.getJellyfinQueue();
+    } catch {
+      queue = { cursor: 0, tracks: [] };
+    }
+    renderQueue();
+  }
+
+  function renderStations() {
+    stationSelect.replaceChildren(
+      ...stations.map((s, i) =>
+        el("option", { value: String(i), selected: i === selected },
+          s.name + (s.name === activeStation ? "  • on air" : "")),
+      ),
+    );
+    deleteBtn.disabled = stations.length <= 1;
+    onAirBtn.disabled = cur()?.name === activeStation;
+    onAirBtn.textContent = cur()?.name === activeStation ? "On air" : "Set on air";
+  }
+
+  function renderEditor() {
+    if (!cur()) return;
+    renderStations();
+    idInput.value = cur().playlist_id || "";
+    favCheck.checked = !!cur().use_favorites;
+  }
+
+  function renderQueue() {
+    const terms = fold(search).split(/\s+/).filter(Boolean);
+    const rows = (queue.tracks || []).filter(t => {
+      if (!terms.length) return true;
+      const hay = fold(`${t.title || ""} ${t.artist || ""}`); 
+      return terms.every(w => hay.includes(w));
+    });
+    queueCount.textContent = `${queue.tracks?.length || 0} tracks`;
+    trackList.replaceChildren(
+      ...rows.map(t => {
+        const li = el("li", { class: "lf-track" + (t.index === queue.cursor ? " current" : "") }, [
+          el("div", { class: "lf-track-main" }, [
+            el("span", { class: "lf-track-title" }, t.title || "Unknown Track"),
+          ]),
+          t.artist ? el("span", { class: "lf-track-folder muted" }, t.artist) : null,
+        ]);
+        li.addEventListener("click", async () => {
+          try {
+            await api.playJellyfinIndex(t.index);
+            queue.cursor = t.index;
+            renderQueue();
+          } catch (e) {
+            toast(e.message, true);
+          }
+        });
+        return li;
+      }),
+    );
+    if (!rows.length) {
+      trackList.append(el("li", { class: "muted" }, terms.length ? "No matches." : "Queue is empty."));
+    }
+  }
+
+  stationSelect.addEventListener("change", () => {
+    selected = parseInt(stationSelect.value, 10) || 0;
+    renderEditor();
+  });
+  
+  newBtn.addEventListener("click", () => {
+    let name = "New Station";
+    let n = 2;
+    while (stations.some(s => s.name === name)) name = `New Station ${n++}`;
+    stations.push(newStation(name));
+    selected = stations.length - 1;
+    renderEditor();
+  });
+  
+  renameBtn.addEventListener("click", () => {
+    const s = cur();
+    const name = window.prompt("Station name", s.name)?.trim();
+    if (!name || name === s.name) return;
+    if (stations.some(x => x !== s && x.name === name)) return toast("A station with that name exists", true);
+    if (s.name === activeStation) activeStation = name;
+    s.name = name;
+    renderEditor();
+  });
+  
+  deleteBtn.addEventListener("click", () => {
+    if (stations.length <= 1) return;
+    const wasActive = cur().name === activeStation;
+    stations.splice(selected, 1);
+    selected = Math.min(selected, stations.length - 1);
+    if (wasActive) activeStation = stations[0].name;
+    renderEditor();
+  });
+
+  searchInput.addEventListener("input", () => {
+    search = searchInput.value;
+    renderQueue();
+  });
+
+  saveBtn.addEventListener("click", async () => {
+    if (cur()) {
+      cur().playlist_id = idInput.value.trim();
+      cur().use_favorites = favCheck.checked;
+    }
+    try {
+      await api.putJellyfinStations(stations, activeStation);
+      toast("Saved Jellyfin stations");
+      await ctx.onSaved?.();
+      loadQueue();
+    } catch (e) {
+      toast(e.message, true);
+    }
+  });
+
+  castBtn.addEventListener("click", async () => {
+    const id = idInput.value.trim();
+    const isFav = favCheck.checked;
+    if (!id && !isFav) return;
+
+    idInput.disabled = true;
+    favCheck.disabled = true;
+    castBtn.disabled = true;
+    
+    try {
+      await api.castJellyfin(id, isFav);
+      toast("Casting to Jellyfin...");
+      await ctx.onSaved?.();
+      loadQueue();
+    } catch (e) {
+      toast(e.message, true);
+    } finally {
+      idInput.disabled = false;
+      favCheck.disabled = false;
+      castBtn.disabled = false;
+    }
+  });
+
+  shuffleBtn.addEventListener("click", async () => {
+    const isShuffled = shuffleBtn.classList.contains("toggled");
+    try {
+        await api.shuffleJellyfin(!isShuffled);
+        toast(!isShuffled ? "Shuffle on" : "Shuffle off");
+        await ctx.onSaved?.(); 
+        loadQueue();
+    } catch (err) {
+        toast(err.message, true);
+    }
+  });
+
+  onAirBtn.addEventListener("click", async () => {
+    const name = cur().name;
+    try {
+      await api.putJellyfinStations(stations, name); 
+      await api.activateJellyfinStation(name); 
+
+      await api.switchSource("jellyfin");
+      await api.transport("jellyfin", "play");
+
+      activeStation = name;
+      renderStations();
+      toast(`On air: ${name}`);
+      await ctx.onSaved?.();
+      loadQueue();
+    } catch (e) {
+      toast(e.message, true);
+    }
+  });
+
+  let lastQueueSize = -1;
+  let lastQueueCursor = -1;
+
+  function render() {
+    const state = ctx.getState();
+    const isActive = state?.sources?.active === "jellyfin";
+    card.hidden = !isActive;
+    if (!isActive) return;
+    load();
+
+    const jfDetails = state?.sources?.available?.find(s => s.name === "jellyfin")?.details;
+    const shuffleOn = !!jfDetails?.shuffle;
+    shuffleBtn.classList.toggle("toggled", shuffleOn);
+    shuffleBtn.setAttribute("aria-pressed", String(shuffleOn));
+
+    const qs = jfDetails?.queue_size ?? -1;
+    const qc = jfDetails?.queue_cursor ?? -1;
+    if (loaded && (qs !== lastQueueSize || qc !== lastQueueCursor)) {
+      lastQueueSize = qs;
+      lastQueueCursor = qc;
+      loadQueue();
+    }
+  }
+
+  return {
+    render,
+    invalidate: () => { loaded = false; },
+  };
+}

--- a/ui/dist/js/render/settings.js
+++ b/ui/dist/js/render/settings.js
@@ -47,6 +47,14 @@ function buildField(section, spec, cfg) {
     ]);
   }
 
+  if (type === "select-kv") {
+    const options = (a || []).map(([val, lbl]) => el("option", { value: String(val), selected: Number(cur) === val }, lbl));
+    return el("div", { class: "field" }, [
+      el("label", { for: id }, label),
+      el("select", { id, dataset: { ...dataset, numeric: "1" } }, options),
+    ]);
+  }
+
   if (type === "bands") {
     const values = Array.isArray(cur) ? cur : [0, 0, 0, 0, 0];
     const rows = EQ_BAND_LABELS.map((bandLabel, i) => {

--- a/ui/dist/js/schema.js
+++ b/ui/dist/js/schema.js
@@ -16,7 +16,6 @@ const KB_KEYS = [
   [0x22, "Page Down"],
   [0x24, "Home"],
   [0x23, "End"],
-  [0x77, "F8"],
   [0x78, "F9"],
   [0x79, "F10"],
   [0x9999, "Double-Tap Radio Change"]

--- a/ui/dist/js/schema.js
+++ b/ui/dist/js/schema.js
@@ -9,6 +9,36 @@ export const SOURCE_SECTIONS = [
   ["vanilla_radio", "Vanilla Radio"],
 ];
 
+// hotkeys
+const KB_KEYS = [
+  [0, "None"],
+  [0x21, "Page Up"],
+  [0x22, "Page Down"],
+  [0x24, "Home"],
+  [0x23, "End"],
+  [0x77, "F8"],
+  [0x78, "F9"],
+  [0x79, "F10"],
+  [0x9999, "Double-Tap Radio Change"]
+];
+
+const PAD_BUTTONS = [
+  [0, "None"],
+  
+  // single unbound buttons
+  [0x0100, "Left Bumper (LB)"],
+  [0x4000, "X Button"],
+  [0x2000, "B Button"],
+  
+  // custom combos (LB / X / B)
+  [0x4100, "LB + X"],
+  [0x2100, "LB + B"],
+  [0x6000, "X + B"],
+  [0x6100, "LB + X + B"],
+
+  [0x9999, "Double-Tap Radio Change"]
+];
+
 // [field, label, type, ...args]. type: checkbox | text | number | select | bands.
 export const SCHEMA = [
   [
@@ -87,7 +117,6 @@ export const SCHEMA = [
     "Playback",
     [
       ["race_start_playback", "Race start", "select", ["next", "restart", "ignore"]],
-      ["quick_station_skip", "Quick station skip", "checkbox"],
       ["volume_normalization", "Normalize loudness", "checkbox"],
       ["equalizer_enabled", "Equalizer", "checkbox"],
       ["equalizer_bands", "Equalizer bands", "bands"],
@@ -95,4 +124,16 @@ export const SCHEMA = [
       ["prebuffer_next_track", "Pre-buffer next track", "checkbox"],
     ],
   ],
+  [
+    "hotkeys",
+    "Global Hotkeys",
+    [
+      ["kb_playpause", "Play / Pause (Keyboard)", "select-kv", KB_KEYS],
+      ["pad_playpause", "Play / Pause (Controller)", "select-kv", PAD_BUTTONS],
+      ["kb_skip", "Skip Track (Keyboard)", "select-kv", KB_KEYS],
+      ["pad_skip", "Skip Track (Controller)", "select-kv", PAD_BUTTONS],
+      ["kb_source", "Switch Source (Keyboard)", "select-kv", KB_KEYS],
+      ["pad_source", "Switch Source (Controller)", "select-kv", PAD_BUTTONS],
+    ]
+  ]
 ];

--- a/ui/dist/js/schema.js
+++ b/ui/dist/js/schema.js
@@ -28,10 +28,12 @@ const PAD_BUTTONS = [
   [0x0100, "Left Bumper (LB)"],
   [0x4000, "X Button"],
   [0x2000, "B Button"],
+  [0x0040, "Left Stick Click (LS)"],
   
   // custom combos (LB / X / B)
   [0x4100, "LB + X"],
   [0x2100, "LB + B"],
+  [0x0140, "LB + LS"],
   [0x6000, "X + B"],
   [0x6100, "LB + X + B"],
 

--- a/ui/dist/js/schema.js
+++ b/ui/dist/js/schema.js
@@ -67,7 +67,6 @@ export const SCHEMA = [
       ["enabled", "Enabled", "checkbox"],
       ["cookies_path", "cookies.txt (optional)", "text"],
       ["yt_dlp_path", "yt-dlp path (optional)", "text"],
-      ["shuffle", "Shuffle", "checkbox"],
     ],
   ],
   [
@@ -78,9 +77,6 @@ export const SCHEMA = [
       ["server_url", "Server URL", "text"],
       ["user_id", "User ID", "text"],
       ["api_key", "API Key", "text"],
-      ["default_playlist", "Default Playlist", "text"],
-      ["use_favorites", "Use Favorites", "checkbox"],
-      ["shuffle", "Shuffle", "checkbox"],
     ],
   ],
   ["external_audio", "External Audio", [["enabled", "Enabled", "checkbox"]]],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable keyboard + gamepad hotkeys for skip next, switch source, and play/pause.
  * Added Jellyfin multi-station support with an active station selector and station/queue controls.
* **Refactor**
  * Replaced the legacy quick-skip setting with hotkey-driven actions (including compatibility behavior).
  * Updated Jellyfin config and HTTP responses to use the new station list model.
* **Bug Fixes**
  * Improved shuffle/tail reordering to better preserve original playlist order.
* **Documentation**
  * Updated example TOML and setup guidance for hotkeys and station-based Jellyfin settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->