### PR TITLE
fix(spotify): Loudness normalization

### DIFF
--- a/include/fh6/sources/spotify_source.hpp
+++ b/include/fh6/sources/spotify_source.hpp
@@ -27,6 +27,7 @@ public:
 
     // Settings drawer hot-update; new paths apply on the next pipe start.
     void set_config(SpotifyConfig cfg, std::filesystem::path ffmpeg_path);
+    void set_playback_options(const PlaybackConfig& opts) override;
 
     void play() override;
     void pause() override;
@@ -53,6 +54,7 @@ private:
     void stop_pipe_locked();           // mu_ held
     void transport_skip(bool forward); // shared next()/previous() body
     bool cache_exists() const;
+    bool volume_normalization_ = false;
 
     SpotifyConfig cfg_;
     std::filesystem::path ffmpeg_path_;

--- a/src/sources/spotify_source.cpp
+++ b/src/sources/spotify_source.cpp
@@ -147,6 +147,11 @@ void SpotifySource::set_config(SpotifyConfig cfg, std::filesystem::path ffmpeg_p
     ffmpeg_path_ = std::move(ffmpeg_path);
 }
 
+void SpotifySource::set_playback_options(const PlaybackConfig& opts) {
+    std::scoped_lock lk{mu_};
+    volume_normalization_ = opts.volume_normalization;
+}
+
 void SpotifySource::shutdown() noexcept {
     std::scoped_lock lk{mu_};
     stop_pipe_locked();
@@ -181,6 +186,10 @@ void SpotifySource::start_pipe_locked() {
     std::wstring spot_cmd = quote(spot) + L" --name \"FH6 Universal Radio\"" + L" --bitrate 320" +
                             L" --backend pipe" + L" --initial-volume 100" + L" --cache " +
                             quote(cache) + L" --disable-audio-cache";
+
+    if (volume_normalization_) {
+        spot_cmd += L" --enable-volume-normalisation";
+    }
 
     // librespot defaults to 44100Hz s16le. We must resample to 48000Hz for FH6.
     // added flags to disable FFmpeg internal buffering for perfect UI sync


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring Spotify playback options, including the ability to enable or disable volume normalization to improve audio consistency during playback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->