### PR TITLE
fix: kill ffmpeg pipe when game pauses to prevent live stream drift

### DIFF
--- a/include/fh6/sources/online_radio_source.hpp
+++ b/include/fh6/sources/online_radio_source.hpp
@@ -49,6 +49,7 @@ public:
     void set_config(const OnlineRadioConfig& c);
     void set_ffmpeg_path(std::filesystem::path p);
     void set_target(std::string url, std::string name = {}, std::string logo = {});
+    void on_radio_audible(bool audible) override;
 
     // single source of truth for what may be handed to ffmpeg -i (guards every
     // playback path against file:/concat:/etc. injection from config or the API).
@@ -85,6 +86,9 @@ private:
     std::atomic<uint64_t> position_ms_{0};
 
     worker::WorkerClient* worker_ = nullptr;
+
+    bool audible_ = true;
+    bool drain_pending_ = false;
 };
 
 } // namespace fh6::sources

--- a/src/sources/online_radio_source.cpp
+++ b/src/sources/online_radio_source.cpp
@@ -209,7 +209,7 @@ void OnlineRadioSource::stop_pipe_locked() {
 
 void OnlineRadioSource::play() {
     std::scoped_lock lk{mu_};
-    audible_ = true;
+    drain_pending_ = true;
     if (!pipe_) start_pipe_locked();
     if (pipe_) state_.store(PlaybackState::playing, std::memory_order_release);
 }
@@ -229,25 +229,27 @@ void OnlineRadioSource::stop() {
 
 void OnlineRadioSource::next() {
     std::scoped_lock lk{mu_};
-    audible_ = true;
     target_url_.clear();
     if (cfg_.stations.empty()) return;
 
     current_station_idx_ = (current_station_idx_ + 1) % cfg_.stations.size();
-    start_pipe_locked();
-    if (pipe_) state_.store(PlaybackState::playing, std::memory_order_release);
+    if (audible_) {
+        start_pipe_locked();
+        if (pipe_) state_.store(PlaybackState::playing, std::memory_order_release);
+    }
 }
 
 void OnlineRadioSource::previous() {
     std::scoped_lock lk{mu_};
-    audible_ = true;
     target_url_.clear();
     if (cfg_.stations.empty()) return;
 
     current_station_idx_ =
         (current_station_idx_ == 0 ? cfg_.stations.size() : current_station_idx_) - 1;
-    start_pipe_locked();
-    if (pipe_) state_.store(PlaybackState::playing, std::memory_order_release);
+    if (audible_) {
+        start_pipe_locked();
+        if (pipe_) state_.store(PlaybackState::playing, std::memory_order_release);
+    }
 }
 
 TrackInfo OnlineRadioSource::current_track() const {
@@ -275,15 +277,15 @@ void OnlineRadioSource::set_playback_options(const PlaybackConfig& opts) {
 }
 
 void OnlineRadioSource::pump(RingBuffer& ring) {
-    auto st = state_.load(std::memory_order_acquire);
-    if (st != PlaybackState::playing && st != PlaybackState::buffering) return;
-
     std::scoped_lock lk{mu_};
 
     if (drain_pending_) {
         ring.drain();
         drain_pending_ = false;
     }
+
+    auto st = state_.load(std::memory_order_relaxed);
+    if (st != PlaybackState::playing && st != PlaybackState::buffering) return;
 
     Pipe* p = pipe_.get();
     if (!p) return;

--- a/src/sources/online_radio_source.cpp
+++ b/src/sources/online_radio_source.cpp
@@ -78,6 +78,20 @@ void OnlineRadioSource::set_target(std::string url, std::string name, std::strin
     target_logo_ = std::move(logo);
 }
 
+void OnlineRadioSource::on_radio_audible(bool audible) {
+    std::scoped_lock lk{mu_};
+    if (audible == audible_) return;
+    audible_ = audible;
+    if (audible) {
+        log::info("[online_radio] radio audible -- reconnecting to live stream");
+        drain_pending_ = true;
+        start_pipe_locked();
+    } else {
+        log::info("[online_radio] radio inaudible -- disconnecting stream");
+        pipe_.reset();
+    }
+}
+
 void OnlineRadioSource::start_pipe_locked() {
     stop_pipe_locked();
 
@@ -195,6 +209,7 @@ void OnlineRadioSource::stop_pipe_locked() {
 
 void OnlineRadioSource::play() {
     std::scoped_lock lk{mu_};
+    audible_ = true;
     if (!pipe_) start_pipe_locked();
     if (pipe_) state_.store(PlaybackState::playing, std::memory_order_release);
 }
@@ -214,6 +229,7 @@ void OnlineRadioSource::stop() {
 
 void OnlineRadioSource::next() {
     std::scoped_lock lk{mu_};
+    audible_ = true;
     target_url_.clear();
     if (cfg_.stations.empty()) return;
 
@@ -224,6 +240,7 @@ void OnlineRadioSource::next() {
 
 void OnlineRadioSource::previous() {
     std::scoped_lock lk{mu_};
+    audible_ = true;
     target_url_.clear();
     if (cfg_.stations.empty()) return;
 
@@ -262,6 +279,12 @@ void OnlineRadioSource::pump(RingBuffer& ring) {
     if (st != PlaybackState::playing && st != PlaybackState::buffering) return;
 
     std::scoped_lock lk{mu_};
+
+    if (drain_pending_) {
+        ring.drain();
+        drain_pending_ = false;
+    }
+
     Pipe* p = pipe_.get();
     if (!p) return;
 


### PR DESCRIPTION
Fixed that live online web radio continues to stream into the ring buffer while not audible (e.g. in pause menu), causing the stream to drift on live radio. Decreasing the ring buffer (to e.g. 64kb) didn't yield the expected result so i just killed the ffmpeg pipeline, which turned out to work great.

Tested locally with a direct stream url of online radio. Also has the nice side effect of the meta showing again when exiting pause menu after a longer break.

P.S. i have no clue what i'm doing, so feel free to deny and implement yourself.
Thanks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Online radio playback now listens for audible-state changes, allowing streams to reconnect smoothly when audio becomes available again.
  * Playback controls (play, next, previous) now coordinate with the current audible state to resume correctly.

* **Bug Fixes**
  * Improved stream teardown when audio is no longer audible to avoid stale connections.
  * Added pending reconnect handling that drains the playback buffer before continuing, keeping output in sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->