### PR TITLE
feat: Add hotkeys for previous track and changing stations, custom keybind support, and fix various bugs

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -108,3 +108,5 @@ kb_source     = 0           # keyboard virtual key code to switch sources (0 = u
 pad_source    = 0           # XInput controller button mask to switch sources (0 = unbound)
 kb_playpause  = 0           # keyboard virtual key code to play track (0 = unbound)
 pad_playpause = 0           # XInput controller button mask to play track (0 = unbound)
+kb_prev       = 0           # keyboard virtual key code to go to previous track (0 = unbound)
+pad_prev      = 0           # XInput controller button mask to go to previous track (0 = unbound)

--- a/config.example.toml
+++ b/config.example.toml
@@ -100,7 +100,6 @@ equalizer_bands      = [0.0, 0.0, 0.0, 0.0, 0.0]   # 60/250/1000/4000/12000 Hz, 
 force_stereo_audio   = true        # off => mono (avoids metallic phase-cancellation on the 3D radio channel)
 prebuffer_next_track = true        # pre-spawn the next track's pipeline so transitions skip the "(loading)" gap
 
-
 [hotkeys]
 kb_skip       = 0           # keyboard virtual key code to skip track (0 = unbound)
 pad_skip      = 0           # XInput controller button mask to skip track (0 = unbound)
@@ -110,3 +109,5 @@ kb_playpause  = 0           # keyboard virtual key code to play track (0 = unbou
 pad_playpause = 0           # XInput controller button mask to play track (0 = unbound)
 kb_prev       = 0           # keyboard virtual key code to go to previous track (0 = unbound)
 pad_prev      = 0           # XInput controller button mask to go to previous track (0 = unbound)
+kb_next_station = 0         # keyboard virtual key code to change active station/playlist (0 = unbound)
+pad_next_station = 0        # XInput controller button mask to change active station/playlist (0 = unbound)

--- a/include/fh6/config.hpp
+++ b/include/fh6/config.hpp
@@ -15,6 +15,8 @@ struct HotkeysConfig {
     int pad_source = 0;
     int kb_playpause = 0;
     int pad_playpause = 0;
+    int kb_prev = 0;
+    int pad_prev = 0;
 };
 
 struct PlaybackConfig {

--- a/include/fh6/config.hpp
+++ b/include/fh6/config.hpp
@@ -17,6 +17,8 @@ struct HotkeysConfig {
     int pad_playpause = 0;
     int kb_prev = 0;
     int pad_prev = 0;
+    int kb_next_station = 0;
+    int pad_next_station = 0;
 };
 
 struct PlaybackConfig {

--- a/include/fh6/fmod/dsp_control_loop.hpp
+++ b/include/fh6/fmod/dsp_control_loop.hpp
@@ -25,7 +25,7 @@ namespace fh6::fmod_bridge {
 class ControlLoop {
 public:
     ControlLoop(DSPBridge& bridge, const PEImage& img, PlaybackConfig initial_playback,
-                float configured_gain, std::function<void()> on_cycle_station = nullptr);
+                float configured_gain, std::function<bool()> on_cycle_station = nullptr);
     ~ControlLoop();
 
     ControlLoop(const ControlLoop&)            = delete;
@@ -59,7 +59,7 @@ private:
     DSPBridge& bridge_;
     const PEImage& img_;
     std::atomic<float> configured_gain_;
-    std::function<void()> on_cycle_station_;
+    std::function<bool()> on_cycle_station_;
     MetadataInjector meta_;
     GameStateProbe game_state_;
     std::uint64_t prev_calls_     = 0;

--- a/include/fh6/fmod/dsp_control_loop.hpp
+++ b/include/fh6/fmod/dsp_control_loop.hpp
@@ -81,6 +81,8 @@ private:
     bool prev_skip_hotkey_ = false;
     bool prev_source_hotkey_ = false;
     bool prev_playpause_hotkey_ = false;
+    bool prev_prev_hotkey_ = false;
+
     bool quick_skip_armed_  = false;
     bool paused_by_race_off_  = false;
     bool first_connection_    = true;
@@ -89,14 +91,19 @@ private:
     bool pending_skip_ = false;
     bool pending_src_ = false;
     bool pending_pp_ = false;
+    bool pending_prev_ = false;
+
     time_point last_source_cmd_{};
     time_point last_playpause_cmd_{};
+    time_point last_prev_cmd_{};
+
     time_point last_r10_off_{};
     time_point last_race_event_{};
     time_point last_skip_cmd_{};
     bool old_method_src_fired_ = false;
     bool old_method_pp_fired_  = false;
     bool old_method_skip_fired_ = false;
+    bool old_method_prev_fired_ = false;
 
     std::jthread thread_;
 };

--- a/include/fh6/fmod/dsp_control_loop.hpp
+++ b/include/fh6/fmod/dsp_control_loop.hpp
@@ -14,6 +14,7 @@
 #include <mutex>
 #include <stop_token>
 #include <thread>
+#include <functional>
 
 namespace fh6 {
 class IAudioSource;

--- a/include/fh6/fmod/dsp_control_loop.hpp
+++ b/include/fh6/fmod/dsp_control_loop.hpp
@@ -24,7 +24,7 @@ namespace fh6::fmod_bridge {
 class ControlLoop {
 public:
     ControlLoop(DSPBridge& bridge, const PEImage& img, PlaybackConfig initial_playback,
-                float configured_gain);
+                float configured_gain, std::function<void()> on_cycle_station = nullptr);
     ~ControlLoop();
 
     ControlLoop(const ControlLoop&)            = delete;
@@ -58,6 +58,7 @@ private:
     DSPBridge& bridge_;
     const PEImage& img_;
     std::atomic<float> configured_gain_;
+    std::function<void()> on_cycle_station_;
     MetadataInjector meta_;
     GameStateProbe game_state_;
     std::uint64_t prev_calls_     = 0;
@@ -82,6 +83,7 @@ private:
     bool prev_source_hotkey_ = false;
     bool prev_playpause_hotkey_ = false;
     bool prev_prev_hotkey_ = false;
+    bool prev_station_hotkey_ = false;
 
     bool quick_skip_armed_  = false;
     bool paused_by_race_off_  = false;
@@ -92,10 +94,12 @@ private:
     bool pending_src_ = false;
     bool pending_pp_ = false;
     bool pending_prev_ = false;
+    bool pending_station_ = false;
 
     time_point last_source_cmd_{};
     time_point last_playpause_cmd_{};
     time_point last_prev_cmd_{};
+    time_point last_station_cmd_{};
 
     time_point last_r10_off_{};
     time_point last_race_event_{};
@@ -104,6 +108,7 @@ private:
     bool old_method_pp_fired_  = false;
     bool old_method_skip_fired_ = false;
     bool old_method_prev_fired_ = false;
+    bool old_method_station_fired_ = false;
 
     std::jthread thread_;
 };

--- a/include/fh6/sources/external_audio_source.hpp
+++ b/include/fh6/sources/external_audio_source.hpp
@@ -38,6 +38,7 @@ public:
     void next() override;
     void previous() override;
     bool skip_next() override;
+    bool restart_current() override;
     void pump(RingBuffer& ring) override;
     void on_radio_audible(bool audible) override;
     void set_config(ExternalAudioConfig cfg);

--- a/include/fh6/sources/spotify_source.hpp
+++ b/include/fh6/sources/spotify_source.hpp
@@ -33,6 +33,7 @@ public:
     void stop() override;
     void next() override; // next/prev are handled by OS media keys
     void previous() override;
+    bool restart_current() override;
     void pump(RingBuffer& ring) override;
 
     TrackInfo current_track() const override;

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -246,37 +246,43 @@ void run_bridge(HMODULE self) noexcept {
     bridge.set_force_stereo_audio(cfg.playback.force_stereo_audio);
 
     // cycle the playlist for whichever source is currently active
-    auto cycle_station = [&store, &mgr]() {
-        store.patch([&mgr](Config& c) {
+    auto cycle_station = [&store, &mgr]() -> bool {
+        bool changed = false;
+        store.patch([&mgr, &changed](Config& c) {
             auto* active = mgr.active();
             if (!active) return;
             auto name = active->name();
             
-            if (name == "local_files" && !c.local_files.stations.empty()) {
+            if (name == "local_files" && c.local_files.stations.size() > 1) {
                 size_t idx = 0;
                 for (size_t i = 0; i < c.local_files.stations.size(); ++i) {
                     if (c.local_files.stations[i].name == c.local_files.active_station) { idx = i; break; }
                 }
                 c.local_files.active_station = c.local_files.stations[(idx + 1) % c.local_files.stations.size()].name;
+                changed = true;
             }
-            else if (name == "youtube_music" && !c.youtube_music.stations.empty()) {
+            else if (name == "youtube_music" && c.youtube_music.stations.size() > 1) {
                 size_t idx = 0;
                 for (size_t i = 0; i < c.youtube_music.stations.size(); ++i) {
                     if (c.youtube_music.stations[i].name == c.youtube_music.active_station) { idx = i; break; }
                 }
                 c.youtube_music.active_station = c.youtube_music.stations[(idx + 1) % c.youtube_music.stations.size()].name;
+                changed = true;
             }
-            else if (name == "jellyfin" && !c.jellyfin.stations.empty()) {
+            else if (name == "jellyfin" && c.jellyfin.stations.size() > 1) {
                 size_t idx = 0;
                 for (size_t i = 0; i < c.jellyfin.stations.size(); ++i) {
                     if (c.jellyfin.stations[i].name == c.jellyfin.active_station) { idx = i; break; }
                 }
                 c.jellyfin.active_station = c.jellyfin.stations[(idx + 1) % c.jellyfin.stations.size()].name;
+                changed = true;
             }
-            else if (name == "online_radio" && !c.online_radio.stations.empty()) {
+            else if (name == "online_radio" && c.online_radio.stations.size() > 1) {
                 c.online_radio.default_station_index = (c.online_radio.default_station_index + 1) % c.online_radio.stations.size();
+                changed = true;
             }
         });
+        return changed;
     };
 
     std::unique_ptr<fmod_bridge::ControlLoop> ctrl;

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -322,10 +322,16 @@ void run_bridge(HMODULE self) noexcept {
             yt->set_config(c.youtube_music); 
             yt->set_yt_dlp_path(c.youtube_music.yt_dlp_path);
             yt->set_shuffle(c.youtube_music.shuffle);
+            if (mgr.active() == yt && yt->playback_state() != PlaybackState::playing) {
+                yt->play();
+            }
         }
         if (auto* jf = dynamic_cast<sources::JellyfinSource*>(mgr.find("jellyfin"))) {
             jf->set_ffmpeg_path(c.general.ffmpeg_path);
             jf->set_config(c.jellyfin);
+            if (mgr.active() == jf && jf->playback_state() != PlaybackState::playing) {
+                jf->play();
+            }
         }
         if (auto* ext = dynamic_cast<sources::ExternalAudioSource*>(mgr.find("external_audio"))) {
             ext->set_config(c.external_audio);
@@ -336,6 +342,9 @@ void run_bridge(HMODULE self) noexcept {
         if (auto* rd = dynamic_cast<sources::OnlineRadioSource*>(mgr.find("online_radio"))) {
             rd->set_ffmpeg_path(c.general.ffmpeg_path);
             rd->set_config(c.online_radio);
+            if (mgr.active() == rd && rd->playback_state() != PlaybackState::playing) {
+                rd->play();
+            }
         }
 
         for (auto* s : mgr.sources_snapshot()) s->set_playback_options(c.playback);

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -245,10 +245,44 @@ void run_bridge(HMODULE self) noexcept {
     bridge.set_gain(cfg.audio.output_gain);
     bridge.set_force_stereo_audio(cfg.playback.force_stereo_audio);
 
+    // cycle the playlist for whichever source is currently active
+    auto cycle_station = [&store, &mgr]() {
+        store.patch([&mgr](Config& c) {
+            auto* active = mgr.active();
+            if (!active) return;
+            auto name = active->name();
+            
+            if (name == "local_files" && !c.local_files.stations.empty()) {
+                size_t idx = 0;
+                for (size_t i = 0; i < c.local_files.stations.size(); ++i) {
+                    if (c.local_files.stations[i].name == c.local_files.active_station) { idx = i; break; }
+                }
+                c.local_files.active_station = c.local_files.stations[(idx + 1) % c.local_files.stations.size()].name;
+            }
+            else if (name == "youtube_music" && !c.youtube_music.stations.empty()) {
+                size_t idx = 0;
+                for (size_t i = 0; i < c.youtube_music.stations.size(); ++i) {
+                    if (c.youtube_music.stations[i].name == c.youtube_music.active_station) { idx = i; break; }
+                }
+                c.youtube_music.active_station = c.youtube_music.stations[(idx + 1) % c.youtube_music.stations.size()].name;
+            }
+            else if (name == "jellyfin" && !c.jellyfin.stations.empty()) {
+                size_t idx = 0;
+                for (size_t i = 0; i < c.jellyfin.stations.size(); ++i) {
+                    if (c.jellyfin.stations[i].name == c.jellyfin.active_station) { idx = i; break; }
+                }
+                c.jellyfin.active_station = c.jellyfin.stations[(idx + 1) % c.jellyfin.stations.size()].name;
+            }
+            else if (name == "online_radio" && !c.online_radio.stations.empty()) {
+                c.online_radio.default_station_index = (c.online_radio.default_station_index + 1) % c.online_radio.stations.size();
+            }
+        });
+    };
+
     std::unique_ptr<fmod_bridge::ControlLoop> ctrl;
     if (fns.ready()) {
         ctrl = std::make_unique<fmod_bridge::ControlLoop>(bridge, img, cfg.playback,
-                                                          cfg.audio.output_gain);
+                                                          cfg.audio.output_gain, cycle_station);
     }
 
     for (auto* s : mgr.sources_snapshot()) s->set_playback_options(cfg.playback);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -250,11 +250,14 @@ Config load_config(const std::filesystem::path& path) {
     cfg.playback.hotkeys.pad_source = pick<int>(hk, "pad_source", cfg.playback.hotkeys.pad_source);
     cfg.playback.hotkeys.kb_playpause = pick<int>(hk, "kb_playpause", cfg.playback.hotkeys.kb_playpause);
     cfg.playback.hotkeys.pad_playpause = pick<int>(hk, "pad_playpause", cfg.playback.hotkeys.pad_playpause);
+    cfg.playback.hotkeys.kb_prev = pick<int>(hk, "kb_prev", cfg.playback.hotkeys.kb_prev);
+    cfg.playback.hotkeys.pad_prev = pick<int>(hk, "pad_prev", cfg.playback.hotkeys.pad_prev);
 
     const bool any_hotkey_bound =
         cfg.playback.hotkeys.kb_skip || cfg.playback.hotkeys.pad_skip ||
         cfg.playback.hotkeys.kb_source || cfg.playback.hotkeys.pad_source ||
-        cfg.playback.hotkeys.kb_playpause || cfg.playback.hotkeys.pad_playpause;
+        cfg.playback.hotkeys.kb_playpause || cfg.playback.hotkeys.pad_playpause ||
+        cfg.playback.hotkeys.kb_prev || cfg.playback.hotkeys.pad_prev;
     if (legacy_quick_station_skip && !any_hotkey_bound) {
         cfg.playback.hotkeys.kb_skip = 0x9999; // legacy quick-skip sentinel
         cfg.playback.hotkeys.pad_skip = 0x9999; // legacy quick-skip sentinel
@@ -463,6 +466,8 @@ void save_config(const std::filesystem::path& path, const Config& cfg) {
     e.kv("pad_source", (int64_t)cfg.playback.hotkeys.pad_source);
     e.kv("kb_playpause", (int64_t)cfg.playback.hotkeys.kb_playpause);
     e.kv("pad_playpause", (int64_t)cfg.playback.hotkeys.pad_playpause);
+    e.kv("kb_prev", (int64_t)cfg.playback.hotkeys.kb_prev);
+    e.kv("pad_prev", (int64_t)cfg.playback.hotkeys.pad_prev);
 
     auto tmp  = path;
     tmp      += ".tmp";

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -252,12 +252,15 @@ Config load_config(const std::filesystem::path& path) {
     cfg.playback.hotkeys.pad_playpause = pick<int>(hk, "pad_playpause", cfg.playback.hotkeys.pad_playpause);
     cfg.playback.hotkeys.kb_prev = pick<int>(hk, "kb_prev", cfg.playback.hotkeys.kb_prev);
     cfg.playback.hotkeys.pad_prev = pick<int>(hk, "pad_prev", cfg.playback.hotkeys.pad_prev);
+    cfg.playback.hotkeys.kb_next_station = pick<int>(hk, "kb_next_station", cfg.playback.hotkeys.kb_next_station);
+    cfg.playback.hotkeys.pad_next_station = pick<int>(hk, "pad_next_station", cfg.playback.hotkeys.pad_next_station);
 
     const bool any_hotkey_bound =
         cfg.playback.hotkeys.kb_skip || cfg.playback.hotkeys.pad_skip ||
         cfg.playback.hotkeys.kb_source || cfg.playback.hotkeys.pad_source ||
         cfg.playback.hotkeys.kb_playpause || cfg.playback.hotkeys.pad_playpause ||
-        cfg.playback.hotkeys.kb_prev || cfg.playback.hotkeys.pad_prev;
+        cfg.playback.hotkeys.kb_prev || cfg.playback.hotkeys.pad_prev ||
+        cfg.playback.hotkeys.kb_next_station || cfg.playback.hotkeys.pad_next_station;
     if (legacy_quick_station_skip && !any_hotkey_bound) {
         cfg.playback.hotkeys.kb_skip = 0x9999; // legacy quick-skip sentinel
         cfg.playback.hotkeys.pad_skip = 0x9999; // legacy quick-skip sentinel
@@ -468,6 +471,8 @@ void save_config(const std::filesystem::path& path, const Config& cfg) {
     e.kv("pad_playpause", (int64_t)cfg.playback.hotkeys.pad_playpause);
     e.kv("kb_prev", (int64_t)cfg.playback.hotkeys.kb_prev);
     e.kv("pad_prev", (int64_t)cfg.playback.hotkeys.pad_prev);
+    e.kv("kb_next_station", (int64_t)cfg.playback.hotkeys.kb_next_station);
+    e.kv("pad_next_station", (int64_t)cfg.playback.hotkeys.pad_next_station);
 
     auto tmp  = path;
     tmp      += ".tmp";

--- a/src/fmod/dsp_control_loop.cpp
+++ b/src/fmod/dsp_control_loop.cpp
@@ -342,7 +342,7 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
     });
 
     XINPUT_STATE xstate{};
-    const bool has_pad_hotkeys = opts->hotkeys.pad_skip || opts->hotkeys.pad_source || opts->hotkeys.pad_playpause || opts->hotkeys.pad_prev;
+    const bool has_pad_hotkeys = opts->hotkeys.pad_skip || opts->hotkeys.pad_source || opts->hotkeys.pad_playpause || opts->hotkeys.pad_prev || opts->hotkeys.pad_next_station;
     bool pad_connected = has_pad_hotkeys && pXInputGetState && (pXInputGetState(0, &xstate) == ERROR_SUCCESS);
 
     // helper to resolve overlap conflicts

--- a/src/fmod/dsp_control_loop.cpp
+++ b/src/fmod/dsp_control_loop.cpp
@@ -341,7 +341,7 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
     });
 
     XINPUT_STATE xstate{};
-    const bool has_pad_hotkeys = opts->hotkeys.pad_skip || opts->hotkeys.pad_source || opts->hotkeys.pad_playpause;
+    const bool has_pad_hotkeys = opts->hotkeys.pad_skip || opts->hotkeys.pad_source || opts->hotkeys.pad_playpause || opts->hotkeys.pad_prev;
     bool pad_connected = has_pad_hotkeys && pXInputGetState && (pXInputGetState(0, &xstate) == ERROR_SUCCESS);
 
     // helper to resolve overlap conflicts
@@ -353,39 +353,46 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
     bool kb_skip = opts->hotkeys.kb_skip && (opts->hotkeys.kb_skip != 0x9999) && (GetAsyncKeyState(opts->hotkeys.kb_skip) & 0x8000);
     bool kb_src  = opts->hotkeys.kb_source && (opts->hotkeys.kb_source != 0x9999) && (GetAsyncKeyState(opts->hotkeys.kb_source) & 0x8000);
     bool kb_pp   = opts->hotkeys.kb_playpause && (opts->hotkeys.kb_playpause != 0x9999) && (GetAsyncKeyState(opts->hotkeys.kb_playpause) & 0x8000);
+    bool kb_prev = opts->hotkeys.kb_prev && (opts->hotkeys.kb_prev != 0x9999) && (GetAsyncKeyState(opts->hotkeys.kb_prev) & 0x8000);
 
     // check controller (resolve overlap by complexity)
     bool p_skip = check_pad(opts->hotkeys.pad_skip);
     bool p_src  = check_pad(opts->hotkeys.pad_source);
     bool p_pp   = check_pad(opts->hotkeys.pad_playpause);
+    bool p_prev = check_pad(opts->hotkeys.pad_prev);
 
     DWORD max_bits = std::max<DWORD>({
         p_skip ? static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_skip))) : 0u,
         p_src  ? static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_source))) : 0u,
         p_pp   ? static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_playpause))) : 0u
+        p_prev ? static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_prev))) : 0u
     });
 
     bool pad_skip_pressed = p_skip && (static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_skip))) == max_bits);
     bool pad_src_pressed  = p_src && (static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_source))) == max_bits);
     bool pad_pp_pressed   = p_pp && (static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_playpause))) == max_bits);
+    bool pad_prev_pressed = p_prev && (static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_prev))) == max_bits);
 
     bool skip_pressed = kb_skip || pad_skip_pressed;
     bool src_pressed  = kb_src || pad_src_pressed;
     bool pp_pressed   = kb_pp || pad_pp_pressed;
+    bool prev_pressed   = kb_prev || pad_prev_pressed;
 
     // --- quickStationSkip (R10 edge) ---
     const bool use_old_skip = (opts->hotkeys.kb_skip      == 0x9999 || opts->hotkeys.pad_skip      == 0x9999);
     const bool use_old_src  = (opts->hotkeys.kb_source    == 0x9999 || opts->hotkeys.pad_source    == 0x9999);
     const bool use_old_pp   = (opts->hotkeys.kb_playpause == 0x9999 || opts->hotkeys.pad_playpause == 0x9999);
+    const bool use_old_prev = (opts->hotkeys.kb_prev      == 0x9999 || opts->hotkeys.pad_prev      == 0x9999);
 
     if (prev_r10_ && !r10) {
         last_r10_off_ = now;
-        if (use_old_skip || use_old_src || use_old_pp) quick_skip_armed_ = true;
+        if (use_old_skip || use_old_src || use_old_pp || use_old_prev) quick_skip_armed_ = true;
     } else if (!prev_r10_ && r10) {
         if (quick_skip_armed_ && now - last_r10_off_ <= kQuickSkipWindow) {
             if (use_old_skip) old_method_skip_fired_ = true;
             if (use_old_src)  old_method_src_fired_  = true;
             if (use_old_pp)   old_method_pp_fired_   = true;
+            if (use_old_prev) old_method_prev_fired_ = true;
         }
         quick_skip_armed_ = false;
     }
@@ -395,27 +402,31 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
     bool skip_edge = skip_pressed && !prev_skip_hotkey_;
     bool src_edge  = src_pressed && !prev_source_hotkey_;
     bool pp_edge   = pp_pressed && !prev_playpause_hotkey_;
+    bool prev_edge = prev_pressed && !prev_prev_hotkey_;
 
     // buffer
     if (skip_edge) pending_skip_ = true;
     if (src_edge)  pending_src_ = true;
     if (pp_edge)   pending_pp_ = true;
+    if (prev_edge) pending_prev_ = true;
 
     bool trigger_skip = old_method_skip_fired_;
     bool trigger_src  = old_method_src_fired_;
     bool trigger_pp   = old_method_pp_fired_;
+    bool trigger_prev = old_method_prev_fired_;
     old_method_skip_fired_ = false;
     old_method_src_fired_  = false;
     old_method_pp_fired_   = false;
+    old_method_prev_fired_ = false;
 
     // track how long buttons have been held to allow combos to form
-    if (skip_pressed || src_pressed || pp_pressed) {
+    if (skip_pressed || src_pressed || pp_pressed || prev_pressed) {
         if (combo_wait_ticks_ >= 0) {
             combo_wait_ticks_++;
         }
     } else {
         combo_wait_ticks_ = 0;
-        pending_skip_ = pending_src_ = pending_pp_ = false;
+        pending_skip_ = pending_src_ = pending_pp_ = pending_prev_ = false;
     }
 
     // trigger combos immediately, delay single buttons by 3 ticks (~60ms) to prevent overlap
@@ -426,10 +437,12 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
             trigger_src = true;
         } else if (pending_skip_ && max_bits == static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_skip)))) {
             trigger_skip = true;
+        } else if (pending_prev_ && max_bits == static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_prev)))) {
+            trigger_prev = true;
         }
 
         // clear pending states
-        pending_skip_ = pending_src_ = pending_pp_ = false;
+        pending_skip_ = pending_src_ = pending_pp_ = pending_prev_ = false;
         
         // set to a negative number to prevent firing again until buttons are released
         combo_wait_ticks_ = -9999; 
@@ -472,9 +485,18 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
         last_playpause_cmd_ = now;
     }
 
+    // execute previous track
+    if (trigger_prev && (now - last_prev_cmd_ >= kSkipCommandCooldown)) {
+        active->previous();
+        ring.drain();
+        last_prev_cmd_ = now;
+        log::info("[ctrl] Hotkey triggered: returned to previous track");
+    }
+
     prev_skip_hotkey_ = skip_pressed;
     prev_source_hotkey_ = src_pressed;
     prev_playpause_hotkey_ = pp_pressed;
+    prev_prev_hotkey_ = prev_pressed;
 }
 
 void ControlLoop::push_metadata() noexcept {

--- a/src/fmod/dsp_control_loop.cpp
+++ b/src/fmod/dsp_control_loop.cpp
@@ -39,7 +39,7 @@ constexpr const char* kTargetSoundName = "HZ6_R9_PeterBroderick_EyesClosedandTra
 } // namespace
 
 ControlLoop::ControlLoop(DSPBridge& bridge, const PEImage& img, PlaybackConfig initial_playback,
-                         float configured_gain, std::function<void()> on_cycle_station)
+                         float configured_gain, std::function<bool()> on_cycle_station)
     : bridge_{bridge}, img_{img}, configured_gain_{configured_gain}, game_state_{img},
       on_cycle_station_{std::move(on_cycle_station)},
       playback_opts_{std::make_shared<const PlaybackConfig>(std::move(initial_playback))},
@@ -509,10 +509,11 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
 
     // execute cycle station/playlist
     if (trigger_station && (now - last_station_cmd_ >= 250ms)) {
-        if (on_cycle_station_) on_cycle_station_();
-        ring.drain();
+        if (on_cycle_station_ && on_cycle_station_()) {
+            ring.drain();
+            log::info("[ctrl] Hotkey triggered: cycled active station");
+        }
         last_station_cmd_ = now;
-        log::info("[ctrl] Hotkey triggered: cycled active station");
     }
 
     prev_skip_hotkey_ = skip_pressed;

--- a/src/fmod/dsp_control_loop.cpp
+++ b/src/fmod/dsp_control_loop.cpp
@@ -376,6 +376,7 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
     bool pad_src_pressed  = p_src && (static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_source))) == max_bits);
     bool pad_pp_pressed   = p_pp && (static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_playpause))) == max_bits);
     bool pad_prev_pressed = p_prev && (static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_prev))) == max_bits);
+    bool pad_station_pressed = p_station && (static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_next_station))) == max_bits);
 
     bool skip_pressed = kb_skip || pad_skip_pressed;
     bool src_pressed  = kb_src || pad_src_pressed;

--- a/src/fmod/dsp_control_loop.cpp
+++ b/src/fmod/dsp_control_loop.cpp
@@ -39,8 +39,9 @@ constexpr const char* kTargetSoundName = "HZ6_R9_PeterBroderick_EyesClosedandTra
 } // namespace
 
 ControlLoop::ControlLoop(DSPBridge& bridge, const PEImage& img, PlaybackConfig initial_playback,
-                         float configured_gain)
+                         float configured_gain, std::function<void()> on_cycle_station)
     : bridge_{bridge}, img_{img}, configured_gain_{configured_gain}, game_state_{img},
+      on_cycle_station_{std::move(on_cycle_station)},
       playback_opts_{std::make_shared<const PlaybackConfig>(std::move(initial_playback))},
       thread_{[this](const std::stop_token& tok) { run(tok); }} {}
 
@@ -354,18 +355,21 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
     bool kb_src  = opts->hotkeys.kb_source && (opts->hotkeys.kb_source != 0x9999) && (GetAsyncKeyState(opts->hotkeys.kb_source) & 0x8000);
     bool kb_pp   = opts->hotkeys.kb_playpause && (opts->hotkeys.kb_playpause != 0x9999) && (GetAsyncKeyState(opts->hotkeys.kb_playpause) & 0x8000);
     bool kb_prev = opts->hotkeys.kb_prev && (opts->hotkeys.kb_prev != 0x9999) && (GetAsyncKeyState(opts->hotkeys.kb_prev) & 0x8000);
+    bool kb_station = opts->hotkeys.kb_next_station && (opts->hotkeys.kb_next_station != 0x9999) && (GetAsyncKeyState(opts->hotkeys.kb_next_station) & 0x8000);
 
     // check controller (resolve overlap by complexity)
     bool p_skip = check_pad(opts->hotkeys.pad_skip);
     bool p_src  = check_pad(opts->hotkeys.pad_source);
     bool p_pp   = check_pad(opts->hotkeys.pad_playpause);
     bool p_prev = check_pad(opts->hotkeys.pad_prev);
+    bool p_station  = check_pad(opts->hotkeys.pad_next_station);
 
     DWORD max_bits = std::max<DWORD>({
         p_skip ? static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_skip))) : 0u,
         p_src  ? static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_source))) : 0u,
-        p_pp   ? static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_playpause))) : 0u
-        p_prev ? static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_prev))) : 0u
+        p_pp   ? static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_playpause))) : 0u,
+        p_prev ? static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_prev))) : 0u,
+        p_station ? static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_next_station))) : 0u
     });
 
     bool pad_skip_pressed = p_skip && (static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_skip))) == max_bits);
@@ -377,22 +381,25 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
     bool src_pressed  = kb_src || pad_src_pressed;
     bool pp_pressed   = kb_pp || pad_pp_pressed;
     bool prev_pressed   = kb_prev || pad_prev_pressed;
+    bool station_pressed     = kb_station || pad_station_pressed;
 
     // --- quickStationSkip (R10 edge) ---
     const bool use_old_skip = (opts->hotkeys.kb_skip      == 0x9999 || opts->hotkeys.pad_skip      == 0x9999);
     const bool use_old_src  = (opts->hotkeys.kb_source    == 0x9999 || opts->hotkeys.pad_source    == 0x9999);
     const bool use_old_pp   = (opts->hotkeys.kb_playpause == 0x9999 || opts->hotkeys.pad_playpause == 0x9999);
     const bool use_old_prev = (opts->hotkeys.kb_prev      == 0x9999 || opts->hotkeys.pad_prev      == 0x9999);
-
+    const bool use_old_station = (opts->hotkeys.kb_next_station == 0x9999 || opts->hotkeys.pad_next_station == 0x9999);
+    
     if (prev_r10_ && !r10) {
         last_r10_off_ = now;
-        if (use_old_skip || use_old_src || use_old_pp || use_old_prev) quick_skip_armed_ = true;
+        if (use_old_skip || use_old_src || use_old_pp || use_old_prev || use_old_station) quick_skip_armed_ = true;
     } else if (!prev_r10_ && r10) {
         if (quick_skip_armed_ && now - last_r10_off_ <= kQuickSkipWindow) {
             if (use_old_skip) old_method_skip_fired_ = true;
             if (use_old_src)  old_method_src_fired_  = true;
             if (use_old_pp)   old_method_pp_fired_   = true;
             if (use_old_prev) old_method_prev_fired_ = true;
+            if (use_old_station) old_method_station_fired_ = true;
         }
         quick_skip_armed_ = false;
     }
@@ -403,30 +410,34 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
     bool src_edge  = src_pressed && !prev_source_hotkey_;
     bool pp_edge   = pp_pressed && !prev_playpause_hotkey_;
     bool prev_edge = prev_pressed && !prev_prev_hotkey_;
+    bool station_edge = station_pressed && !prev_station_hotkey_;
 
     // buffer
     if (skip_edge) pending_skip_ = true;
     if (src_edge)  pending_src_ = true;
     if (pp_edge)   pending_pp_ = true;
     if (prev_edge) pending_prev_ = true;
+    if (station_edge) pending_station_ = true;
 
     bool trigger_skip = old_method_skip_fired_;
     bool trigger_src  = old_method_src_fired_;
     bool trigger_pp   = old_method_pp_fired_;
     bool trigger_prev = old_method_prev_fired_;
+    bool trigger_station = old_method_station_fired_;
     old_method_skip_fired_ = false;
     old_method_src_fired_  = false;
     old_method_pp_fired_   = false;
     old_method_prev_fired_ = false;
+    old_method_station_fired_ = false;
 
     // track how long buttons have been held to allow combos to form
-    if (skip_pressed || src_pressed || pp_pressed || prev_pressed) {
+    if (skip_pressed || src_pressed || pp_pressed || prev_pressed || station_pressed) {
         if (combo_wait_ticks_ >= 0) {
             combo_wait_ticks_++;
         }
     } else {
         combo_wait_ticks_ = 0;
-        pending_skip_ = pending_src_ = pending_pp_ = pending_prev_ = false;
+        pending_skip_ = pending_src_ = pending_pp_ = pending_prev_ = pending_station_ = false;
     }
 
     // trigger combos immediately, delay single buttons by 3 ticks (~60ms) to prevent overlap
@@ -439,10 +450,12 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
             trigger_skip = true;
         } else if (pending_prev_ && max_bits == static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_prev)))) {
             trigger_prev = true;
+        } else if (pending_station_ && max_bits == static_cast<DWORD>(std::popcount(static_cast<uint32_t>(opts->hotkeys.pad_next_station)))) {
+            trigger_station = true;
         }
 
         // clear pending states
-        pending_skip_ = pending_src_ = pending_pp_ = pending_prev_ = false;
+        pending_skip_ = pending_src_ = pending_pp_ = pending_prev_ = pending_station_ = false;
         
         // set to a negative number to prevent firing again until buttons are released
         combo_wait_ticks_ = -9999; 
@@ -493,10 +506,19 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
         log::info("[ctrl] Hotkey triggered: returned to previous track");
     }
 
+    // execute cycle station/playlist
+    if (trigger_station && (now - last_station_cmd_ >= 250ms)) {
+        if (on_cycle_station_) on_cycle_station_();
+        ring.drain();
+        last_station_cmd_ = now;
+        log::info("[ctrl] Hotkey triggered: cycled active station");
+    }
+
     prev_skip_hotkey_ = skip_pressed;
     prev_source_hotkey_ = src_pressed;
     prev_playpause_hotkey_ = pp_pressed;
     prev_prev_hotkey_ = prev_pressed;
+    prev_station_hotkey_ = station_pressed;
 }
 
 void ControlLoop::push_metadata() noexcept {

--- a/src/fmod/dsp_control_loop.cpp
+++ b/src/fmod/dsp_control_loop.cpp
@@ -351,11 +351,32 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
     };
 
     // check keyboard (direct)
-    bool kb_skip = opts->hotkeys.kb_skip && (opts->hotkeys.kb_skip != 0x9999) && (GetAsyncKeyState(opts->hotkeys.kb_skip) & 0x8000);
-    bool kb_src  = opts->hotkeys.kb_source && (opts->hotkeys.kb_source != 0x9999) && (GetAsyncKeyState(opts->hotkeys.kb_source) & 0x8000);
-    bool kb_pp   = opts->hotkeys.kb_playpause && (opts->hotkeys.kb_playpause != 0x9999) && (GetAsyncKeyState(opts->hotkeys.kb_playpause) & 0x8000);
-    bool kb_prev = opts->hotkeys.kb_prev && (opts->hotkeys.kb_prev != 0x9999) && (GetAsyncKeyState(opts->hotkeys.kb_prev) & 0x8000);
-    bool kb_station = opts->hotkeys.kb_next_station && (opts->hotkeys.kb_next_station != 0x9999) && (GetAsyncKeyState(opts->hotkeys.kb_next_station) & 0x8000);
+    // helper function to decode keyboard combinations
+    auto check_kb = [](int bind) {
+        if (!bind || bind == 0x9999) return false;
+        
+        int vk = bind & 0xFF;
+        bool shift_req = (bind & 0x0100) != 0;
+        bool ctrl_req  = (bind & 0x0200) != 0;
+        bool alt_req   = (bind & 0x0400) != 0;
+
+        // check if the base key is physically pressed
+        if (!(GetAsyncKeyState(vk) & 0x8000)) return false;
+
+        // strictly check if the modifiers match the requirement
+        bool shift_down = (GetAsyncKeyState(VK_SHIFT) & 0x8000) != 0;
+        bool ctrl_down  = (GetAsyncKeyState(VK_CONTROL) & 0x8000) != 0;
+        bool alt_down   = (GetAsyncKeyState(VK_MENU) & 0x8000) != 0;
+
+        return (shift_req == shift_down) && (ctrl_req == ctrl_down) && (alt_req == alt_down);
+    };
+
+    // evaluate keyboard inputs
+    bool kb_skip    = check_kb(opts->hotkeys.kb_skip);
+    bool kb_src     = check_kb(opts->hotkeys.kb_source);
+    bool kb_pp      = check_kb(opts->hotkeys.kb_playpause);
+    bool kb_prev    = check_kb(opts->hotkeys.kb_prev);
+    bool kb_station = check_kb(opts->hotkeys.kb_next_station);
 
     // check controller (resolve overlap by complexity)
     bool p_skip = check_pad(opts->hotkeys.pad_skip);
@@ -413,13 +434,6 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
     bool prev_edge = prev_pressed && !prev_prev_hotkey_;
     bool station_edge = station_pressed && !prev_station_hotkey_;
 
-    // buffer
-    if (skip_edge) pending_skip_ = true;
-    if (src_edge)  pending_src_ = true;
-    if (pp_edge)   pending_pp_ = true;
-    if (prev_edge) pending_prev_ = true;
-    if (station_edge) pending_station_ = true;
-
     bool trigger_skip = old_method_skip_fired_;
     bool trigger_src  = old_method_src_fired_;
     bool trigger_pp   = old_method_pp_fired_;
@@ -431,8 +445,30 @@ void ControlLoop::run_playback_state_machines(time_point now) noexcept {
     old_method_prev_fired_ = false;
     old_method_station_fired_ = false;
 
+    // buffer controller inputs or fire keyboard immediately
+    if (skip_edge) {
+        if (kb_skip) trigger_skip = true;
+        else pending_skip_ = true;
+    }
+    if (src_edge) {
+        if (kb_src) trigger_src = true;
+        else pending_src_ = true;
+    }
+    if (pp_edge) {
+        if (kb_pp) trigger_pp = true;
+        else pending_pp_ = true;
+    }
+    if (prev_edge) {
+        if (kb_prev) trigger_prev = true;
+        else pending_prev_ = true;
+    }
+    if (station_edge) {
+        if (kb_station) trigger_station = true;
+        else pending_station_ = true;
+    }
+
     // track how long buttons have been held to allow combos to form
-    if (skip_pressed || src_pressed || pp_pressed || prev_pressed || station_pressed) {
+    if (pad_skip_pressed || pad_src_pressed || pad_pp_pressed || pad_prev_pressed || pad_station_pressed) {
         if (combo_wait_ticks_ >= 0) {
             combo_wait_ticks_++;
         }

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -285,6 +285,10 @@ json config_to_json(const Config& c) {
              {"pad_source", c.playback.hotkeys.pad_source},
              {"kb_playpause", c.playback.hotkeys.kb_playpause},
              {"pad_playpause", c.playback.hotkeys.pad_playpause},
+             {"kb_prev", c.playback.hotkeys.kb_prev},
+             {"pad_prev", c.playback.hotkeys.pad_prev},
+             {"kb_next_station", c.playback.hotkeys.kb_next_station},
+             {"pad_next_station", c.playback.hotkeys.pad_next_station},
          }},
     };
 }
@@ -451,6 +455,14 @@ void apply_patch(Config& c, const json& j) {
             pull(*it, "kb_playpause", c.playback.hotkeys.kb_playpause);
         c.playback.hotkeys.pad_playpause = 
             pull(*it, "pad_playpause", c.playback.hotkeys.pad_playpause);
+        c.playback.hotkeys.kb_prev = 
+            pull(*it, "kb_prev", c.playback.hotkeys.kb_prev);
+        c.playback.hotkeys.pad_prev = 
+            pull(*it, "pad_prev", c.playback.hotkeys.pad_prev);
+        c.playback.hotkeys.kb_next_station = 
+            pull(*it, "kb_next_station", c.playback.hotkeys.kb_next_station);
+        c.playback.hotkeys.pad_next_station = 
+            pull(*it, "pad_next_station", c.playback.hotkeys.pad_next_station);
     }
 }
 

--- a/src/sources/external_audio_source.cpp
+++ b/src/sources/external_audio_source.cpp
@@ -586,6 +586,11 @@ bool ExternalAudioSource::skip_next() {
     return true; 
 }
 
+bool ExternalAudioSource::restart_current() {
+    previous();
+    return true;
+}
+
 void ExternalAudioSource::pump(RingBuffer& ring) {
     if (state_.load(std::memory_order_acquire) != PlaybackState::playing) return;
 

--- a/src/sources/local_file_source.cpp
+++ b/src/sources/local_file_source.cpp
@@ -106,12 +106,40 @@ std::string sniff_image_mime(const std::string& d) noexcept {
 // 8 MiB cap: covers are small and an unbounded read could balloon.
 ArtworkImage extract_cover(const std::wstring& ff_bin, const std::filesystem::path& file,
                            worker::WorkerClient* worker) {
+                           
+    // create a unique temporary file path to prevent collisions
+    auto now = std::chrono::steady_clock::now().time_since_epoch().count();
+    std::filesystem::path tmp = std::filesystem::temp_directory_path() / 
+                                ("fh6_cover_" + std::to_string(now) + ".jpg");
+
+    // tell FFmpeg to save the image directly to the temp file
     const std::wstring cmd =
         quote(ff_bin) + L" -hide_banner -nostdin -loglevel error -i " + quote(file.wstring()) +
-        L" -an -c:v copy -frames:v 1 -f image2pipe pipe:1";
+        L" -an -c:v mjpeg -frames:v 1 -y " + quote(tmp.wstring());
 
-    std::string data = (worker && worker->alive()) ? worker->run_capture(cmd)
-                                                    : capture_output(cmd, false, 8u << 20);
+    // output is written to disk
+    if (worker && worker->alive()) {
+        worker->run_capture(cmd);
+    } else {
+        capture_output(cmd, false, 0);
+    }
+
+    // read the pristine binary data back from the temp file
+    std::string data;
+    std::ifstream is{tmp, std::ios::binary | std::ios::ate};
+    if (is) {
+        auto size = is.tellg();
+        is.seekg(0, std::ios::beg);
+        if (size > 0 && size <= (8u << 20)) { // cap at 8MB
+            data.resize(size);
+            is.read(data.data(), size);
+        }
+    }
+    
+    // clean up
+    std::error_code ec;
+    std::filesystem::remove(tmp, ec);
+
     ArtworkImage out;
     out.mime = sniff_image_mime(data);
     if (!out.mime.empty()) out.bytes = std::move(data);
@@ -957,6 +985,7 @@ std::optional<ArtworkImage> LocalFileSource::artwork() const {
 
 void LocalFileSource::set_config(LocalFilesConfig cfg) {
     bool rescan;
+    bool station_changed;
     {
         std::scoped_lock lk{mu_};
         const LocalStation* o        = active_station_locked();
@@ -966,20 +995,32 @@ void LocalFileSource::set_config(LocalFilesConfig cfg) {
         cfg_                         = std::move(cfg);
         const LocalStation* n        = active_station_locked();
         const LocalStation neu       = n ? *n : LocalStation{};
+        station_changed = old_active != cfg_.active_station;
         rescan = old_active != cfg_.active_station || old.roots != neu.roots ||
                  old.excluded != neu.excluded || old.recursive != neu.recursive ||
                  old.order != neu.order || old.grouping != neu.grouping ||
                  old_formats != cfg_.supported_formats;
     }
+
+    if (station_changed) stop();
+
     if (rescan) rebuild_playlist();
 }
 
 void LocalFileSource::set_active_station(std::string name) {
+    bool changed = false;
     {
         std::scoped_lock lk{mu_};
         if (cfg_.active_station == name) return;
         cfg_.active_station = std::move(name);
+        changed = true;
     }
+
+    if (changed) {
+        stop();
+        rebuild_playlist();
+    }
+
     rebuild_playlist();
 }
 

--- a/src/sources/local_file_source.cpp
+++ b/src/sources/local_file_source.cpp
@@ -105,17 +105,19 @@ std::string sniff_image_mime(const std::string& d) noexcept {
 // Copy the embedded cover out via one ffmpeg pass; empty when there's none.
 // 8 MiB cap: covers are small and an unbounded read could balloon.
 ArtworkImage extract_cover(const std::wstring& ff_bin, const std::filesystem::path& file,
-                           worker::WorkerClient* worker) {
-                           
+                           worker::WorkerClient* worker) {          
     // create a unique temporary file path to prevent collisions
-    auto now = std::chrono::steady_clock::now().time_since_epoch().count();
-    std::filesystem::path tmp = std::filesystem::temp_directory_path() / 
-                                ("fh6_cover_" + std::to_string(now) + ".jpg");
+    wchar_t temp_dir[MAX_PATH];
+    GetTempPathW(MAX_PATH, temp_dir);
+    wchar_t temp_file[MAX_PATH];
+    GetTempFileNameW(temp_dir, L"fh6", 0, temp_file);
+    
+    std::filesystem::path tmp{temp_file};
 
     // tell FFmpeg to save the image directly to the temp file
     const std::wstring cmd =
         quote(ff_bin) + L" -hide_banner -nostdin -loglevel error -i " + quote(file.wstring()) +
-        L" -an -c:v mjpeg -frames:v 1 -y " + quote(tmp.wstring());
+        L" -an -c:v mjpeg -frames:v 1 -f mjpeg -y " + quote(tmp.wstring());
 
     // output is written to disk
     if (worker && worker->alive()) {
@@ -1008,19 +1010,12 @@ void LocalFileSource::set_config(LocalFilesConfig cfg) {
 }
 
 void LocalFileSource::set_active_station(std::string name) {
-    bool changed = false;
     {
         std::scoped_lock lk{mu_};
         if (cfg_.active_station == name) return;
         cfg_.active_station = std::move(name);
-        changed = true;
     }
-
-    if (changed) {
-        stop();
-        rebuild_playlist();
-    }
-
+    stop();
     rebuild_playlist();
 }
 

--- a/src/sources/spotify_source.cpp
+++ b/src/sources/spotify_source.cpp
@@ -132,7 +132,7 @@ bool SpotifySource::initialize() {
     std::filesystem::create_directories(cfg_.cache_dir, ec);
     if (ec) {
         log::warn("[spotify] cannot create cache dir {} ({})", cfg_.cache_dir.string(),
-                  ec.message());
+                ec.message());
         return false;
     }
     return true;
@@ -164,9 +164,9 @@ AuthState SpotifySource::auth_state() const noexcept {
 
 std::string SpotifySource::auth_instructions() const {
     return "1. Ensure your PC and phone are on the same Wi-Fi network.\n"
-           "2. Open the Spotify app on your phone.\n"
-           "3. Tap the 'Devices' icon and select 'FH6 Universal Radio'.\n"
-           "Once connected, credentials will automatically save to the cache folder.";
+        "2. Open the Spotify app on your phone.\n"
+        "3. Tap the 'Devices' icon and select 'FH6 Universal Radio'.\n"
+        "Once connected, credentials will automatically save to the cache folder.";
 }
 
 void SpotifySource::start_pipe_locked() {
@@ -186,9 +186,9 @@ void SpotifySource::start_pipe_locked() {
     // librespot defaults to 44100Hz s16le. We must resample to 48000Hz for FH6.
     // added flags to disable FFmpeg internal buffering for perfect UI sync
     std::wstring ff_cmd = quote(ff) + L" -loglevel error" + L" -fflags nobuffer -flags low_delay" +
-                          L" -blocksize 4096" + // force micro-block processing
-                          L" -f s16le -ar 44100 -ac 2 -i pipe:0" + L" -flush_packets 1" +
-                          L" -f s16le -acodec pcm_s16le -ar 48000 -ac 2 pipe:1";
+                        L" -blocksize 4096" + // force micro-block processing
+                        L" -f s16le -ar 44100 -ac 2 -i pipe:0" + L" -flush_packets 1" +
+                        L" -f s16le -acodec pcm_s16le -ar 48000 -ac 2 pipe:1";
 
     // request debug logs for the player module to intercept Seek events & metadata
     SetEnvironmentVariableW(L"RUST_LOG",
@@ -286,8 +286,8 @@ void SpotifySource::start_pipe_locked() {
 
     if (!pipe->proc_spot) {
         log::warn("[spotify] failed to launch librespot -- {} (check {})",
-                  describe_launch_failure(std::wstring{spot}, ec_spot, !cfg_.librespot_path.empty()),
-                  stderr_log_path().string());
+                describe_launch_failure(std::wstring{spot}, ec_spot, !cfg_.librespot_path.empty()),
+                stderr_log_path().string());
         bail();
         return;
     }
@@ -312,8 +312,8 @@ void SpotifySource::start_pipe_locked() {
 
     if (!pipe->proc_ff) {
         log::warn("[spotify] failed to launch ffmpeg -- {} (check {})",
-                  describe_launch_failure(std::wstring{ff}, ec_ff, !ffmpeg_path_.empty()),
-                  stderr_log_path().string());
+                describe_launch_failure(std::wstring{ff}, ec_ff, !ffmpeg_path_.empty()),
+                stderr_log_path().string());
         bail(); // clean up unassigned pipe handles
         return;
     }
@@ -371,6 +371,11 @@ void SpotifySource::transport_skip(bool forward) {
 void SpotifySource::next() { transport_skip(true); }
 void SpotifySource::previous() { transport_skip(false); }
 
+bool SpotifySource::restart_current() {
+    previous();
+    return true;
+}
+
 TrackInfo SpotifySource::current_track() const {
     std::scoped_lock lk{mu_};
     return info_;
@@ -387,7 +392,7 @@ void SpotifySource::pump(RingBuffer& ring) {
 
     // Adopt a track's metadata into the now-playing info
     auto apply_info = [&](const std::string& title, const std::string& artist,
-                          const std::string& album, uint64_t dur, const std::string& cover_url) {
+                        const std::string& album, uint64_t dur, const std::string& cover_url) {
         info_.title          = title;
         info_.artist         = artist;
         info_.album          = album;
@@ -404,8 +409,8 @@ void SpotifySource::pump(RingBuffer& ring) {
 
         // process a maximum of 16KB of logs per pump cycle
         while (safety++ < 16 &&
-               PeekNamedPipe(p->err_pipe, nullptr, 0, nullptr, &err_avail, nullptr) &&
-               err_avail > 0) {
+            PeekNamedPipe(p->err_pipe, nullptr, 0, nullptr, &err_avail, nullptr) &&
+            err_avail > 0) {
             char buf[1024];
             DWORD to_read = std::min<DWORD>(err_avail, (DWORD)sizeof(buf));
             DWORD got     = 0;
@@ -436,7 +441,7 @@ void SpotifySource::pump(RingBuffer& ring) {
                     std::string out_line = line + "\r\n";
                     DWORD w              = 0;
                     WriteFile(p->log_file, out_line.data(), static_cast<DWORD>(out_line.size()), &w,
-                              nullptr);
+                            nullptr);
                 }
 
                 if (is_trace_start &&
@@ -491,7 +496,7 @@ void SpotifySource::pump(RingBuffer& ring) {
                             }
                             p->next_meta_cover_bytes.clear(); // retry the next image on a bad parse
                         } else if (size_t d = line.find_first_of("0123456789");
-                                   d != std::string::npos) {
+                                d != std::string::npos) {
                             try {
                                 int val = std::stoi(line.substr(d));
                                 if (val >= 0 && val <= 255)
@@ -511,7 +516,7 @@ void SpotifySource::pump(RingBuffer& ring) {
                                 p->next_meta_title.empty()) {
                                 p->next_meta_title = val;
                             } else if (p->meta_context == Pipe::MetaContext::Album &&
-                                       p->next_meta_album.empty()) {
+                                    p->next_meta_album.empty()) {
                                 p->next_meta_album = val;
                             } else if (p->meta_context == Pipe::MetaContext::Artist) {
                                 // librespot repeats artists across track/album; de-dup whole names
@@ -580,7 +585,7 @@ void SpotifySource::pump(RingBuffer& ring) {
                         // First track, an explicit skip, or an in-app skip: apply at once.
                         if (p->awaiting_first_track || p->force_next_metadata || is_external_skip) {
                             apply_info(final_title, final_artist, final_album, parsed_duration,
-                                       final_cover);
+                                    final_cover);
                             p->bytes_consumed       = 0;
                             p->awaiting_first_track = false;
                             p->force_next_metadata  = false;
@@ -617,7 +622,7 @@ void SpotifySource::pump(RingBuffer& ring) {
             // the user manually skipped during the final 30 seconds of the song
             if (p->has_pending) {
                 apply_info(p->pending_title, p->pending_artist, p->pending_album,
-                           p->pending_duration_ms, p->pending_cover_url);
+                        p->pending_duration_ms, p->pending_cover_url);
                 p->bytes_consumed = 0;
             }
             // catch-all for extreme network lag / dead stream (stall for > 800ms)
@@ -634,7 +639,7 @@ void SpotifySource::pump(RingBuffer& ring) {
         uint64_t track_bytes = p->track_duration_ms * kBytesPerMs;
         if (p->bytes_consumed >= track_bytes) {
             apply_info(p->pending_title, p->pending_artist, p->pending_album,
-                       p->pending_duration_ms, p->pending_cover_url);
+                    p->pending_duration_ms, p->pending_cover_url);
             // carry the remainder so the timer stays exact
             p->bytes_consumed -= track_bytes;
             p->stall_ticks     = 0;

--- a/src/sources/spotify_source.cpp
+++ b/src/sources/spotify_source.cpp
@@ -177,11 +177,10 @@ void SpotifySource::start_pipe_locked() {
     const auto spot = cfg_.librespot_path.empty() ? L"librespot" : cfg_.librespot_path.wstring();
     const std::wstring ff = ffmpeg_path_.empty() ? std::wstring{L"ffmpeg"} : ffmpeg_path_.wstring();
     const auto cache      = cfg_.cache_dir.wstring();
-    const auto tmp_dir    = (cfg_.cache_dir / L"tmp").wstring();
 
     std::wstring spot_cmd = quote(spot) + L" --name \"FH6 Universal Radio\"" + L" --bitrate 320" +
                             L" --backend pipe" + L" --initial-volume 100" + L" --cache " +
-                            quote(cache) + L" --tmp " + quote(tmp_dir) + L" --disable-audio-cache";
+                            quote(cache) + L" --disable-audio-cache";
 
     // librespot defaults to 44100Hz s16le. We must resample to 48000Hz for FH6.
     // added flags to disable FFmpeg internal buffering for perfect UI sync

--- a/ui/dist/js/render/jellyfin.js
+++ b/ui/dist/js/render/jellyfin.js
@@ -256,6 +256,15 @@ export function createJellyfin(main, ctx) {
     load();
 
     const jfDetails = state?.sources?.available?.find(s => s.name === "jellyfin")?.details;
+
+    const liveActiveStation = jfDetails?.active_station;
+    if (loaded && liveActiveStation && liveActiveStation !== activeStation) {
+      activeStation = liveActiveStation;
+      selected = Math.max(0, stations.findIndex(s => s.name === activeStation));
+      renderEditor();
+      loadQueue();
+    }
+    
     const shuffleOn = !!jfDetails?.shuffle;
     shuffleBtn.classList.toggle("toggled", shuffleOn);
     shuffleBtn.setAttribute("aria-pressed", String(shuffleOn));

--- a/ui/dist/js/render/localFiles.js
+++ b/ui/dist/js/render/localFiles.js
@@ -438,6 +438,7 @@ export function createLocalFiles(main, ctx) {
   // --- lifecycle ------------------------------------------------------------
   let lastTrackCount = -1;
   let lastIndexVersion = -1;
+  let lastTrackSig = ""; 
   function render() {
     const state = ctx.getState();
     const isActive = state?.sources?.active === "local_files";
@@ -454,12 +455,14 @@ export function createLocalFiles(main, ctx) {
       selected = Math.max(0, stations.findIndex(s => s.name === activeStation));
       renderEditor();
     }
-    
+
     const tc = lf?.details?.track_count ?? -1;
     const iv = lf?.details?.index_version ?? -1;
-    if (loaded && (tc !== lastTrackCount || iv !== lastIndexVersion)) {
+    const currentTrackSig = state?.track?.title + "|" + state?.track?.artist;
+    if (loaded && (tc !== lastTrackCount || iv !== lastIndexVersion || currentTrackSig !== lastTrackSig)) {
       lastTrackCount = tc;
       lastIndexVersion = iv;
+      lastTrackSig = currentTrackSig; // update the signature
       loadQueue();
     }
   }

--- a/ui/dist/js/render/localFiles.js
+++ b/ui/dist/js/render/localFiles.js
@@ -447,6 +447,14 @@ export function createLocalFiles(main, ctx) {
     // Refresh the queue (titles, artists, current-track highlight) when the
     // track count changes (rescan) or the metadata index advances.
     const lf = state?.sources?.available?.find(s => s.name === "local_files");
+
+    const liveActiveStation = lf?.details?.active_station;
+    if (loaded && liveActiveStation && liveActiveStation !== activeStation) {
+      activeStation = liveActiveStation;
+      selected = Math.max(0, stations.findIndex(s => s.name === activeStation));
+      renderEditor();
+    }
+    
     const tc = lf?.details?.track_count ?? -1;
     const iv = lf?.details?.index_version ?? -1;
     if (loaded && (tc !== lastTrackCount || iv !== lastIndexVersion)) {

--- a/ui/dist/js/render/settings.js
+++ b/ui/dist/js/render/settings.js
@@ -77,6 +77,159 @@ function buildField(section, spec, cfg) {
     return el("div", { class: "field bands" }, [el("label", {}, label), ...rows]);
   }
 
+  if (type === "keybind-kb" || type === "keybind-pad") {
+    const isPad = type === "keybind-pad";
+    const optionsData = a || [];
+
+    const curNum = Number(cur || 0);
+    const isPredefined = optionsData.some(([val]) => val === curNum);
+    const isCustom = !isPredefined;
+
+    const select = el("select", {}, optionsData.map(([val, lbl]) => {
+      return el("option", { value: String(val), selected: val === curNum }, lbl);
+    }));
+    select.append(el("option", { value: "custom", selected: isCustom }, "Custom..."));
+    
+    // --- naming helpers ---
+    const formatKb = (code) => {
+      if (!code) return "";
+      const vk = code & 0xFF; // base key
+      const shift = (code & 0x0100) ? "Shift + " : "";
+      const ctrl = (code & 0x0200) ? "Ctrl + " : "";
+      const alt = (code & 0x0400) ? "Alt + " : "";
+      
+      let baseKey = vk;
+      // convert standard letters and numbers to characters
+      if ((vk >= 65 && vk <= 90) || (vk >= 48 && vk <= 57)) {
+         baseKey = String.fromCharCode(vk);
+      }
+      return `${ctrl}${shift}${alt}${baseKey}`;
+    };
+    
+    const padMap = {
+      0x1000: "A", 0x2000: "B", 0x4000: "X", 0x8000: "Y",
+      0x0100: "LB", 0x0200: "RB", 0x0020: "View", 0x0010: "Menu",
+      0x0040: "LS", 0x0080: "RS", 0x0001: "D-Up", 0x0002: "D-Down",
+      0x0004: "D-Left", 0x0008: "D-Right"
+    };
+
+    const formatPad = (code) => {
+      if (!code) return "";
+      const hex = "0x" + code.toString(16).toUpperCase();
+
+      const pressedNames = [];
+      const orderedKeys = [
+        0x0100, 0x0200, 0x4000, 0x8000, 0x1000, 0x2000, // bumpers, face buttons
+        0x0040, 0x0080, 0x0020, 0x0010, 0x0001, 0x0002, 0x0004, 0x0008 // sticks, d-pad
+      ];
+      
+      for (const k of orderedKeys) {
+        if ((code & k) === k) pressedNames.push(padMap[k]);
+      }
+      
+      return pressedNames.length > 0 ? `${hex} (${pressedNames.join(" + ")})` : hex;
+    };
+
+    const initialCustomStr = isPad ? formatPad(curNum) : formatKb(curNum);
+
+    // --- create custom input ---
+    const customInput = el("input", {
+      type: "text",
+      placeholder: isPad ? "Click and press a controller button..." : "Click and press a key...",
+      readOnly: true,
+      value: isCustom ? initialCustomStr : ""
+    });
+
+    customInput.style.marginTop = "0.5rem";
+    customInput.style.display = isCustom ? "block" : "none";
+
+    const customDataset = isPad ? { isHex: "1" } : { isNumeric: "1" };
+    const hiddenInput = el("input", {
+      type: "hidden",
+      id,
+      dataset: { ...dataset, ...customDataset },
+      value: isCustom ? initialCustomStr : curNum
+    });
+
+    // --- dropdown logic ---
+    select.addEventListener("change", () => {
+      if (select.value === "custom") {
+        customInput.style.display = "block";
+        customInput.focus();
+        hiddenInput.value = customInput.value || 0;
+      } else {
+        customInput.style.display = "none";
+        hiddenInput.value = select.value;
+      }
+    });
+
+    // --- input capturing ---
+    if (!isPad) {
+      customInput.addEventListener("keydown", (e) => {
+        e.preventDefault();
+        
+        if (e.keyCode === 27) { // escape clears the bind
+          customInput.value = "";
+          hiddenInput.value = "0";
+          return;
+        }
+        
+        // ignore solitary modifier presses
+        if (e.keyCode === 16 || e.keyCode === 17 || e.keyCode === 18) return; 
+
+        let mask = e.keyCode;
+        
+        // pack modifier states into the higher bits
+        if (e.shiftKey) mask |= 0x0100;
+        if (e.ctrlKey)  mask |= 0x0200;
+        if (e.altKey)   mask |= 0x0400;
+
+        customInput.value = formatKb(mask);
+        if (select.value === "custom") hiddenInput.value = mask;
+      });
+    } else {
+      // gamepad API polling for controllers
+      let padInterval;
+      const gpMap = [
+        0x1000, 0x2000, 0x4000, 0x8000, 0x0100, 0x0200, null, null,
+        0x0020, 0x0010, 0x0040, 0x0080, 0x0001, 0x0002, 0x0004, 0x0008
+      ];
+      
+      customInput.addEventListener("focus", () => {
+        padInterval = setInterval(() => {
+          const gamepads = navigator.getGamepads ? navigator.getGamepads() : [];
+          for (let gp of gamepads) {
+            if (!gp) continue;
+            
+            let currentMask = 0;
+            
+            for (let i = 0; i < gp.buttons.length; i++) {
+              if (gp.buttons[i].pressed && gpMap[i]) {
+                // bitwise OR: adds the buttons hex value to running total
+                currentMask |= gpMap[i]; 
+              }
+            }
+
+            if (currentMask > 0) {
+              const str = formatPad(currentMask);
+              customInput.value = str;
+              if (select.value === "custom") hiddenInput.value = str; 
+            }
+          }
+        }, 50); // polls 20 times a second
+      });
+
+      customInput.addEventListener("blur", () => clearInterval(padInterval));
+    }
+
+    return el("div", { class: "field" }, [
+      el("label", { for: id }, label),
+      select,
+      customInput,
+      hiddenInput
+    ]);
+  }
+
   const input = el("input", { id, type, value: cur ?? "", dataset });
   if (type === "number") {
     if (a != null) input.min = String(a);
@@ -99,9 +252,11 @@ export function renderSettings(form, cfg) {
 export function collectSettings(form) {
   const patch = {};
   for (const node of $$("[data-section]", form)) {
-    const { section, key, index } = node.dataset;
+    const { section, key, index, isHex, isNumeric } = node.dataset;
     patch[section] ??= {};
-    if (index !== undefined) {
+    if (isHex || isNumeric) {
+      patch[section][key] = parseInt(node.value) || 0;
+    } else if (index !== undefined) {
       const band = (patch[section][key] ??= []);
       band[parseInt(index, 10)] = parseFloat(node.value);
     } else if (node.type === "checkbox") {

--- a/ui/dist/js/render/youtubeMusic.js
+++ b/ui/dist/js/render/youtubeMusic.js
@@ -248,6 +248,15 @@ export function createYoutubeMusic(main, ctx) {
     load();
 
     const ytDetails = state?.sources?.available?.find(s => s.name === "youtube_music")?.details;
+
+    const liveActiveStation = ytDetails?.active_station;
+    if (loaded && liveActiveStation && liveActiveStation !== activeStation) {
+      activeStation = liveActiveStation;
+      selected = Math.max(0, stations.findIndex(s => s.name === activeStation));
+      renderEditor();
+      loadQueue();
+    }
+    
     const shuffleOn = !!ytDetails?.shuffle;
     shuffleBtn.classList.toggle("toggled", shuffleOn);
     shuffleBtn.setAttribute("aria-pressed", String(shuffleOn));

--- a/ui/dist/js/schema.js
+++ b/ui/dist/js/schema.js
@@ -127,8 +127,10 @@ export const SCHEMA = [
     [
       ["kb_playpause", "Play / Pause (Keyboard)", "select-kv", KB_KEYS],
       ["pad_playpause", "Play / Pause (Controller)", "select-kv", PAD_BUTTONS],
-      ["kb_skip", "Skip Track (Keyboard)", "select-kv", KB_KEYS],
-      ["pad_skip", "Skip Track (Controller)", "select-kv", PAD_BUTTONS],
+      ["kb_skip", "Next Track (Keyboard)", "select-kv", KB_KEYS],
+      ["pad_skip", "Next Track (Controller)", "select-kv", PAD_BUTTONS],
+      ["kb_prev", "Previous Track (Keyboard)", "select-kv", KB_KEYS],
+      ["pad_prev", "Previous Track (Controller)", "select-kv", PAD_BUTTONS],
       ["kb_source", "Switch Source (Keyboard)", "select-kv", KB_KEYS],
       ["pad_source", "Switch Source (Controller)", "select-kv", PAD_BUTTONS],
     ]

--- a/ui/dist/js/schema.js
+++ b/ui/dist/js/schema.js
@@ -125,16 +125,16 @@ export const SCHEMA = [
     "hotkeys",
     "Global Hotkeys",
     [
-      ["kb_playpause", "Play / Pause (Keyboard)", "select-kv", KB_KEYS],
-      ["pad_playpause", "Play / Pause (Controller)", "select-kv", PAD_BUTTONS],
-      ["kb_skip", "Next Track (Keyboard)", "select-kv", KB_KEYS],
-      ["pad_skip", "Next Track (Controller)", "select-kv", PAD_BUTTONS],
-      ["kb_prev", "Previous Track (Keyboard)", "select-kv", KB_KEYS],
-      ["pad_prev", "Previous Track (Controller)", "select-kv", PAD_BUTTONS],
-      ["kb_next_station", "Cycle Station/Playlist (Keyboard)", "select-kv", KB_KEYS],
-      ["pad_next_station", "Cycle Station/Playlist (Controller)", "select-kv", PAD_BUTTONS],
-      ["kb_source", "Switch Source (Keyboard)", "select-kv", KB_KEYS],
-      ["pad_source", "Switch Source (Controller)", "select-kv", PAD_BUTTONS],
+      ["kb_playpause", "Play / Pause (Keyboard)", "keybind-kb", KB_KEYS],
+      ["pad_playpause", "Play / Pause (Controller)", "keybind-pad", PAD_BUTTONS],
+      ["kb_skip", "Next Track (Keyboard)", "keybind-kb", KB_KEYS],
+      ["pad_skip", "Next Track (Controller)", "keybind-pad", PAD_BUTTONS],
+      ["kb_prev", "Previous Track (Keyboard)", "keybind-kb", KB_KEYS],
+      ["pad_prev", "Previous Track (Controller)", "keybind-pad", PAD_BUTTONS],
+      ["kb_next_station", "Cycle Station/Playlist (Keyboard)", "keybind-kb", KB_KEYS],
+      ["pad_next_station", "Cycle Station/Playlist (Controller)", "keybind-pad", PAD_BUTTONS],
+      ["kb_source", "Switch Source (Keyboard)", "keybind-kb", KB_KEYS],
+      ["pad_source", "Switch Source (Controller)", "keybind-pad", PAD_BUTTONS],
     ]
   ]
 ];

--- a/ui/dist/js/schema.js
+++ b/ui/dist/js/schema.js
@@ -131,6 +131,8 @@ export const SCHEMA = [
       ["pad_skip", "Next Track (Controller)", "select-kv", PAD_BUTTONS],
       ["kb_prev", "Previous Track (Keyboard)", "select-kv", KB_KEYS],
       ["pad_prev", "Previous Track (Controller)", "select-kv", PAD_BUTTONS],
+      ["kb_next_station", "Cycle Station/Playlist (Keyboard)", "select-kv", KB_KEYS],
+      ["pad_next_station", "Cycle Station/Playlist (Controller)", "select-kv", PAD_BUTTONS],
       ["kb_source", "Switch Source (Keyboard)", "select-kv", KB_KEYS],
       ["pad_source", "Switch Source (Controller)", "select-kv", PAD_BUTTONS],
     ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable hotkeys for **previous** and **next station/playlist** on keyboard and gamepad.
  * Added **“restart current”** support for **external audio** and **Spotify** sources.
* **Improvements**
  * Station/playlist cycling now supports the next active selection, with previous where available.
  * Auto-play now resumes for additional active sources (YouTube Music, Jellyfin, Online Radio) after config updates.
  * Hotkey settings are now exported/imported via config JSON and reflected in the config example.
* **Bug Fixes**
  * Improved local file cover-art extraction and refined station switching to stop/rebuild more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->