### PR TITLE
fix(spotify): Resolve out-of-bounds playback time

### DIFF
--- a/src/sources/spotify_source.cpp
+++ b/src/sources/spotify_source.cpp
@@ -562,6 +562,14 @@ void SpotifySource::pump(RingBuffer& ring) {
                     }
                 }
 
+                // catch warning about invalid start position out-of-bounds
+                if (line.find("Invalid start position") != std::string::npos &&
+                    line.find("starting track from the beginning") != std::string::npos) {
+                    p->explicit_position_bytes = 0;
+                    p->has_explicit_position   = true;
+                    continue; // overriding the last bad load command
+                }
+
                 // catch Load events for initial position sync (mid-song connect)
                 const std::string load_marker = "command=Load";
                 size_t load_pos               = line.find(load_marker);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of playback position warnings so tracks with an out-of-bounds start position recover more reliably.
  * Added a fallback that resets the requested position when this specific warning appears, helping playback continue without getting stuck on invalid seek data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->