### PR TITLE
fix: Artwork support for legacy UI

### DIFF
--- a/include/fh6/fmod/texture_injector.hpp
+++ b/include/fh6/fmod/texture_injector.hpp
@@ -26,6 +26,8 @@ public:
     // lets the control loop know if currently building a new texture
     bool is_processing() const { return is_processing_.load(); }
 
+    void set_target_height(int height) { target_height_.store(height); }
+
     void set_worker_client(std::shared_ptr<worker::WorkerClient> w) { 
         std::lock_guard<std::mutex> lock(mtx_);
         worker_ = std::move(w); 
@@ -50,6 +52,7 @@ private:
 
     std::atomic<bool> is_processing_{false}; 
     std::atomic<uint64_t> latest_job_id_{0};
+    std::atomic<int> target_height_{0};
 
     std::shared_ptr<worker::WorkerClient> worker_;
     ConfigStore* config_store_ = nullptr;

--- a/src/fmod/texture_injector.cpp
+++ b/src/fmod/texture_injector.cpp
@@ -145,9 +145,19 @@ void TextureInjector::update_artwork_url(const std::string& url) {
             // calculate aspect-ratio preserving dimensions
             // wait until the DX12 hook discovers the target UI size
             int target_h = 0;
+            const auto height_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
             while ((target_h = target_height_.load()) == 0) {
                 if (latest_job_id_.load() != my_job_id) return;
+                if (std::chrono::steady_clock::now() >= height_deadline) {
+                    log::warn("[dx12] job {}: timed out waiting for target texture height", my_job_id);
+                    return;
+                }
                 std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            }
+
+            if (target_h != 104 && target_h != 196) {
+                log::warn("[dx12] job {}: unsupported target texture height {}", my_job_id, target_h);
+                return;
             }
 
             int square_size = 104;

--- a/src/fmod/texture_injector.cpp
+++ b/src/fmod/texture_injector.cpp
@@ -143,9 +143,15 @@ void TextureInjector::update_artwork_url(const std::string& url) {
             }
 
             // calculate aspect-ratio preserving dimensions
+            // wait until the DX12 hook discovers the target UI size
+            int target_h = 0;
+            while ((target_h = target_height_.load()) == 0) {
+                if (latest_job_id_.load() != my_job_id) return;
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            }
+
             int square_size = 104;
             int target_w = 196;
-            int target_h = 104;
             
             // border settings
             int border_thickness = is_default_artwork ? 0 : 4; 
@@ -160,7 +166,7 @@ void TextureInjector::update_artwork_url(const std::string& url) {
             stbir_resize_uint8_linear(img_data, width, height, 0, resized_data.data(), new_w, new_h, 0, STBIR_RGBA);
             stbi_image_free(img_data);
 
-            // create transparent padded canvas
+            // create transparent padded canvas to what DX12 requested
             std::vector<unsigned char> padded_data(target_w * target_h * 4, 0);
 
             // calculate source offsets to center-crop
@@ -190,23 +196,23 @@ void TextureInjector::update_artwork_url(const std::string& url) {
             unsigned char b_b = (unsigned char)(avg_b * brightness_factor);
             unsigned char b_a = 255;
 
-            // copy the cropped square into the far left, applying the border
-            for (int y = 0; y < square_size; ++y) {
+            // stretches the y-axis if target_h is 196
+            for (int y = 0; y < target_h; ++y) {
                 for (int x = 0; x < square_size; ++x) {
                     int dst_idx = (y * target_w + x) * 4; 
 
-                    // check if the current pixel falls within the border perimeter
+                    // map the current y back to the 104-pixel source space
+                    int orig_y = (y * square_size) / target_h; 
+
                     if (x < border_thickness || x >= square_size - border_thickness ||
-                        y < border_thickness || y >= square_size - border_thickness) {
+                        orig_y < border_thickness || orig_y >= square_size - border_thickness) {
                         
-                        // draw the dynamic border color
                         padded_data[dst_idx]   = b_r;
                         padded_data[dst_idx+1] = b_g;
                         padded_data[dst_idx+2] = b_b;
                         padded_data[dst_idx+3] = b_a;
                     } else {
-                        // draw the image pixel
-                        int src_idx = ((y + src_offset_y) * new_w + (x + src_offset_x)) * 4;
+                        int src_idx = ((orig_y + src_offset_y) * new_w + (x + src_offset_x)) * 4;
                         padded_data[dst_idx]   = resized_data[src_idx];
                         padded_data[dst_idx+1] = resized_data[src_idx+1];
                         padded_data[dst_idx+2] = resized_data[src_idx+2];
@@ -219,7 +225,8 @@ void TextureInjector::update_artwork_url(const std::string& url) {
 
             log::info("[dx12] job {}: compressing to BC7 with texconv...", my_job_id);
 
-            std::string texconv_cmd = "\"" + texconv_path + "\" -f BC7_UNORM -w 196 -h 104 -m 1 -pmalpha -gpu 0 -y -o \"" + temp_dir_str + "\" \"" + png_path + "\"";
+            // export to the dynamic size requested
+            std::string texconv_cmd = "\"" + texconv_path + "\" -f BC7_UNORM -w 196 -h " + std::to_string(target_h) + " -m 1 -pmalpha -gpu 0 -y -o \"" + temp_dir_str + "\" \"" + png_path + "\"";
             std::vector<char> cmd_buf(texconv_cmd.begin(), texconv_cmd.end());
             cmd_buf.push_back('\0');
             
@@ -270,7 +277,7 @@ void TextureInjector::update_artwork_url(const std::string& url) {
 
                             std::lock_guard<std::mutex> lock(mtx_);
                             width_ = 196; 
-                            height_ = 104;
+                            height_ = target_h;
                             pending_pixels_ = std::move(bc7_payload); 
                             has_new_image_ = true;
                             log::info("[dx12] job {} complete", my_job_id);

--- a/src/proxy/dll_main.cpp
+++ b/src/proxy/dll_main.cpp
@@ -23,7 +23,8 @@
 
 void InitDX12HookThread();
 
-uint64_t EXPECTED_STREAMER_HASH = 0x69F6C569FDFE6B09ULL; // hash for streamer mode logo
+uint64_t EXPECTED_STREAMER_HASH = 0x22BC7164008461C9ULL; // hash for streamer mode logo (196x104)
+uint64_t EXPECTED_ALT_HASH      = 0xF5223D52CFA65930ULL; // hash for modified icon (196x196)
 
 struct TrackedTexture {
     Microsoft::WRL::ComPtr<ID3D12Resource> ptr;
@@ -34,11 +35,16 @@ std::mutex g_TextureMutex;
 std::vector<TrackedTexture> g_UnverifiedResources;
 std::vector<Microsoft::WRL::ComPtr<ID3D12Resource>> g_StreamerModeResources;
 
-uint64_t CalculateFNV1a(const uint8_t* data, size_t length) {
+// hashes the packed pixel blocks, ignoring uninitialized GPU padding bytes in the buffer
+uint64_t CalculateFNV1aPitched(const uint8_t* data, UINT blocksX, UINT blocksY, UINT alignedRowPitch) {
     uint64_t hash = 0xcbf29ce484222325ull;
-    for (size_t i = 0; i < length; ++i) {
-        hash ^= data[i];
-        hash *= 0x100000001b3ull;
+    UINT tightRowPitch = blocksX * 16;
+    for (UINT y = 0; y < blocksY; ++y) {
+        const uint8_t* rowStart = data + (y * alignedRowPitch);
+        for (UINT x = 0; x < tightRowPitch; ++x) {
+            hash ^= rowStart[x];
+            hash *= 0x100000001b3ull;
+        }
     }
     return hash;
 }
@@ -54,7 +60,7 @@ bool IsTargetTexture(ID3D12Resource* pResource) {
     __try {
         D3D12_RESOURCE_DESC desc = pResource->GetDesc();
         return (desc.Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE2D && 
-                desc.Width == 196 && desc.Height == 104 &&
+                desc.Width == 196 && (desc.Height == 104 || desc.Height == 196) &&
                 (desc.Format == DXGI_FORMAT_BC7_UNORM || desc.Format == DXGI_FORMAT_BC7_UNORM_SRGB));
     } __except (EXCEPTION_EXECUTE_HANDLER) {
         return false; 
@@ -64,10 +70,15 @@ bool IsTargetTexture(ID3D12Resource* pResource) {
 void ProcessFingerprintResult(uint64_t hash, ID3D12Resource* pRes) {
     fh6::log::info("[dx12] fingerprint checksum: 0x{:X}", hash);
     
-    if (EXPECTED_STREAMER_HASH == 0 || hash == EXPECTED_STREAMER_HASH) {
+    if (EXPECTED_STREAMER_HASH == 0 || hash == EXPECTED_STREAMER_HASH || hash == EXPECTED_ALT_HASH) {
         std::lock_guard<std::mutex> lock(g_TextureMutex);
         g_StreamerModeResources.emplace_back(pRes);
-        fh6::log::info("[dx12] ---> added to streamer mode array");
+        
+        // notify TextureInjector of the UI height required
+        D3D12_RESOURCE_DESC desc = pRes->GetDesc();
+        fh6::TextureInjector::instance().set_target_height(desc.Height);
+
+        fh6::log::info("[dx12] ---> added to streamer mode array, requesting {}px payload", desc.Height);
     }
 }
 
@@ -78,7 +89,6 @@ __declspec(noinline) bool SafeExecuteFingerprint(
     ID3D12CommandAllocator* pRbAllocator,
     ID3D12Resource* pReadbackRes,
     UINT alignedRowPitch,
-    UINT64 readbackSize,
     ID3D12Resource* pRes)
 {
     __try {
@@ -97,8 +107,12 @@ __declspec(noinline) bool SafeExecuteFingerprint(
         D3D12_TEXTURE_COPY_LOCATION srcLoc = { pRes, D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX, 0 };
         D3D12_TEXTURE_COPY_LOCATION dstLoc = { pReadbackRes, D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT, {} };
         dstLoc.PlacedFootprint.Footprint.Format = DXGI_FORMAT_BC7_UNORM;
-        dstLoc.PlacedFootprint.Footprint.Width = 196; dstLoc.PlacedFootprint.Footprint.Height = 104;
-        dstLoc.PlacedFootprint.Footprint.Depth = 1; dstLoc.PlacedFootprint.Footprint.RowPitch = alignedRowPitch;
+        
+        // match the readback size dynamically to the resource
+        dstLoc.PlacedFootprint.Footprint.Width = static_cast<UINT>(desc.Width);
+        dstLoc.PlacedFootprint.Footprint.Height = desc.Height;
+        dstLoc.PlacedFootprint.Footprint.Depth = 1; 
+        dstLoc.PlacedFootprint.Footprint.RowPitch = alignedRowPitch;
 
         pRbCmdList->CopyTextureRegion(&dstLoc, 0, 0, 0, &srcLoc, nullptr);
 
@@ -132,7 +146,9 @@ __declspec(noinline) bool SafeExecuteFingerprint(
 
         uint8_t* pMapped = nullptr;
         if (SUCCEEDED(pReadbackRes->Map(0, nullptr, (void**)&pMapped))) {
-            uint64_t hash = CalculateFNV1a(pMapped, readbackSize);
+            UINT blocksX = (static_cast<UINT>(desc.Width) + 3) / 4;
+            UINT blocksY = (desc.Height + 3) / 4;
+            uint64_t hash = CalculateFNV1aPitched(pMapped, blocksX, blocksY, alignedRowPitch);
             pReadbackRes->Unmap(0, nullptr);
 
             ProcessFingerprintResult(hash, pRes);
@@ -167,6 +183,17 @@ __declspec(noinline) bool SafeExecuteInjection(
             destLoc.pResource = pDestRes;
             destLoc.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
             destLoc.SubresourceIndex = 0;
+            
+            // limit the source copy region to the targets height
+            // if the target is 196x104, it only reads the top 104 rows of the 196x196 payload
+            // if the target is 196x196, it reads all 196 rows, adding transparency over garbage pixels in the bottom half of the payload
+            D3D12_BOX srcBox = {};
+            srcBox.left = 0;
+            srcBox.top = 0;
+            srcBox.front = 0;
+            srcBox.right = (UINT)desc.Width;
+            srcBox.bottom = (UINT)desc.Height;
+            srcBox.back = 1;
 
             D3D12_RESOURCE_BARRIER barrier = {};
             barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
@@ -176,7 +203,7 @@ __declspec(noinline) bool SafeExecuteInjection(
             barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
             pCmdList->ResourceBarrier(1, &barrier);
 
-            pCmdList->CopyTextureRegion(&destLoc, 0, 0, 0, pSrcLoc, nullptr);
+            pCmdList->CopyTextureRegion(&destLoc, 0, 0, 0, pSrcLoc, &srcBox);
 
             std::swap(barrier.Transition.StateBefore, barrier.Transition.StateAfter);
             pCmdList->ResourceBarrier(1, &barrier);
@@ -220,6 +247,9 @@ CreateShaderResourceView_t OriginalCreateSRV = nullptr;
 
 void __stdcall HookedCreateSRV(ID3D12Device* pDevice, ID3D12Resource* pResource, const D3D12_SHADER_RESOURCE_VIEW_DESC* pDesc, D3D12_CPU_DESCRIPTOR_HANDLE DestDescriptor) 
 {
+    D3D12_SHADER_RESOURCE_VIEW_DESC customDesc = {};
+    const D3D12_SHADER_RESOURCE_VIEW_DESC* pFinalDesc = pDesc;
+
     if (IsTargetTexture(pResource)) {
         static auto last_time = std::chrono::steady_clock::now();
         auto now = std::chrono::steady_clock::now();
@@ -243,10 +273,32 @@ void __stdcall HookedCreateSRV(ID3D12Device* pDevice, ID3D12Resource* pResource,
             
         if (!found && it == g_StreamerModeResources.end()) {
             g_UnverifiedResources.push_back({pResource, now});
-            fh6::log::info("[dx12] found a 196x104 texture @ {}", (void*)pResource);
+            fh6::log::info("[dx12] found a target texture @ {}", (void*)pResource);
+        }
+
+        // apply mipmap = 1 to force rendering engine to only read subresource 0
+        if (pDesc) {
+            customDesc = *pDesc;
+            if (customDesc.ViewDimension == D3D12_SRV_DIMENSION_TEXTURE2D) {
+                customDesc.Texture2D.MipLevels = 1; 
+                pFinalDesc = &customDesc;
+            } else if (customDesc.ViewDimension == D3D12_SRV_DIMENSION_TEXTURE2DARRAY) {
+                customDesc.Texture2DArray.MipLevels = 1; 
+                pFinalDesc = &customDesc;
+            }
+        } else {
+            D3D12_RESOURCE_DESC resDesc = pResource->GetDesc();
+            customDesc.Format = resDesc.Format;
+            customDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+            customDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+            customDesc.Texture2D.MostDetailedMip = 0;
+            customDesc.Texture2D.MipLevels = 1; 
+            customDesc.Texture2D.PlaneSlice = 0;
+            customDesc.Texture2D.ResourceMinLODClamp = 0.0f;
+            pFinalDesc = &customDesc;
         }
     }
-    OriginalCreateSRV(pDevice, pResource, pDesc, DestDescriptor);
+    OriginalCreateSRV(pDevice, pResource, pFinalDesc, DestDescriptor);
 }
 
 // ==============================================================================
@@ -279,20 +331,21 @@ void __stdcall HookedExecuteCommandLists(ID3D12CommandQueue* pQueue, UINT NumCom
         }
 
         // ==========================================================================
-        // 2. GPU READBACK FINGERPRINTING
+        // GPU READBACK FINGERPRINTING
         // ==========================================================================
         if (!ready_to_fingerprint.empty()) {
             fh6::log::info("[dx12] fingerprinting {} textures...", ready_to_fingerprint.size());
             
-            UINT blocksX = (196 + 3) / 4;  
-            UINT blocksY = (104 + 3) / 4;  
-            UINT alignedRowPitch = ((blocksX * 16) + 255) & ~255; 
-            UINT64 readbackSize = alignedRowPitch * blocksY;
+            // accommodate max possible height (196) for discovery mapping
+            UINT maxBlocksX = (196 + 3) / 4;  
+            UINT maxBlocksY = (196 + 3) / 4;  
+            UINT alignedRowPitch = ((maxBlocksX * 16) + 255) & ~255; 
+            UINT64 maxReadbackSize = alignedRowPitch * maxBlocksY;
 
             D3D12_HEAP_PROPERTIES rbHeap = { D3D12_HEAP_TYPE_READBACK };
             D3D12_RESOURCE_DESC rbDesc = {};
             rbDesc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
-            rbDesc.Width = readbackSize;
+            rbDesc.Width = maxReadbackSize;
             rbDesc.Height = 1; rbDesc.DepthOrArraySize = 1; rbDesc.MipLevels = 1;
             rbDesc.SampleDesc.Count = 1; rbDesc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
             
@@ -306,7 +359,7 @@ void __stdcall HookedExecuteCommandLists(ID3D12CommandQueue* pQueue, UINT NumCom
                     SUCCEEDED(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, pRbAllocator, nullptr, __uuidof(ID3D12GraphicsCommandList), (void**)&pRbCmdList))) {
 
                     for (const auto& pRes : ready_to_fingerprint) {
-                        SafeExecuteFingerprint(pDevice, pQueue, pRbCmdList, pRbAllocator, pReadbackRes, alignedRowPitch, readbackSize, pRes.Get());
+                        SafeExecuteFingerprint(pDevice, pQueue, pRbCmdList, pRbAllocator, pReadbackRes, alignedRowPitch, pRes.Get());
                     }
                     pRbCmdList->Release(); 
                     pRbAllocator->Release();
@@ -316,7 +369,7 @@ void __stdcall HookedExecuteCommandLists(ID3D12CommandQueue* pQueue, UINT NumCom
         }
 
         // ==========================================================================
-        // 3. INJECTION
+        // INJECTION
         // ==========================================================================
         std::vector<ID3D12Resource*> streamer_copy;
         {
@@ -334,14 +387,16 @@ void __stdcall HookedExecuteCommandLists(ID3D12CommandQueue* pQueue, UINT NumCom
             if (fh6::TextureInjector::instance().pop_pending_pixels(new_pixels, w, h)) {
                 fh6::log::info("[dx12] intercepted ExecuteCommandLists - processing GPU upload...");
                 
+                // process 196x196 payload dimensions
                 UINT blocksX = (w + 3) / 4;  
                 UINT blocksY = (h + 3) / 4;  
                 UINT tightRowPitch = blocksX * 16; 
                 UINT alignedRowPitch = (tightRowPitch + 255) & ~255; 
-                UINT64 uploadBufferSize = alignedRowPitch * blocksY;
+                UINT64 uploadBufferSize = static_cast<UINT64>(alignedRowPitch) * blocksY;
 
+                // allow both sizes dynamically
                 const size_t requiredPayloadSize = static_cast<size_t>(tightRowPitch) * blocksY;
-                if (w != 196 || h != 104 || new_pixels.size() < requiredPayloadSize) {
+                if (w != 196 || (h != 104 && h != 196) || new_pixels.size() < requiredPayloadSize) {
                     fh6::log::warn("[dx12] invalid BC7 payload: {}x{}, {} bytes", w, h, new_pixels.size());
                     pDevice->Release();
                     OriginalExecuteCommandLists(pQueue, NumCommandLists, ppCommandLists);

--- a/src/proxy/dll_main.cpp
+++ b/src/proxy/dll_main.cpp
@@ -191,8 +191,10 @@ __declspec(noinline) bool SafeExecuteInjection(
             srcBox.left = 0;
             srcBox.top = 0;
             srcBox.front = 0;
-            srcBox.right = (UINT)desc.Width;
-            srcBox.bottom = (UINT)desc.Height;
+            const UINT srcWidth = pSrcLoc->PlacedFootprint.Footprint.Width;
+            const UINT srcHeight = pSrcLoc->PlacedFootprint.Footprint.Height;
+            srcBox.right = std::min<UINT>(static_cast<UINT>(desc.Width), srcWidth);
+            srcBox.bottom = std::min<UINT>(static_cast<UINT>(desc.Height), srcHeight);
             srcBox.back = 1;
 
             D3D12_RESOURCE_BARRIER barrier = {};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for artwork/texture exports at dynamic heights, enabling taller layouts.
  * Expanded the injection pipeline to accept multiple valid texture variants (e.g., 196x104 and 196x196).

* **Bug Fixes**
  * Improved height synchronization and validation before resizing/exporting, with correct padded canvas scaling along Y.
  * Updated GPU fingerprinting, payload validation, and copy region sizing to match the actual destination dimensions more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->